### PR TITLE
Add comprehensive test suites for URL query repositories

### DIFF
--- a/libs/ui/src/data/url/expenseListQuery.test.ts
+++ b/libs/ui/src/data/url/expenseListQuery.test.ts
@@ -1,0 +1,163 @@
+import Router from 'next/router';
+import { UrlExpenseListQueryRepository } from './expenseListQuery';
+
+describe('UrlExpenseListQueryRepository', () => {
+  let repo: UrlExpenseListQueryRepository;
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    (Router.replace as jest.Mock).mockClear();
+    repo = new UrlExpenseListQueryRepository();
+  });
+
+  describe('getPage', () => {
+    it('returns 1 as default when param is absent', () => {
+      expect(repo.getPage()).toBe(1);
+    });
+
+    it('returns parsed page number when param is present', () => {
+      window.history.pushState({}, '', '/?page=2');
+      expect(repo.getPage()).toBe(2);
+    });
+  });
+
+  describe('setPage', () => {
+    it('sets the page param in the URL', () => {
+      repo.setPage(6);
+      expect(new URL(window.location.href).searchParams.get('page')).toBe('6');
+    });
+  });
+
+  describe('getItemPerPage', () => {
+    it('returns 10 as default when param is absent', () => {
+      expect(repo.getItemPerPage()).toBe(10);
+    });
+
+    it('returns parsed itemPerPage when param is present', () => {
+      window.history.pushState({}, '', '/?itemPerPage=30');
+      expect(repo.getItemPerPage()).toBe(30);
+    });
+  });
+
+  describe('setItemPerPage', () => {
+    it('sets the itemPerPage param in the URL', () => {
+      repo.setItemPerPage(25);
+      expect(
+        new URL(window.location.href).searchParams.get('itemPerPage')
+      ).toBe('25');
+    });
+  });
+
+  describe('getSearchQuery', () => {
+    it('returns empty string as default when param is absent', () => {
+      expect(repo.getSearchQuery()).toBe('');
+    });
+
+    it('returns the search query when param is present', () => {
+      window.history.pushState({}, '', '/?query=food');
+      expect(repo.getSearchQuery()).toBe('food');
+    });
+  });
+
+  describe('setSearchQuery', () => {
+    it('sets the query param in the URL', () => {
+      repo.setSearchQuery('transport');
+      expect(new URL(window.location.href).searchParams.get('query')).toBe(
+        'transport'
+      );
+    });
+  });
+
+  describe('getSortBy', () => {
+    it('returns "created_at" as default when param is absent', () => {
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+
+    it('returns "created_at" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?sortBy=invalid');
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+  });
+
+  describe('setSortBy', () => {
+    it('sets the sortBy param in the URL', () => {
+      repo.setSortBy('created_at');
+      expect(new URL(window.location.href).searchParams.get('sortBy')).toBe(
+        'created_at'
+      );
+    });
+  });
+
+  describe('getOrderBy', () => {
+    it('returns "desc" as default when param is absent', () => {
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+
+    it('returns "asc" when param is "asc"', () => {
+      window.history.pushState({}, '', '/?orderBy=asc');
+      expect(repo.getOrderBy()).toBe('asc');
+    });
+
+    it('returns "desc" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?orderBy=invalid');
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+  });
+
+  describe('setOrderBy', () => {
+    it('sets the orderBy param in the URL', () => {
+      repo.setOrderBy('asc');
+      expect(new URL(window.location.href).searchParams.get('orderBy')).toBe(
+        'asc'
+      );
+    });
+  });
+
+  describe('getWalletId', () => {
+    it('returns null as default when param is absent', () => {
+      expect(repo.getWalletId()).toBeNull();
+    });
+
+    it('returns null when param is "all"', () => {
+      window.history.pushState({}, '', '/?walletId=all');
+      expect(repo.getWalletId()).toBeNull();
+    });
+
+    it('returns parsed number when param is a numeric string', () => {
+      window.history.pushState({}, '', '/?walletId=3');
+      expect(repo.getWalletId()).toBe(3);
+    });
+  });
+
+  describe('setWalletId', () => {
+    it('sets walletId param to "all" when value is null', () => {
+      repo.setWalletId(null);
+      expect(new URL(window.location.href).searchParams.get('walletId')).toBe(
+        'all'
+      );
+    });
+
+    it('sets walletId param to the numeric string when value is a number', () => {
+      repo.setWalletId(9);
+      expect(new URL(window.location.href).searchParams.get('walletId')).toBe(
+        '9'
+      );
+    });
+  });
+
+  describe('getBudgetId', () => {
+    it('returns null as default when param is absent', () => {
+      expect(repo.getBudgetId()).toBeNull();
+    });
+
+    it('returns null when param is "all"', () => {
+      window.history.pushState({}, '', '/?budgetId=all');
+      expect(repo.getBudgetId()).toBeNull();
+    });
+
+    it('returns parsed number when param is a numeric string', () => {
+      window.history.pushState({}, '', '/?budgetId=5');
+      expect(repo.getBudgetId()).toBe(5);
+    });
+  });
+});

--- a/libs/ui/src/data/url/materialListQuery.test.ts
+++ b/libs/ui/src/data/url/materialListQuery.test.ts
@@ -1,0 +1,115 @@
+import Router from 'next/router';
+import { UrlMaterialListQueryRepository } from './materialListQuery';
+
+describe('UrlMaterialListQueryRepository', () => {
+  let repo: UrlMaterialListQueryRepository;
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    (Router.replace as jest.Mock).mockClear();
+    repo = new UrlMaterialListQueryRepository();
+  });
+
+  describe('getPage', () => {
+    it('returns 1 as default when param is absent', () => {
+      expect(repo.getPage()).toBe(1);
+    });
+
+    it('returns parsed page number when param is present', () => {
+      window.history.pushState({}, '', '/?page=7');
+      expect(repo.getPage()).toBe(7);
+    });
+  });
+
+  describe('setPage', () => {
+    it('sets the page param in the URL', () => {
+      repo.setPage(2);
+      expect(new URL(window.location.href).searchParams.get('page')).toBe('2');
+    });
+  });
+
+  describe('getItemPerPage', () => {
+    it('returns 10 as default when param is absent', () => {
+      expect(repo.getItemPerPage()).toBe(10);
+    });
+
+    it('returns parsed itemPerPage when param is present', () => {
+      window.history.pushState({}, '', '/?itemPerPage=40');
+      expect(repo.getItemPerPage()).toBe(40);
+    });
+  });
+
+  describe('setItemPerPage', () => {
+    it('sets the itemPerPage param in the URL', () => {
+      repo.setItemPerPage(50);
+      expect(
+        new URL(window.location.href).searchParams.get('itemPerPage')
+      ).toBe('50');
+    });
+  });
+
+  describe('getSearchQuery', () => {
+    it('returns empty string as default when param is absent', () => {
+      expect(repo.getSearchQuery()).toBe('');
+    });
+
+    it('returns the search query when param is present', () => {
+      window.history.pushState({}, '', '/?query=flour');
+      expect(repo.getSearchQuery()).toBe('flour');
+    });
+  });
+
+  describe('setSearchQuery', () => {
+    it('sets the query param in the URL', () => {
+      repo.setSearchQuery('sugar');
+      expect(new URL(window.location.href).searchParams.get('query')).toBe(
+        'sugar'
+      );
+    });
+  });
+
+  describe('getSortBy', () => {
+    it('returns "created_at" as default when param is absent', () => {
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+
+    it('returns "created_at" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?sortBy=name');
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+  });
+
+  describe('setSortBy', () => {
+    it('sets the sortBy param in the URL', () => {
+      repo.setSortBy('created_at');
+      expect(new URL(window.location.href).searchParams.get('sortBy')).toBe(
+        'created_at'
+      );
+    });
+  });
+
+  describe('getOrderBy', () => {
+    it('returns "desc" as default when param is absent', () => {
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+
+    it('returns "asc" when param is "asc"', () => {
+      window.history.pushState({}, '', '/?orderBy=asc');
+      expect(repo.getOrderBy()).toBe('asc');
+    });
+
+    it('returns "desc" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?orderBy=invalid');
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+  });
+
+  describe('setOrderBy', () => {
+    it('sets the orderBy param in the URL', () => {
+      repo.setOrderBy('asc');
+      expect(new URL(window.location.href).searchParams.get('orderBy')).toBe(
+        'asc'
+      );
+    });
+  });
+});

--- a/libs/ui/src/data/url/productListQuery.test.ts
+++ b/libs/ui/src/data/url/productListQuery.test.ts
@@ -1,0 +1,155 @@
+import Router from 'next/router';
+import { UrlProductListQueryRepository } from './productListQuery';
+
+describe('UrlProductListQueryRepository', () => {
+  let repo: UrlProductListQueryRepository;
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    (Router.replace as jest.Mock).mockClear();
+    repo = new UrlProductListQueryRepository();
+  });
+
+  describe('getPage', () => {
+    it('returns 1 as default when param is absent', () => {
+      expect(repo.getPage()).toBe(1);
+    });
+
+    it('returns parsed page number when param is present', () => {
+      window.history.pushState({}, '', '/?page=5');
+      expect(repo.getPage()).toBe(5);
+    });
+  });
+
+  describe('setPage', () => {
+    it('sets the page param in the URL', () => {
+      repo.setPage(3);
+      expect(new URL(window.location.href).searchParams.get('page')).toBe('3');
+    });
+  });
+
+  describe('getItemPerPage', () => {
+    it('returns 10 as default when param is absent', () => {
+      expect(repo.getItemPerPage()).toBe(10);
+    });
+
+    it('returns parsed itemPerPage when param is present', () => {
+      window.history.pushState({}, '', '/?itemPerPage=25');
+      expect(repo.getItemPerPage()).toBe(25);
+    });
+  });
+
+  describe('setItemPerPage', () => {
+    it('sets the itemPerPage param in the URL', () => {
+      repo.setItemPerPage(20);
+      expect(
+        new URL(window.location.href).searchParams.get('itemPerPage')
+      ).toBe('20');
+    });
+  });
+
+  describe('getSearchQuery', () => {
+    it('returns empty string as default when param is absent', () => {
+      expect(repo.getSearchQuery()).toBe('');
+    });
+
+    it('returns the search query when param is present', () => {
+      window.history.pushState({}, '', '/?query=shoes');
+      expect(repo.getSearchQuery()).toBe('shoes');
+    });
+  });
+
+  describe('setSearchQuery', () => {
+    it('sets the query param in the URL', () => {
+      repo.setSearchQuery('boots');
+      expect(new URL(window.location.href).searchParams.get('query')).toBe(
+        'boots'
+      );
+    });
+  });
+
+  describe('getSortBy', () => {
+    it('returns "created_at" as default when param is absent', () => {
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+
+    it('returns "created_at" when param is valid', () => {
+      window.history.pushState({}, '', '/?sortBy=created_at');
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+
+    it('returns "created_at" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?sortBy=unknown_field');
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+  });
+
+  describe('setSortBy', () => {
+    it('sets the sortBy param in the URL', () => {
+      repo.setSortBy('created_at');
+      expect(new URL(window.location.href).searchParams.get('sortBy')).toBe(
+        'created_at'
+      );
+    });
+  });
+
+  describe('getOrderBy', () => {
+    it('returns "desc" as default when param is absent', () => {
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+
+    it('returns "asc" when param is "asc"', () => {
+      window.history.pushState({}, '', '/?orderBy=asc');
+      expect(repo.getOrderBy()).toBe('asc');
+    });
+
+    it('returns "desc" when param is "desc"', () => {
+      window.history.pushState({}, '', '/?orderBy=desc');
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+
+    it('returns "desc" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?orderBy=random');
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+  });
+
+  describe('setOrderBy', () => {
+    it('sets the orderBy param in the URL', () => {
+      repo.setOrderBy('asc');
+      expect(new URL(window.location.href).searchParams.get('orderBy')).toBe(
+        'asc'
+      );
+    });
+  });
+
+  describe('getSaleType', () => {
+    it('returns "all" as default when param is absent', () => {
+      expect(repo.getSaleType()).toBe('all');
+    });
+
+    it('returns "purchase" when param is "purchase"', () => {
+      window.history.pushState({}, '', '/?saleType=purchase');
+      expect(repo.getSaleType()).toBe('purchase');
+    });
+
+    it('returns "rental" when param is "rental"', () => {
+      window.history.pushState({}, '', '/?saleType=rental');
+      expect(repo.getSaleType()).toBe('rental');
+    });
+
+    it('returns "all" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?saleType=unknown');
+      expect(repo.getSaleType()).toBe('all');
+    });
+  });
+
+  describe('setSaleType', () => {
+    it('sets the saleType param in the URL', () => {
+      repo.setSaleType('purchase');
+      expect(new URL(window.location.href).searchParams.get('saleType')).toBe(
+        'purchase'
+      );
+    });
+  });
+});

--- a/libs/ui/src/data/url/rentalListQuery.test.ts
+++ b/libs/ui/src/data/url/rentalListQuery.test.ts
@@ -1,0 +1,145 @@
+import Router from 'next/router';
+import { UrlRentalListQueryRepository } from './rentalListQuery';
+
+describe('UrlRentalListQueryRepository', () => {
+  let repo: UrlRentalListQueryRepository;
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    (Router.replace as jest.Mock).mockClear();
+    repo = new UrlRentalListQueryRepository();
+  });
+
+  describe('getPage', () => {
+    it('returns 1 as default when param is absent', () => {
+      expect(repo.getPage()).toBe(1);
+    });
+
+    it('returns parsed page number when param is present', () => {
+      window.history.pushState({}, '', '/?page=6');
+      expect(repo.getPage()).toBe(6);
+    });
+  });
+
+  describe('setPage', () => {
+    it('sets the page param in the URL', () => {
+      repo.setPage(3);
+      expect(new URL(window.location.href).searchParams.get('page')).toBe('3');
+    });
+  });
+
+  describe('getItemPerPage', () => {
+    it('returns 10 as default when param is absent', () => {
+      expect(repo.getItemPerPage()).toBe(10);
+    });
+
+    it('returns parsed itemPerPage when param is present', () => {
+      window.history.pushState({}, '', '/?itemPerPage=15');
+      expect(repo.getItemPerPage()).toBe(15);
+    });
+  });
+
+  describe('setItemPerPage', () => {
+    it('sets the itemPerPage param in the URL', () => {
+      repo.setItemPerPage(10);
+      expect(
+        new URL(window.location.href).searchParams.get('itemPerPage')
+      ).toBe('10');
+    });
+  });
+
+  describe('getSearchQuery', () => {
+    it('returns empty string as default when param is absent', () => {
+      expect(repo.getSearchQuery()).toBe('');
+    });
+
+    it('returns the search query when param is present', () => {
+      window.history.pushState({}, '', '/?query=bike');
+      expect(repo.getSearchQuery()).toBe('bike');
+    });
+  });
+
+  describe('setSearchQuery', () => {
+    it('sets the query param in the URL', () => {
+      repo.setSearchQuery('scooter');
+      expect(new URL(window.location.href).searchParams.get('query')).toBe(
+        'scooter'
+      );
+    });
+  });
+
+  describe('getSortBy', () => {
+    it('returns "created_at" as default when param is absent', () => {
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+
+    it('returns "created_at" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?sortBy=invalid');
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+  });
+
+  describe('setSortBy', () => {
+    it('sets the sortBy param in the URL', () => {
+      repo.setSortBy('created_at');
+      expect(new URL(window.location.href).searchParams.get('sortBy')).toBe(
+        'created_at'
+      );
+    });
+  });
+
+  describe('getOrderBy', () => {
+    it('returns "desc" as default when param is absent', () => {
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+
+    it('returns "asc" when param is "asc"', () => {
+      window.history.pushState({}, '', '/?orderBy=asc');
+      expect(repo.getOrderBy()).toBe('asc');
+    });
+
+    it('returns "desc" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?orderBy=invalid');
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+  });
+
+  describe('setOrderBy', () => {
+    it('sets the orderBy param in the URL', () => {
+      repo.setOrderBy('asc');
+      expect(new URL(window.location.href).searchParams.get('orderBy')).toBe(
+        'asc'
+      );
+    });
+  });
+
+  describe('getCheckoutStatus', () => {
+    it('returns "all" as default when param is absent', () => {
+      expect(repo.getCheckoutStatus()).toBe('all');
+    });
+
+    it('returns "completed" when param is "completed"', () => {
+      window.history.pushState({}, '', '/?checkoutStatus=completed');
+      expect(repo.getCheckoutStatus()).toBe('completed');
+    });
+
+    it('returns "ongoing" when param is "ongoing"', () => {
+      window.history.pushState({}, '', '/?checkoutStatus=ongoing');
+      expect(repo.getCheckoutStatus()).toBe('ongoing');
+    });
+
+    it('returns "all" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?checkoutStatus=unknown');
+      expect(repo.getCheckoutStatus()).toBe('all');
+    });
+  });
+
+  describe('setCheckoutStatus', () => {
+    it('sets the paymentStatus param in the URL', () => {
+      repo.setCheckoutStatus('completed');
+      expect(
+        new URL(window.location.href).searchParams.get('paymentStatus')
+      ).toBe('completed');
+    });
+  });
+});

--- a/libs/ui/src/data/url/supplierListQuery.test.ts
+++ b/libs/ui/src/data/url/supplierListQuery.test.ts
@@ -1,0 +1,115 @@
+import Router from 'next/router';
+import { UrlSupplierListQueryRepository } from './supplierListQuery';
+
+describe('UrlSupplierListQueryRepository', () => {
+  let repo: UrlSupplierListQueryRepository;
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    (Router.replace as jest.Mock).mockClear();
+    repo = new UrlSupplierListQueryRepository();
+  });
+
+  describe('getPage', () => {
+    it('returns 1 as default when param is absent', () => {
+      expect(repo.getPage()).toBe(1);
+    });
+
+    it('returns parsed page number when param is present', () => {
+      window.history.pushState({}, '', '/?page=10');
+      expect(repo.getPage()).toBe(10);
+    });
+  });
+
+  describe('setPage', () => {
+    it('sets the page param in the URL', () => {
+      repo.setPage(8);
+      expect(new URL(window.location.href).searchParams.get('page')).toBe('8');
+    });
+  });
+
+  describe('getItemPerPage', () => {
+    it('returns 10 as default when param is absent', () => {
+      expect(repo.getItemPerPage()).toBe(10);
+    });
+
+    it('returns parsed itemPerPage when param is present', () => {
+      window.history.pushState({}, '', '/?itemPerPage=100');
+      expect(repo.getItemPerPage()).toBe(100);
+    });
+  });
+
+  describe('setItemPerPage', () => {
+    it('sets the itemPerPage param in the URL', () => {
+      repo.setItemPerPage(30);
+      expect(
+        new URL(window.location.href).searchParams.get('itemPerPage')
+      ).toBe('30');
+    });
+  });
+
+  describe('getSearchQuery', () => {
+    it('returns empty string as default when param is absent', () => {
+      expect(repo.getSearchQuery()).toBe('');
+    });
+
+    it('returns the search query when param is present', () => {
+      window.history.pushState({}, '', '/?query=acme');
+      expect(repo.getSearchQuery()).toBe('acme');
+    });
+  });
+
+  describe('setSearchQuery', () => {
+    it('sets the query param in the URL', () => {
+      repo.setSearchQuery('supplier-corp');
+      expect(new URL(window.location.href).searchParams.get('query')).toBe(
+        'supplier-corp'
+      );
+    });
+  });
+
+  describe('getSortBy', () => {
+    it('returns "created_at" as default when param is absent', () => {
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+
+    it('returns "created_at" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?sortBy=name');
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+  });
+
+  describe('setSortBy', () => {
+    it('sets the sortBy param in the URL', () => {
+      repo.setSortBy('created_at');
+      expect(new URL(window.location.href).searchParams.get('sortBy')).toBe(
+        'created_at'
+      );
+    });
+  });
+
+  describe('getOrderBy', () => {
+    it('returns "desc" as default when param is absent', () => {
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+
+    it('returns "asc" when param is "asc"', () => {
+      window.history.pushState({}, '', '/?orderBy=asc');
+      expect(repo.getOrderBy()).toBe('asc');
+    });
+
+    it('returns "desc" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?orderBy=invalid');
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+  });
+
+  describe('setOrderBy', () => {
+    it('sets the orderBy param in the URL', () => {
+      repo.setOrderBy('desc');
+      expect(new URL(window.location.href).searchParams.get('orderBy')).toBe(
+        'desc'
+      );
+    });
+  });
+});

--- a/libs/ui/src/data/url/transactionListQuery.test.ts
+++ b/libs/ui/src/data/url/transactionListQuery.test.ts
@@ -1,0 +1,177 @@
+import Router from 'next/router';
+import { UrlTransactionListQueryRepository } from './transactionListQuery';
+
+describe('UrlTransactionListQueryRepository', () => {
+  let repo: UrlTransactionListQueryRepository;
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    (Router.replace as jest.Mock).mockClear();
+    repo = new UrlTransactionListQueryRepository();
+  });
+
+  describe('getPage', () => {
+    it('returns 1 as default when param is absent', () => {
+      expect(repo.getPage()).toBe(1);
+    });
+
+    it('returns parsed page number when param is present', () => {
+      window.history.pushState({}, '', '/?page=4');
+      expect(repo.getPage()).toBe(4);
+    });
+  });
+
+  describe('setPage', () => {
+    it('sets the page param in the URL', () => {
+      repo.setPage(2);
+      expect(new URL(window.location.href).searchParams.get('page')).toBe('2');
+    });
+  });
+
+  describe('getItemPerPage', () => {
+    it('returns 10 as default when param is absent', () => {
+      expect(repo.getItemPerPage()).toBe(10);
+    });
+
+    it('returns parsed itemPerPage when param is present', () => {
+      window.history.pushState({}, '', '/?itemPerPage=50');
+      expect(repo.getItemPerPage()).toBe(50);
+    });
+  });
+
+  describe('setItemPerPage', () => {
+    it('sets the itemPerPage param in the URL', () => {
+      repo.setItemPerPage(15);
+      expect(
+        new URL(window.location.href).searchParams.get('itemPerPage')
+      ).toBe('15');
+    });
+  });
+
+  describe('getSearchQuery', () => {
+    it('returns empty string as default when param is absent', () => {
+      expect(repo.getSearchQuery()).toBe('');
+    });
+
+    it('returns the search query when param is present', () => {
+      window.history.pushState({}, '', '/?query=coffee');
+      expect(repo.getSearchQuery()).toBe('coffee');
+    });
+  });
+
+  describe('setSearchQuery', () => {
+    it('sets the query param in the URL', () => {
+      repo.setSearchQuery('latte');
+      expect(new URL(window.location.href).searchParams.get('query')).toBe(
+        'latte'
+      );
+    });
+  });
+
+  describe('getSortBy', () => {
+    it('returns "created_at" as default when param is absent', () => {
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+
+    it('returns "created_at" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?sortBy=invalid');
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+  });
+
+  describe('setSortBy', () => {
+    it('sets the sortBy param in the URL', () => {
+      repo.setSortBy('created_at');
+      expect(new URL(window.location.href).searchParams.get('sortBy')).toBe(
+        'created_at'
+      );
+    });
+  });
+
+  describe('getOrderBy', () => {
+    it('returns "desc" as default when param is absent', () => {
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+
+    it('returns "asc" when param is "asc"', () => {
+      window.history.pushState({}, '', '/?orderBy=asc');
+      expect(repo.getOrderBy()).toBe('asc');
+    });
+
+    it('returns "desc" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?orderBy=invalid');
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+  });
+
+  describe('setOrderBy', () => {
+    it('sets the orderBy param in the URL', () => {
+      repo.setOrderBy('desc');
+      expect(new URL(window.location.href).searchParams.get('orderBy')).toBe(
+        'desc'
+      );
+    });
+  });
+
+  describe('getPaymentStatus', () => {
+    it('returns "all" as default when param is absent', () => {
+      expect(repo.getPaymentStatus()).toBe('all');
+    });
+
+    it('returns "paid" when param is "paid"', () => {
+      window.history.pushState({}, '', '/?paymentStatus=paid');
+      expect(repo.getPaymentStatus()).toBe('paid');
+    });
+
+    it('returns "unpaid" when param is "unpaid"', () => {
+      window.history.pushState({}, '', '/?paymentStatus=unpaid');
+      expect(repo.getPaymentStatus()).toBe('unpaid');
+    });
+
+    it('returns "all" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?paymentStatus=invalid');
+      expect(repo.getPaymentStatus()).toBe('all');
+    });
+  });
+
+  describe('setPaymentStatus', () => {
+    it('sets the paymentStatus param in the URL', () => {
+      repo.setPaymentStatus('paid');
+      expect(
+        new URL(window.location.href).searchParams.get('paymentStatus')
+      ).toBe('paid');
+    });
+  });
+
+  describe('getWalletId', () => {
+    it('returns null as default when param is absent', () => {
+      expect(repo.getWalletId()).toBeNull();
+    });
+
+    it('returns null when param is "all"', () => {
+      window.history.pushState({}, '', '/?walletId=all');
+      expect(repo.getWalletId()).toBeNull();
+    });
+
+    it('returns parsed number when param is a numeric string', () => {
+      window.history.pushState({}, '', '/?walletId=7');
+      expect(repo.getWalletId()).toBe(7);
+    });
+  });
+
+  describe('setWalletId', () => {
+    it('sets walletId param to "all" when value is null', () => {
+      repo.setWalletId(null);
+      expect(new URL(window.location.href).searchParams.get('walletId')).toBe(
+        'all'
+      );
+    });
+
+    it('sets walletId param to the numeric string when value is a number', () => {
+      repo.setWalletId(42);
+      expect(new URL(window.location.href).searchParams.get('walletId')).toBe(
+        '42'
+      );
+    });
+  });
+});

--- a/libs/ui/src/data/url/transactionStatisticListQuery.test.ts
+++ b/libs/ui/src/data/url/transactionStatisticListQuery.test.ts
@@ -1,0 +1,42 @@
+import Router from 'next/router';
+import { UrlTransactionStatisticListQueryRepository } from './transactionStatisticListQuery';
+
+describe('UrlTransactionStatisticListQueryRepository', () => {
+  let repo: UrlTransactionStatisticListQueryRepository;
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    (Router.replace as jest.Mock).mockClear();
+    repo = new UrlTransactionStatisticListQueryRepository();
+  });
+
+  describe('getGroupBy', () => {
+    it('returns "date" as default when param is absent', () => {
+      expect(repo.getGroupBy()).toBe('date');
+    });
+
+    it('returns "date" when param is "date"', () => {
+      window.history.pushState({}, '', '/?groupBy=date');
+      expect(repo.getGroupBy()).toBe('date');
+    });
+
+    it('returns "month" when param is "month"', () => {
+      window.history.pushState({}, '', '/?groupBy=month');
+      expect(repo.getGroupBy()).toBe('month');
+    });
+
+    it('returns "date" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?groupBy=year');
+      expect(repo.getGroupBy()).toBe('date');
+    });
+  });
+
+  describe('setGroupBy', () => {
+    it('sets the groupBy param in the URL', () => {
+      repo.setGroupBy('month');
+      expect(new URL(window.location.href).searchParams.get('groupBy')).toBe(
+        'month'
+      );
+    });
+  });
+});

--- a/libs/ui/src/data/url/variantListQuery.test.ts
+++ b/libs/ui/src/data/url/variantListQuery.test.ts
@@ -1,0 +1,115 @@
+import Router from 'next/router';
+import { UrlVariantListQueryRepository } from './variantListQuery';
+
+describe('UrlVariantListQueryRepository', () => {
+  let repo: UrlVariantListQueryRepository;
+
+  beforeEach(() => {
+    window.history.pushState({}, '', '/');
+    (Router.replace as jest.Mock).mockClear();
+    repo = new UrlVariantListQueryRepository();
+  });
+
+  describe('getPage', () => {
+    it('returns 1 as default when param is absent', () => {
+      expect(repo.getPage()).toBe(1);
+    });
+
+    it('returns parsed page number when param is present', () => {
+      window.history.pushState({}, '', '/?page=3');
+      expect(repo.getPage()).toBe(3);
+    });
+  });
+
+  describe('setPage', () => {
+    it('sets the page param in the URL', () => {
+      repo.setPage(4);
+      expect(new URL(window.location.href).searchParams.get('page')).toBe('4');
+    });
+  });
+
+  describe('getItemPerPage', () => {
+    it('returns 10 as default when param is absent', () => {
+      expect(repo.getItemPerPage()).toBe(10);
+    });
+
+    it('returns parsed itemPerPage when param is present', () => {
+      window.history.pushState({}, '', '/?itemPerPage=20');
+      expect(repo.getItemPerPage()).toBe(20);
+    });
+  });
+
+  describe('setItemPerPage', () => {
+    it('sets the itemPerPage param in the URL', () => {
+      repo.setItemPerPage(5);
+      expect(
+        new URL(window.location.href).searchParams.get('itemPerPage')
+      ).toBe('5');
+    });
+  });
+
+  describe('getSearchQuery', () => {
+    it('returns empty string as default when param is absent', () => {
+      expect(repo.getSearchQuery()).toBe('');
+    });
+
+    it('returns the search query when param is present', () => {
+      window.history.pushState({}, '', '/?query=blue');
+      expect(repo.getSearchQuery()).toBe('blue');
+    });
+  });
+
+  describe('setSearchQuery', () => {
+    it('sets the query param in the URL', () => {
+      repo.setSearchQuery('red');
+      expect(new URL(window.location.href).searchParams.get('query')).toBe(
+        'red'
+      );
+    });
+  });
+
+  describe('getSortBy', () => {
+    it('returns "created_at" as default when param is absent', () => {
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+
+    it('returns "created_at" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?sortBy=invalid');
+      expect(repo.getSortBy()).toBe('created_at');
+    });
+  });
+
+  describe('setSortBy', () => {
+    it('sets the sortBy param in the URL', () => {
+      repo.setSortBy('created_at');
+      expect(new URL(window.location.href).searchParams.get('sortBy')).toBe(
+        'created_at'
+      );
+    });
+  });
+
+  describe('getOrderBy', () => {
+    it('returns "desc" as default when param is absent', () => {
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+
+    it('returns "asc" when param is "asc"', () => {
+      window.history.pushState({}, '', '/?orderBy=asc');
+      expect(repo.getOrderBy()).toBe('asc');
+    });
+
+    it('returns "desc" as fallback when param value is invalid', () => {
+      window.history.pushState({}, '', '/?orderBy=invalid');
+      expect(repo.getOrderBy()).toBe('desc');
+    });
+  });
+
+  describe('setOrderBy', () => {
+    it('sets the orderBy param in the URL', () => {
+      repo.setOrderBy('desc');
+      expect(new URL(window.location.href).searchParams.get('orderBy')).toBe(
+        'desc'
+      );
+    });
+  });
+});

--- a/openapitools.json
+++ b/openapitools.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "./node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.9.0"
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive test coverage for all URL-based query repository classes that manage pagination, filtering, and sorting state through URL query parameters.

## Key Changes
- **transactionListQuery.test.ts**: 177 lines of tests covering page, itemPerPage, searchQuery, sortBy, orderBy, paymentStatus, and walletId parameters with validation and default value handling
- **expenseListQuery.test.ts**: 163 lines of tests for expense list filtering including budgetId parameter support
- **productListQuery.test.ts**: 155 lines of tests with saleType parameter for product categorization
- **rentalListQuery.test.ts**: 145 lines of tests with checkoutStatus parameter for rental tracking
- **materialListQuery.test.ts**: 115 lines of tests for material inventory management
- **supplierListQuery.test.ts**: 115 lines of tests for supplier list management
- **variantListQuery.test.ts**: 115 lines of tests for product variant filtering
- **transactionStatisticListQuery.test.ts**: 42 lines of tests for groupBy parameter (date/month aggregation)
- **openapitools.json**: Configuration file for OpenAPI generator (version 7.9.0)

## Notable Implementation Details
- All tests follow a consistent pattern: testing default values, parsing URL parameters, and setting parameters back to the URL
- Tests validate fallback behavior for invalid parameter values
- Tests cover both getter and setter methods for each query parameter
- Each repository test suite uses `beforeEach` to reset URL state and mock Router.replace
- Parameter validation includes type coercion (string to number) and enum validation for restricted values
- Tests verify that null/special values (like "all") are properly handled for optional filters

https://claude.ai/code/session_01NJ2ZMzasHc8kHsTadqD5Yu