### PR TITLE
Refactor handler tests to use real usecases with mock repos

### DIFF
--- a/libs/ui/src/__mocks__/tamagui.tsx
+++ b/libs/ui/src/__mocks__/tamagui.tsx
@@ -91,7 +91,7 @@ export const YGroup = Object.assign(YGroupBase, {
 // Tamagui's built-in ListItem (distinct from our base/ListItem.tsx)
 export const ListItem = ({ children, title, onPress }: AnyProps) =>
   React.createElement(
-    'div',
+    onPress ? 'button' : 'div',
     { 'data-component': 'TamaguiListItem', ...(onPress ? { onClick: onPress } : {}) },
     title,
     children

--- a/libs/ui/src/__mocks__/tamagui.tsx
+++ b/libs/ui/src/__mocks__/tamagui.tsx
@@ -7,8 +7,12 @@ type AnyProps = {
 };
 
 const makeComponent = (name: string) => {
-  const Component = ({ children }: AnyProps) =>
-    React.createElement('div', { 'data-component': name }, children);
+  const Component = ({ children, onPress }: AnyProps) =>
+    React.createElement(
+      'div',
+      { 'data-component': name, ...(onPress ? { onClick: onPress } : {}) },
+      children
+    );
   Component.displayName = name;
   return Component;
 };
@@ -34,8 +38,9 @@ export const Text = ({ children }: AnyProps) => React.createElement('span', null
 export const Button = ({ children, onPress }: AnyProps) =>
   React.createElement('button', { onClick: onPress }, children);
 
-export const Input = ({ value, placeholder, onChangeText }: AnyProps) =>
+export const Input = ({ value, placeholder, onChangeText, id }: AnyProps) =>
   React.createElement('input', {
+    id,
     value,
     placeholder,
     onChange: (e: { target: { value: string } }) => onChangeText?.(e.target.value),
@@ -54,7 +59,8 @@ const PopoverBase = ({ children }: AnyProps) =>
   React.createElement('div', { 'data-component': 'Popover' }, children);
 const PopoverTrigger = ({ children }: AnyProps) =>
   React.createElement(React.Fragment, null, children);
-const PopoverContent = () => null;
+const PopoverContent = ({ children }: AnyProps) =>
+  React.createElement(React.Fragment, null, children);
 const PopoverArrow = () => null;
 export const Popover = Object.assign(PopoverBase, {
   Trigger: PopoverTrigger,
@@ -83,12 +89,25 @@ export const YGroup = Object.assign(YGroupBase, {
 });
 
 // Tamagui's built-in ListItem (distinct from our base/ListItem.tsx)
-export const ListItem = ({ children, title }: AnyProps) =>
-  React.createElement('div', { 'data-component': 'TamaguiListItem' }, title, children);
+export const ListItem = ({ children, title, onPress }: AnyProps) =>
+  React.createElement(
+    'div',
+    { 'data-component': 'TamaguiListItem', ...(onPress ? { onClick: onPress } : {}) },
+    title,
+    children
+  );
 
-// AlertDialog
-const AlertDialogBase = ({ open, children }: AnyProps) =>
-  open ? React.createElement('div', { 'data-component': 'AlertDialog' }, children) : null;
+// AlertDialog — supports onOpenChange context so Cancel children can close the dialog
+const AlertDialogContext = React.createContext<{ onOpenChange?: () => void }>({});
+
+const AlertDialogBase = ({ open, children, onOpenChange }: AnyProps) =>
+  open
+    ? React.createElement(
+        AlertDialogContext.Provider,
+        { value: { onOpenChange } },
+        React.createElement('div', { 'data-component': 'AlertDialog' }, children)
+      )
+    : null;
 const AlertDialogPortal = ({ children }: AnyProps) =>
   React.createElement(React.Fragment, null, children);
 const AlertDialogOverlay = () => null;
@@ -98,8 +117,11 @@ const AlertDialogTitle = ({ children }: AnyProps) =>
   React.createElement('h3', null, children);
 const AlertDialogDescription = ({ children }: AnyProps) =>
   React.createElement('p', null, children);
-const AlertDialogCancel = ({ children }: AnyProps) =>
-  React.createElement(React.Fragment, null, children);
+// Cancel: wraps children in a span that calls onOpenChange when clicked (simulates asChild close)
+const AlertDialogCancel = ({ children }: AnyProps) => {
+  const { onOpenChange } = React.useContext(AlertDialogContext);
+  return React.createElement('span', { onClick: () => onOpenChange?.() }, children);
+};
 const AlertDialogAction = ({ children }: AnyProps) =>
   React.createElement(React.Fragment, null, children);
 export const AlertDialog = Object.assign(AlertDialogBase, {

--- a/libs/ui/src/__mocks__/tamagui.tsx
+++ b/libs/ui/src/__mocks__/tamagui.tsx
@@ -46,8 +46,8 @@ export const Input = ({ value, placeholder, onChangeText, id }: AnyProps) =>
     onChange: (e: { target: { value: string } }) => onChangeText?.(e.target.value),
   });
 
-export const Label = ({ children }: AnyProps) =>
-  React.createElement('label', null, children);
+export const Label = ({ children, htmlFor }: AnyProps) =>
+  React.createElement('label', { htmlFor }, children);
 
 export const Separator = () => React.createElement('hr', null);
 

--- a/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
@@ -1,108 +1,96 @@
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { AuthLoginHandler } from './AuthLoginHandler';
 import { MockAuthRepository } from '../../data/mock';
 import { AuthLoginUsecase } from '../../domain';
+import { flushPromises } from '../../utils/testUtils';
 
 const mockRouterPush = jest.fn();
 jest.mock('solito/router', () => ({
   useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), back: jest.fn() }),
 }));
 
-const mockToastShow = jest.fn();
 jest.mock('@tamagui/toast', () => ({
-  useToastController: () => ({ show: mockToastShow }),
+  useToastController: () => ({ show: jest.fn() }),
 }));
 
-// Mock the Screen so forms don't need to render — tests focus on orchestration
-jest.mock('./AuthLoginScreen', () => ({
-  AuthLoginScreen: () => null,
-}));
-
-// Mutable state container for the mocked controller
-const authLoginCtrl = {
-  state: {
-    type: 'loaded' as string,
-    errorMessage: null as string | null,
-    values: { username: '', password: '' },
-  },
-  dispatch: jest.fn(),
-  form: {} as never,
+const createProps = (options: { shouldFail?: boolean } = {}) => {
+  const mockAuthRepo = new MockAuthRepository();
+  if (options.shouldFail) mockAuthRepo.setShouldFail(true);
+  return {
+    authLoginUsecase: new AuthLoginUsecase(mockAuthRepo),
+  };
 };
-
-jest.mock('../controllers', () => ({
-  useAuthLoginController: () => ({
-    state: authLoginCtrl.state,
-    dispatch: authLoginCtrl.dispatch,
-    form: authLoginCtrl.form,
-  }),
-}));
-
-const createProps = () => ({
-  authLoginUsecase: new AuthLoginUsecase(new MockAuthRepository()),
-});
 
 describe('AuthLoginHandler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    authLoginCtrl.state = {
-      type: 'loaded',
-      errorMessage: null,
-      values: { username: '', password: '' },
-    };
   });
 
-  it('should navigate to "/" when state reaches submitSuccess', async () => {
-    authLoginCtrl.state = {
-      type: 'submitSuccess',
-      errorMessage: null,
-      values: { username: 'admin', password: 'secret' },
-    };
+  it('should render login form initially', () => {
+    const { getByText } = render(<AuthLoginHandler {...createProps()} />);
+    expect(getByText('Submit')).toBeTruthy();
+  });
+
+  it('should render username and password input fields', () => {
+    const { container } = render(<AuthLoginHandler {...createProps()} />);
+    expect(container.querySelector('#username')).toBeTruthy();
+    expect(container.querySelector('#password')).toBeTruthy();
+  });
+
+  it('should navigate to "/" after successful login', async () => {
+    const { container, getByText } = render(<AuthLoginHandler {...createProps()} />);
+
+    const usernameInput = container.querySelector('#username') as HTMLInputElement;
+    const passwordInput = container.querySelector('#password') as HTMLInputElement;
+
+    fireEvent.change(usernameInput, { target: { value: 'admin' } });
+    fireEvent.change(passwordInput, { target: { value: 'secret' } });
+    fireEvent.click(getByText('Submit'));
 
     await act(async () => {
-      render(<AuthLoginHandler {...createProps()} />);
+      await flushPromises();
     });
 
     expect(mockRouterPush).toHaveBeenCalledWith('/');
   });
 
-  it('should not navigate when state is loaded', async () => {
-    authLoginCtrl.state = {
-      type: 'loaded',
-      errorMessage: null,
-      values: { username: '', password: '' },
-    };
+  it('should not navigate when login fails', async () => {
+    const { container, getByText } = render(
+      <AuthLoginHandler {...createProps({ shouldFail: true })} />
+    );
+
+    const usernameInput = container.querySelector('#username') as HTMLInputElement;
+    const passwordInput = container.querySelector('#password') as HTMLInputElement;
+
+    fireEvent.change(usernameInput, { target: { value: 'admin' } });
+    fireEvent.change(passwordInput, { target: { value: 'wrong' } });
+    fireEvent.click(getByText('Submit'));
 
     await act(async () => {
-      render(<AuthLoginHandler {...createProps()} />);
+      await flushPromises();
     });
 
     expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
-  it('should not navigate when state is submitting', async () => {
-    authLoginCtrl.state = {
-      type: 'submitting',
-      errorMessage: null,
-      values: { username: 'admin', password: 'secret' },
-    };
+  it('should not navigate when fields are empty (validation fails)', async () => {
+    const { getByText } = render(<AuthLoginHandler {...createProps()} />);
+
+    fireEvent.click(getByText('Submit'));
 
     await act(async () => {
-      render(<AuthLoginHandler {...createProps()} />);
+      await flushPromises();
     });
 
     expect(mockRouterPush).not.toHaveBeenCalled();
   });
 
-  it('should not navigate when state is submitError', async () => {
-    authLoginCtrl.state = {
-      type: 'submitError',
-      errorMessage: 'Login failed',
-      values: { username: 'admin', password: 'wrong' },
-    };
+  it('should not navigate without any user interaction', async () => {
+    render(<AuthLoginHandler {...createProps()} />);
 
     await act(async () => {
-      render(<AuthLoginHandler {...createProps()} />);
+      await flushPromises();
     });
 
     expect(mockRouterPush).not.toHaveBeenCalled();

--- a/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
@@ -11,8 +11,9 @@ jest.mock('solito/router', () => ({
   useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), back: jest.fn() }),
 }));
 
+const mockToastShow = jest.fn();
 jest.mock('@tamagui/toast', () => ({
-  useToastController: () => ({ show: jest.fn() }),
+  useToastController: () => ({ show: mockToastShow }),
 }));
 
 const createProps = (options: { shouldFail?: boolean } = {}) => {
@@ -90,5 +91,34 @@ describe('AuthLoginHandler', () => {
     });
 
     expect(mockRouterPush).not.toHaveBeenCalled();
+  });
+
+  it('should show error messages when fields are empty and submit is clicked', async () => {
+    const user = userEvent.setup();
+    render(<AuthLoginHandler {...createProps()} />);
+
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    const errorMessages = screen.getAllByText('String must contain at least 1 character(s)');
+    expect(errorMessages.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('should show toast error message when login fails', async () => {
+    const user = userEvent.setup();
+    render(<AuthLoginHandler {...createProps({ shouldFail: true })} />);
+
+    await user.type(screen.getByRole('textbox', { name: 'Username' }), 'admin');
+    await user.type(screen.getByRole('textbox', { name: 'Password' }), 'wrong');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await act(async () => {
+      await flushPromises();
+    });
+
+    expect(mockToastShow).toHaveBeenCalledWith('Login Error');
   });
 });

--- a/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, fireEvent, act, screen } from '@testing-library/react';
 import { AuthLoginHandler } from './AuthLoginHandler';
 import { MockAuthRepository } from '../../data/mock';
 import { AuthLoginUsecase } from '../../domain';
@@ -33,19 +33,16 @@ describe('AuthLoginHandler', () => {
   });
 
   it('should render username and password input fields', () => {
-    const { container } = render(<AuthLoginHandler {...createProps()} />);
-    expect(container.querySelector('#username')).toBeTruthy();
-    expect(container.querySelector('#password')).toBeTruthy();
+    render(<AuthLoginHandler {...createProps()} />);
+    expect(screen.getByLabelText('Username')).toBeTruthy();
+    expect(screen.getByLabelText('Password')).toBeTruthy();
   });
 
   it('should navigate to "/" after successful login', async () => {
-    const { container, getByText } = render(<AuthLoginHandler {...createProps()} />);
+    const { getByText } = render(<AuthLoginHandler {...createProps()} />);
 
-    const usernameInput = container.querySelector('#username') as HTMLInputElement;
-    const passwordInput = container.querySelector('#password') as HTMLInputElement;
-
-    fireEvent.change(usernameInput, { target: { value: 'admin' } });
-    fireEvent.change(passwordInput, { target: { value: 'secret' } });
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'admin' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret' } });
     fireEvent.click(getByText('Submit'));
 
     await act(async () => {
@@ -56,15 +53,12 @@ describe('AuthLoginHandler', () => {
   });
 
   it('should not navigate when login fails', async () => {
-    const { container, getByText } = render(
+    const { getByText } = render(
       <AuthLoginHandler {...createProps({ shouldFail: true })} />
     );
 
-    const usernameInput = container.querySelector('#username') as HTMLInputElement;
-    const passwordInput = container.querySelector('#password') as HTMLInputElement;
-
-    fireEvent.change(usernameInput, { target: { value: 'admin' } });
-    fireEvent.change(passwordInput, { target: { value: 'wrong' } });
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'admin' } });
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrong' } });
     fireEvent.click(getByText('Submit'));
 
     await act(async () => {

--- a/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, act, screen } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { AuthLoginHandler } from './AuthLoginHandler';
 import { MockAuthRepository } from '../../data/mock';
 import { AuthLoginUsecase } from '../../domain';
@@ -28,22 +29,23 @@ describe('AuthLoginHandler', () => {
   });
 
   it('should render login form initially', () => {
-    const { getByText } = render(<AuthLoginHandler {...createProps()} />);
-    expect(getByText('Submit')).toBeTruthy();
+    render(<AuthLoginHandler {...createProps()} />);
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeTruthy();
   });
 
   it('should render username and password input fields', () => {
     render(<AuthLoginHandler {...createProps()} />);
-    expect(screen.getByLabelText('Username')).toBeTruthy();
-    expect(screen.getByLabelText('Password')).toBeTruthy();
+    expect(screen.getByRole('textbox', { name: 'Username' })).toBeTruthy();
+    expect(screen.getByRole('textbox', { name: 'Password' })).toBeTruthy();
   });
 
   it('should navigate to "/" after successful login', async () => {
-    const { getByText } = render(<AuthLoginHandler {...createProps()} />);
+    const user = userEvent.setup();
+    render(<AuthLoginHandler {...createProps()} />);
 
-    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'admin' } });
-    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'secret' } });
-    fireEvent.click(getByText('Submit'));
+    await user.type(screen.getByRole('textbox', { name: 'Username' }), 'admin');
+    await user.type(screen.getByRole('textbox', { name: 'Password' }), 'secret');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await act(async () => {
       await flushPromises();
@@ -53,13 +55,12 @@ describe('AuthLoginHandler', () => {
   });
 
   it('should not navigate when login fails', async () => {
-    const { getByText } = render(
-      <AuthLoginHandler {...createProps({ shouldFail: true })} />
-    );
+    const user = userEvent.setup();
+    render(<AuthLoginHandler {...createProps({ shouldFail: true })} />);
 
-    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'admin' } });
-    fireEvent.change(screen.getByLabelText('Password'), { target: { value: 'wrong' } });
-    fireEvent.click(getByText('Submit'));
+    await user.type(screen.getByRole('textbox', { name: 'Username' }), 'admin');
+    await user.type(screen.getByRole('textbox', { name: 'Password' }), 'wrong');
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await act(async () => {
       await flushPromises();
@@ -69,9 +70,10 @@ describe('AuthLoginHandler', () => {
   });
 
   it('should not navigate when fields are empty (validation fails)', async () => {
-    const { getByText } = render(<AuthLoginHandler {...createProps()} />);
+    const user = userEvent.setup();
+    render(<AuthLoginHandler {...createProps()} />);
 
-    fireEvent.click(getByText('Submit'));
+    await user.click(screen.getByRole('button', { name: 'Submit' }));
 
     await act(async () => {
       await flushPromises();

--- a/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
@@ -11,8 +11,9 @@ jest.mock('solito/router', () => ({
   useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), back: jest.fn() }),
 }));
 
+const mockToastShow = jest.fn();
 jest.mock('@tamagui/toast', () => ({
-  useToastController: () => ({ show: jest.fn() }),
+  useToastController: () => ({ show: mockToastShow }),
 }));
 
 const createProps = (options: { shouldFail?: boolean } = {}) => {
@@ -91,6 +92,37 @@ describe('CategoryCreateHandler', () => {
       });
 
       expect(mockRouterPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('should show error message when name field is empty and submit is clicked', async () => {
+      const user = userEvent.setup();
+      render(<CategoryCreateHandler {...createProps()} />);
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('String must contain at least 1 character(s)')).toBeTruthy();
+    });
+  });
+
+  describe('toast notifications', () => {
+    it('should show toast error message when creation fails', async () => {
+      const user = userEvent.setup();
+      render(<CategoryCreateHandler {...createProps({ shouldFail: true })} />);
+
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Category');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockToastShow).toHaveBeenCalledWith('Create Category Error');
     });
   });
 });

--- a/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CategoryCreateHandler } from './CategoryCreateHandler';
 import { MockAuthRepository, MockCategoryRepository } from '../../data/mock';
 import { AuthLogoutUsecase, CategoryCreateUsecase } from '../../domain';
@@ -30,23 +31,23 @@ describe('CategoryCreateHandler', () => {
 
   describe('form rendering', () => {
     it('should render the create form in loaded state', () => {
-      const { getByText } = render(<CategoryCreateHandler {...createProps()} />);
-      expect(getByText('Submit')).toBeTruthy();
+      render(<CategoryCreateHandler {...createProps()} />);
+      expect(screen.getByRole('button', { name: 'Submit' })).toBeTruthy();
     });
 
     it('should render the name input field', () => {
-      const { container } = render(<CategoryCreateHandler {...createProps()} />);
-      expect(container.querySelector('#name')).toBeTruthy();
+      render(<CategoryCreateHandler {...createProps()} />);
+      expect(screen.getByRole('textbox', { name: 'Name' })).toBeTruthy();
     });
   });
 
   describe('navigation', () => {
     it('should navigate to "/categories" after successful creation', async () => {
-      const { container, getByText } = render(<CategoryCreateHandler {...createProps()} />);
+      const user = userEvent.setup();
+      render(<CategoryCreateHandler {...createProps()} />);
 
-      const nameInput = container.querySelector('#name') as HTMLInputElement;
-      fireEvent.change(nameInput, { target: { value: 'New Category' } });
-      fireEvent.click(getByText('Submit'));
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Category');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await act(async () => {
         await flushPromises();
@@ -56,13 +57,11 @@ describe('CategoryCreateHandler', () => {
     });
 
     it('should not navigate when creation fails', async () => {
-      const { container, getByText } = render(
-        <CategoryCreateHandler {...createProps({ shouldFail: true })} />
-      );
+      const user = userEvent.setup();
+      render(<CategoryCreateHandler {...createProps({ shouldFail: true })} />);
 
-      const nameInput = container.querySelector('#name') as HTMLInputElement;
-      fireEvent.change(nameInput, { target: { value: 'New Category' } });
-      fireEvent.click(getByText('Submit'));
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Category');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await act(async () => {
         await flushPromises();
@@ -72,9 +71,10 @@ describe('CategoryCreateHandler', () => {
     });
 
     it('should not navigate when name field is empty (validation fails)', async () => {
-      const { getByText } = render(<CategoryCreateHandler {...createProps()} />);
+      const user = userEvent.setup();
+      render(<CategoryCreateHandler {...createProps()} />);
 
-      fireEvent.click(getByText('Submit'));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await act(async () => {
         await flushPromises();

--- a/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
@@ -1,119 +1,96 @@
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { CategoryCreateHandler } from './CategoryCreateHandler';
 import { MockAuthRepository, MockCategoryRepository } from '../../data/mock';
 import { AuthLogoutUsecase, CategoryCreateUsecase } from '../../domain';
+import { flushPromises } from '../../utils/testUtils';
 
 const mockRouterPush = jest.fn();
 jest.mock('solito/router', () => ({
   useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), back: jest.fn() }),
 }));
 
-const mockToastShow = jest.fn();
 jest.mock('@tamagui/toast', () => ({
-  useToastController: () => ({ show: mockToastShow }),
+  useToastController: () => ({ show: jest.fn() }),
 }));
 
-// Mock the Screen — tests focus on handler orchestration, not form rendering
-jest.mock('./CategoryCreateScreen', () => ({
-  CategoryCreateScreen: () => null,
-}));
-
-const categoryCreateCtrl = {
-  state: {
-    type: 'loaded' as string,
-    errorMessage: null as string | null,
-    values: { name: '' },
-  },
-  dispatch: jest.fn(),
-  form: {} as never,
+const createProps = (options: { shouldFail?: boolean } = {}) => {
+  const categoryRepo = new MockCategoryRepository();
+  if (options.shouldFail) categoryRepo.setShouldFail(true);
+  return {
+    authLogoutUsecase: new AuthLogoutUsecase(new MockAuthRepository()),
+    categoryCreateUsecase: new CategoryCreateUsecase(categoryRepo),
+  };
 };
-const authLogoutCtrl = {
-  state: { type: 'idle' as string },
-  dispatch: jest.fn(),
-};
-
-jest.mock('../controllers', () => ({
-  useCategoryCreateController: () => ({
-    state: categoryCreateCtrl.state,
-    dispatch: categoryCreateCtrl.dispatch,
-    form: categoryCreateCtrl.form,
-  }),
-  useAuthLogoutController: () => ({
-    state: authLogoutCtrl.state,
-    dispatch: authLogoutCtrl.dispatch,
-  }),
-}));
-
-const createProps = () => ({
-  authLogoutUsecase: new AuthLogoutUsecase(new MockAuthRepository()),
-  categoryCreateUsecase: new CategoryCreateUsecase(new MockCategoryRepository()),
-});
 
 describe('CategoryCreateHandler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    categoryCreateCtrl.state = {
-      type: 'loaded',
-      errorMessage: null,
-      values: { name: '' },
-    };
-    authLogoutCtrl.state = { type: 'idle' };
   });
 
-  it('should navigate to "/categories" when create succeeds', async () => {
-    categoryCreateCtrl.state = {
-      type: 'submitSuccess',
-      errorMessage: null,
-      values: { name: 'New Category' },
-    };
-
-    await act(async () => {
-      render(<CategoryCreateHandler {...createProps()} />);
+  describe('form rendering', () => {
+    it('should render the create form in loaded state', () => {
+      const { getByText } = render(<CategoryCreateHandler {...createProps()} />);
+      expect(getByText('Submit')).toBeTruthy();
     });
 
-    expect(mockRouterPush).toHaveBeenCalledWith('/categories');
+    it('should render the name input field', () => {
+      const { container } = render(<CategoryCreateHandler {...createProps()} />);
+      expect(container.querySelector('#name')).toBeTruthy();
+    });
   });
 
-  it('should not navigate when state is loaded', async () => {
-    categoryCreateCtrl.state = {
-      type: 'loaded',
-      errorMessage: null,
-      values: { name: '' },
-    };
+  describe('navigation', () => {
+    it('should navigate to "/categories" after successful creation', async () => {
+      const { container, getByText } = render(<CategoryCreateHandler {...createProps()} />);
 
-    await act(async () => {
-      render(<CategoryCreateHandler {...createProps()} />);
+      const nameInput = container.querySelector('#name') as HTMLInputElement;
+      fireEvent.change(nameInput, { target: { value: 'New Category' } });
+      fireEvent.click(getByText('Submit'));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockRouterPush).toHaveBeenCalledWith('/categories');
     });
 
-    expect(mockRouterPush).not.toHaveBeenCalled();
-  });
+    it('should not navigate when creation fails', async () => {
+      const { container, getByText } = render(
+        <CategoryCreateHandler {...createProps({ shouldFail: true })} />
+      );
 
-  it('should not navigate when state is submitting', async () => {
-    categoryCreateCtrl.state = {
-      type: 'submitting',
-      errorMessage: null,
-      values: { name: 'New Category' },
-    };
+      const nameInput = container.querySelector('#name') as HTMLInputElement;
+      fireEvent.change(nameInput, { target: { value: 'New Category' } });
+      fireEvent.click(getByText('Submit'));
 
-    await act(async () => {
-      render(<CategoryCreateHandler {...createProps()} />);
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
     });
 
-    expect(mockRouterPush).not.toHaveBeenCalled();
-  });
+    it('should not navigate when name field is empty (validation fails)', async () => {
+      const { getByText } = render(<CategoryCreateHandler {...createProps()} />);
 
-  it('should not navigate when state is submitError', async () => {
-    categoryCreateCtrl.state = {
-      type: 'submitError',
-      errorMessage: 'Failed to create',
-      values: { name: 'New Category' },
-    };
+      fireEvent.click(getByText('Submit'));
 
-    await act(async () => {
-      render(<CategoryCreateHandler {...createProps()} />);
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
     });
 
-    expect(mockRouterPush).not.toHaveBeenCalled();
+    it('should not navigate without any user interaction', async () => {
+      render(<CategoryCreateHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
+    });
   });
 });

--- a/libs/ui/src/presentation/screens/CategoryListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryListHandler.test.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, fireEvent, act } from '@testing-library/react';
 import { CategoryListHandler } from './CategoryListHandler';
 import { MockAuthRepository, MockCategoryRepository } from '../../data/mock';
-import { AuthLogoutUsecase, CategoryDeleteUsecase, CategoryListUsecase } from '../../domain';
+import {
+  AuthLogoutUsecase,
+  CategoryDeleteUsecase,
+  CategoryListUsecase,
+} from '../../domain';
+import { flushPromises } from '../../utils/testUtils';
 
 const mockRouterPush = jest.fn();
 jest.mock('solito/router', () => ({
@@ -13,137 +18,204 @@ jest.mock('@tamagui/toast', () => ({
   useToastController: () => ({ show: jest.fn() }),
 }));
 
-// Mutable state containers — closed over by the jest.mock factories
-const categoryListCtrl = {
-  state: { type: 'loaded' as string, categories: [] as { id: number; name: string; createdAt: string }[] },
-  dispatch: jest.fn(),
+const createProps = (
+  options: {
+    categoryRepo?: MockCategoryRepository;
+    authRepo?: MockAuthRepository;
+  } = {}
+) => {
+  const categoryRepo = options.categoryRepo ?? new MockCategoryRepository();
+  const authRepo = options.authRepo ?? new MockAuthRepository();
+  return {
+    authLogoutUsecase: new AuthLogoutUsecase(authRepo),
+    categoryListUsecase: new CategoryListUsecase(categoryRepo, { categories: [] }),
+    categoryDeleteUsecase: new CategoryDeleteUsecase(categoryRepo),
+  };
 };
-const categoryDeleteCtrl = {
-  state: { type: 'hidden' as string },
-  dispatch: jest.fn(),
-};
-const authLogoutCtrl = {
-  state: { type: 'idle' as string },
-  dispatch: jest.fn(),
-};
-
-jest.mock('../controllers', () => ({
-  useCategoryListController: () => ({
-    state: categoryListCtrl.state,
-    dispatch: categoryListCtrl.dispatch,
-  }),
-  useCategoryDeleteController: () => ({
-    state: categoryDeleteCtrl.state,
-    dispatch: categoryDeleteCtrl.dispatch,
-  }),
-  useAuthLogoutController: () => ({
-    state: authLogoutCtrl.state,
-    dispatch: authLogoutCtrl.dispatch,
-  }),
-}));
-
-const createProps = () => ({
-  authLogoutUsecase: new AuthLogoutUsecase(new MockAuthRepository()),
-  categoryListUsecase: new CategoryListUsecase(new MockCategoryRepository()),
-  categoryDeleteUsecase: new CategoryDeleteUsecase(new MockCategoryRepository()),
-});
 
 describe('CategoryListHandler', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    categoryListCtrl.state = { type: 'loaded', categories: [] };
-    categoryDeleteCtrl.state = { type: 'hidden' };
-    authLogoutCtrl.state = { type: 'idle' };
   });
 
-  describe('delete → refetch orchestration', () => {
-    it('should dispatch FETCH to category list when delete succeeds', async () => {
-      categoryDeleteCtrl.state = { type: 'deletingSuccess' };
-
-      await act(async () => {
-        render(<CategoryListHandler {...createProps()} />);
-      });
-
-      expect(categoryListCtrl.dispatch).toHaveBeenCalledWith({ type: 'FETCH' });
-    });
-
-    it('should not dispatch FETCH when delete state is hidden', async () => {
-      categoryDeleteCtrl.state = { type: 'hidden' };
-
-      await act(async () => {
-        render(<CategoryListHandler {...createProps()} />);
-      });
-
-      expect(categoryListCtrl.dispatch).not.toHaveBeenCalledWith({ type: 'FETCH' });
-    });
-
-    it('should not dispatch FETCH when delete state is deleting (in progress)', async () => {
-      categoryDeleteCtrl.state = { type: 'deleting' };
-
-      await act(async () => {
-        render(<CategoryListHandler {...createProps()} />);
-      });
-
-      expect(categoryListCtrl.dispatch).not.toHaveBeenCalledWith({ type: 'FETCH' });
-    });
-  });
-
-  describe('delete modal visibility', () => {
-    it('should show delete modal when state is shown', async () => {
-      categoryDeleteCtrl.state = { type: 'shown' };
-
+  describe('loading and data states', () => {
+    it('should show loading state initially', () => {
       const { getByText } = render(<CategoryListHandler {...createProps()} />);
+      expect(getByText('Fetching Categories...')).toBeTruthy();
+    });
+
+    it('should show category list after successful fetch', async () => {
+      const { getByText } = render(<CategoryListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(getByText('Mock Category 1')).toBeTruthy();
+      expect(getByText('Mock Category 2')).toBeTruthy();
+    });
+
+    it('should show error state when fetch fails', async () => {
+      const categoryRepo = new MockCategoryRepository();
+      categoryRepo.setShouldFail(true);
+
+      const { getByText } = render(<CategoryListHandler {...createProps({ categoryRepo })} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(getByText('Failed to Fetch Categories')).toBeTruthy();
+    });
+
+    it('should show empty state when no categories exist', async () => {
+      const categoryRepo = new MockCategoryRepository();
+      categoryRepo.categories = [];
+
+      const { getByText } = render(<CategoryListHandler {...createProps({ categoryRepo })} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(getByText('Oops, Category is Empty')).toBeTruthy();
+    });
+  });
+
+  describe('delete modal', () => {
+    it('should not show delete modal initially', async () => {
+      const { queryByText } = render(<CategoryListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(queryByText('Delete Category ?')).toBeNull();
+    });
+
+    it('should show delete modal when delete menu is pressed', async () => {
+      const { getAllByText, getByText } = render(
+        <CategoryListHandler {...createProps()} />
+      );
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      // Click the "Delete" menu item for the first category
+      const deleteMenuItems = getAllByText('Delete');
+      fireEvent.click(deleteMenuItems[0]);
 
       expect(getByText('Delete Category ?')).toBeTruthy();
     });
 
-    it('should not show delete modal when state is hidden', async () => {
-      categoryDeleteCtrl.state = { type: 'hidden' };
+    it('should hide delete modal when cancel is pressed', async () => {
+      const { getAllByText, getByText, queryByText } = render(
+        <CategoryListHandler {...createProps()} />
+      );
 
-      const { queryByText } = render(<CategoryListHandler {...createProps()} />);
+      await act(async () => {
+        await flushPromises();
+      });
+
+      // Open the delete modal
+      const deleteMenuItems = getAllByText('Delete');
+      fireEvent.click(deleteMenuItems[0]);
+      expect(getByText('Delete Category ?')).toBeTruthy();
+
+      // Cancel the deletion
+      fireEvent.click(getByText('No'));
+
+      await act(async () => {
+        await flushPromises();
+      });
 
       expect(queryByText('Delete Category ?')).toBeNull();
     });
+
+    it('should refetch category list after successful delete', async () => {
+      const categoryRepo = new MockCategoryRepository();
+      const { getAllByText, getByText, queryByText } = render(
+        <CategoryListHandler {...createProps({ categoryRepo })} />
+      );
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      // Verify both categories are shown
+      expect(getByText('Mock Category 1')).toBeTruthy();
+
+      // Open delete modal and confirm
+      const deleteMenuItems = getAllByText('Delete');
+      fireEvent.click(deleteMenuItems[0]);
+      expect(getByText('Delete Category ?')).toBeTruthy();
+
+      fireEvent.click(getByText('Yes'));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      // Modal should be gone after delete completes
+      expect(queryByText('Delete Category ?')).toBeNull();
+      // Remaining categories are still displayed
+      expect(getByText('Mock Category 2')).toBeTruthy();
+    });
   });
 
-  describe('list variant rendering', () => {
-    it('should render loading state when category list is loading', () => {
-      categoryListCtrl.state = { type: 'loading', categories: [] };
+  describe('navigation', () => {
+    it('should navigate to category edit page when edit menu is pressed', async () => {
+      const { getAllByText } = render(<CategoryListHandler {...createProps()} />);
 
-      const { getByText } = render(<CategoryListHandler {...createProps()} />);
+      await act(async () => {
+        await flushPromises();
+      });
 
-      expect(getByText('Fetching Categories...')).toBeTruthy();
+      const editMenuItems = getAllByText('Edit');
+      fireEvent.click(editMenuItems[0]);
+
+      expect(mockRouterPush).toHaveBeenCalledWith('/categories/1');
     });
 
-    it('should render empty state when loaded with no categories', () => {
-      categoryListCtrl.state = { type: 'loaded', categories: [] };
+    it('should navigate to category page when item is pressed', async () => {
+      const { getAllByText } = render(<CategoryListHandler {...createProps()} />);
 
-      const { getByText } = render(<CategoryListHandler {...createProps()} />);
+      await act(async () => {
+        await flushPromises();
+      });
 
-      expect(getByText('Oops, Category is Empty')).toBeTruthy();
+      // Click on category name which is inside the XStack list item
+      const categoryItems = getAllByText('Mock Category 1');
+      fireEvent.click(categoryItems[0]);
+
+      expect(mockRouterPush).toHaveBeenCalledWith('/categories/1');
     });
+  });
 
-    it('should render category names when loaded with data', () => {
-      categoryListCtrl.state = {
-        type: 'loaded',
-        categories: [
-          { id: 1, name: 'Beverages', createdAt: '2024-01-01' },
-          { id: 2, name: 'Snacks', createdAt: '2024-01-02' },
-        ],
-      };
+  describe('error recovery', () => {
+    it('should refetch categories when retry button is pressed', async () => {
+      const categoryRepo = new MockCategoryRepository();
+      categoryRepo.setShouldFail(true);
 
-      const { getByText } = render(<CategoryListHandler {...createProps()} />);
+      const { getByText } = render(<CategoryListHandler {...createProps({ categoryRepo })} />);
 
-      expect(getByText('Beverages')).toBeTruthy();
-      expect(getByText('Snacks')).toBeTruthy();
-    });
-
-    it('should render error state when list fetch fails', () => {
-      categoryListCtrl.state = { type: 'error', categories: [] };
-
-      const { getByText } = render(<CategoryListHandler {...createProps()} />);
+      await act(async () => {
+        await flushPromises();
+      });
 
       expect(getByText('Failed to Fetch Categories')).toBeTruthy();
+
+      // Fix the repo so fetch succeeds on retry
+      categoryRepo.setShouldFail(false);
+
+      fireEvent.click(getByText('Retry'));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(getByText('Mock Category 1')).toBeTruthy();
     });
   });
 });

--- a/libs/ui/src/presentation/screens/CategoryListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryListHandler.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CategoryListHandler } from './CategoryListHandler';
 import { MockAuthRepository, MockCategoryRepository } from '../../data/mock';
 import {
@@ -40,154 +41,150 @@ describe('CategoryListHandler', () => {
 
   describe('loading and data states', () => {
     it('should show loading state initially', () => {
-      const { getByText } = render(<CategoryListHandler {...createProps()} />);
-      expect(getByText('Fetching Categories...')).toBeTruthy();
+      render(<CategoryListHandler {...createProps()} />);
+      expect(screen.getByText('Fetching Categories...')).toBeTruthy();
     });
 
     it('should show category list after successful fetch', async () => {
-      const { getByText } = render(<CategoryListHandler {...createProps()} />);
+      render(<CategoryListHandler {...createProps()} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(getByText('Mock Category 1')).toBeTruthy();
-      expect(getByText('Mock Category 2')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Mock Category 1' })).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Mock Category 2' })).toBeTruthy();
     });
 
     it('should show error state when fetch fails', async () => {
       const categoryRepo = new MockCategoryRepository();
       categoryRepo.setShouldFail(true);
 
-      const { getByText } = render(<CategoryListHandler {...createProps({ categoryRepo })} />);
+      render(<CategoryListHandler {...createProps({ categoryRepo })} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(getByText('Failed to Fetch Categories')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Failed to Fetch Categories' })).toBeTruthy();
     });
 
     it('should show empty state when no categories exist', async () => {
       const categoryRepo = new MockCategoryRepository();
       categoryRepo.categories = [];
 
-      const { getByText } = render(<CategoryListHandler {...createProps({ categoryRepo })} />);
+      render(<CategoryListHandler {...createProps({ categoryRepo })} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(getByText('Oops, Category is Empty')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Oops, Category is Empty' })).toBeTruthy();
     });
   });
 
   describe('delete modal', () => {
     it('should not show delete modal initially', async () => {
-      const { queryByText } = render(<CategoryListHandler {...createProps()} />);
+      render(<CategoryListHandler {...createProps()} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(queryByText('Delete Category ?')).toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Delete Category ?' })).toBeNull();
     });
 
     it('should show delete modal when delete menu is pressed', async () => {
-      const { getAllByText, getByText } = render(
-        <CategoryListHandler {...createProps()} />
-      );
+      const user = userEvent.setup();
+      render(<CategoryListHandler {...createProps()} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      // Click the "Delete" menu item for the first category
-      const deleteMenuItems = getAllByText('Delete');
-      fireEvent.click(deleteMenuItems[0]);
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
 
-      expect(getByText('Delete Category ?')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Delete Category ?' })).toBeTruthy();
     });
 
     it('should hide delete modal when cancel is pressed', async () => {
-      const { getAllByText, getByText, queryByText } = render(
-        <CategoryListHandler {...createProps()} />
-      );
+      const user = userEvent.setup();
+      render(<CategoryListHandler {...createProps()} />);
 
       await act(async () => {
         await flushPromises();
       });
 
       // Open the delete modal
-      const deleteMenuItems = getAllByText('Delete');
-      fireEvent.click(deleteMenuItems[0]);
-      expect(getByText('Delete Category ?')).toBeTruthy();
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      expect(screen.getByRole('heading', { name: 'Delete Category ?' })).toBeTruthy();
 
       // Cancel the deletion
-      fireEvent.click(getByText('No'));
+      await user.click(screen.getByRole('button', { name: 'No' }));
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(queryByText('Delete Category ?')).toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Delete Category ?' })).toBeNull();
     });
 
     it('should refetch category list after successful delete', async () => {
+      const user = userEvent.setup();
       const categoryRepo = new MockCategoryRepository();
-      const { getAllByText, getByText, queryByText } = render(
-        <CategoryListHandler {...createProps({ categoryRepo })} />
-      );
+      render(<CategoryListHandler {...createProps({ categoryRepo })} />);
 
       await act(async () => {
         await flushPromises();
       });
 
       // Verify both categories are shown
-      expect(getByText('Mock Category 1')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Mock Category 1' })).toBeTruthy();
 
       // Open delete modal and confirm
-      const deleteMenuItems = getAllByText('Delete');
-      fireEvent.click(deleteMenuItems[0]);
-      expect(getByText('Delete Category ?')).toBeTruthy();
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      expect(screen.getByRole('heading', { name: 'Delete Category ?' })).toBeTruthy();
 
-      fireEvent.click(getByText('Yes'));
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
 
       await act(async () => {
         await flushPromises();
       });
 
       // Modal should be gone after delete completes
-      expect(queryByText('Delete Category ?')).toBeNull();
+      expect(screen.queryByRole('heading', { name: 'Delete Category ?' })).toBeNull();
       // Remaining categories are still displayed
-      expect(getByText('Mock Category 2')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Mock Category 2' })).toBeTruthy();
     });
   });
 
   describe('navigation', () => {
     it('should navigate to category edit page when edit menu is pressed', async () => {
-      const { getAllByText } = render(<CategoryListHandler {...createProps()} />);
+      const user = userEvent.setup();
+      render(<CategoryListHandler {...createProps()} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      const editMenuItems = getAllByText('Edit');
-      fireEvent.click(editMenuItems[0]);
+      const editMenuItems = screen.getAllByRole('button', { name: 'Edit' });
+      await user.click(editMenuItems[0]);
 
       expect(mockRouterPush).toHaveBeenCalledWith('/categories/1');
     });
 
     it('should navigate to category page when item is pressed', async () => {
-      const { getAllByText } = render(<CategoryListHandler {...createProps()} />);
+      const user = userEvent.setup();
+      render(<CategoryListHandler {...createProps()} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      // Click on category name which is inside the XStack list item
-      const categoryItems = getAllByText('Mock Category 1');
-      fireEvent.click(categoryItems[0]);
+      await user.click(screen.getByRole('heading', { name: 'Mock Category 1' }));
 
       expect(mockRouterPush).toHaveBeenCalledWith('/categories/1');
     });
@@ -195,27 +192,28 @@ describe('CategoryListHandler', () => {
 
   describe('error recovery', () => {
     it('should refetch categories when retry button is pressed', async () => {
+      const user = userEvent.setup();
       const categoryRepo = new MockCategoryRepository();
       categoryRepo.setShouldFail(true);
 
-      const { getByText } = render(<CategoryListHandler {...createProps({ categoryRepo })} />);
+      render(<CategoryListHandler {...createProps({ categoryRepo })} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(getByText('Failed to Fetch Categories')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Failed to Fetch Categories' })).toBeTruthy();
 
       // Fix the repo so fetch succeeds on retry
       categoryRepo.setShouldFail(false);
 
-      fireEvent.click(getByText('Retry'));
+      await user.click(screen.getByRole('button', { name: 'Retry' }));
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(getByText('Mock Category 1')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Mock Category 1' })).toBeTruthy();
     });
   });
 });

--- a/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
@@ -11,8 +11,9 @@ jest.mock('solito/router', () => ({
   useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), back: jest.fn() }),
 }));
 
+const mockToastShow = jest.fn();
 jest.mock('@tamagui/toast', () => ({
-  useToastController: () => ({ show: jest.fn() }),
+  useToastController: () => ({ show: mockToastShow }),
 }));
 
 const createProps = (options: {
@@ -132,6 +133,54 @@ describe('CategoryUpdateHandler', () => {
       });
 
       expect(mockRouterPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('validation', () => {
+    it('should show error message when name field is empty and submit is clicked', async () => {
+      const user = userEvent.setup();
+      render(<CategoryUpdateHandler {...createProps({ preloaded: true })} />);
+
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('String must contain at least 1 character(s)')).toBeTruthy();
+    });
+  });
+
+  describe('toast notifications', () => {
+    it('should show toast error message when update fails', async () => {
+      const user = userEvent.setup();
+      const categoryRepo = new MockCategoryRepository();
+      const preloadedCategory = categoryRepo.categories[0];
+      const categoryUpdateUsecase = new CategoryUpdateUsecase(categoryRepo, {
+        categoryId: preloadedCategory.id,
+        category: preloadedCategory,
+      });
+      categoryRepo.setShouldFail(true);
+
+      render(
+        <CategoryUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          categoryUpdateUsecase={categoryUpdateUsecase}
+        />
+      );
+
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Category');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockToastShow).toHaveBeenCalledWith('Update Category Error');
     });
   });
 

--- a/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
@@ -1,0 +1,173 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react';
+import { CategoryUpdateHandler } from './CategoryUpdateHandler';
+import { MockAuthRepository, MockCategoryRepository } from '../../data/mock';
+import { AuthLogoutUsecase, CategoryUpdateUsecase } from '../../domain';
+import { flushPromises } from '../../utils/testUtils';
+
+const mockRouterPush = jest.fn();
+jest.mock('solito/router', () => ({
+  useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock('@tamagui/toast', () => ({
+  useToastController: () => ({ show: jest.fn() }),
+}));
+
+const createProps = (options: {
+  categoryId?: number;
+  shouldFail?: boolean;
+  preloaded?: boolean;
+} = {}) => {
+  const categoryId = options.categoryId ?? 1;
+  const categoryRepo = new MockCategoryRepository();
+  if (options.shouldFail) categoryRepo.setShouldFail(true);
+
+  // When preloaded=true, pass the existing category object to skip async fetch
+  // and immediately start in loaded state with pre-filled form values
+  const preloadedCategory = options.preloaded
+    ? categoryRepo.categories.find((c) => c.id === categoryId) ?? null
+    : null;
+
+  return {
+    authLogoutUsecase: new AuthLogoutUsecase(new MockAuthRepository()),
+    categoryUpdateUsecase: new CategoryUpdateUsecase(categoryRepo, {
+      categoryId,
+      category: preloadedCategory,
+    }),
+  };
+};
+
+describe('CategoryUpdateHandler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('loading and data states', () => {
+    it('should show loading state while fetching category', () => {
+      const { getByText } = render(<CategoryUpdateHandler {...createProps()} />);
+      expect(getByText('Fetching Category...')).toBeTruthy();
+    });
+
+    it('should show the form after category data loads', async () => {
+      const { getByText } = render(<CategoryUpdateHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(getByText('Submit')).toBeTruthy();
+    });
+
+    it('should render pre-filled form when category is preloaded', () => {
+      const { getByDisplayValue } = render(
+        <CategoryUpdateHandler {...createProps({ preloaded: true })} />
+      );
+
+      expect(getByDisplayValue('Mock Category 1')).toBeTruthy();
+    });
+
+    it('should show error state when category fetch fails', async () => {
+      const { getByText } = render(
+        <CategoryUpdateHandler {...createProps({ shouldFail: true })} />
+      );
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(getByText('Failed to Fetch Category')).toBeTruthy();
+    });
+  });
+
+  describe('navigation', () => {
+    it('should navigate to "/categories" after successful update', async () => {
+      const { container, getByText } = render(
+        <CategoryUpdateHandler {...createProps({ preloaded: true })} />
+      );
+
+      const nameInput = container.querySelector('#name') as HTMLInputElement;
+      fireEvent.change(nameInput, { target: { value: 'Updated Category' } });
+      fireEvent.click(getByText('Submit'));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockRouterPush).toHaveBeenCalledWith('/categories');
+    });
+
+    it('should not navigate when update fails', async () => {
+      const categoryRepo = new MockCategoryRepository();
+      // Allow fetch to succeed but fail on update
+      const preloadedCategory = categoryRepo.categories[0];
+      const categoryUpdateUsecase = new CategoryUpdateUsecase(categoryRepo, {
+        categoryId: preloadedCategory.id,
+        category: preloadedCategory,
+      });
+      // Set shouldFail after usecase is created (affects updateCategory)
+      categoryRepo.setShouldFail(true);
+
+      const { container, getByText } = render(
+        <CategoryUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          categoryUpdateUsecase={categoryUpdateUsecase}
+        />
+      );
+
+      const nameInput = container.querySelector('#name') as HTMLInputElement;
+      fireEvent.change(nameInput, { target: { value: 'Updated Category' } });
+      fireEvent.click(getByText('Submit'));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
+    });
+
+    it('should not navigate without user interaction', async () => {
+      render(<CategoryUpdateHandler {...createProps({ preloaded: true })} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockRouterPush).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('error recovery', () => {
+    it('should refetch category when retry button is pressed after error', async () => {
+      const categoryRepo = new MockCategoryRepository();
+      categoryRepo.setShouldFail(true);
+
+      const { getByText } = render(
+        <CategoryUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          categoryUpdateUsecase={new CategoryUpdateUsecase(categoryRepo, {
+            categoryId: 1,
+            category: null,
+          })}
+        />
+      );
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(getByText('Failed to Fetch Category')).toBeTruthy();
+
+      // Fix repo so retry succeeds
+      categoryRepo.setShouldFail(false);
+
+      fireEvent.click(getByText('Retry'));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(getByText('Submit')).toBeTruthy();
+    });
+  });
+});

--- a/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { CategoryUpdateHandler } from './CategoryUpdateHandler';
 import { MockAuthRepository, MockCategoryRepository } from '../../data/mock';
 import { AuthLogoutUsecase, CategoryUpdateUsecase } from '../../domain';
@@ -45,50 +46,45 @@ describe('CategoryUpdateHandler', () => {
 
   describe('loading and data states', () => {
     it('should show loading state while fetching category', () => {
-      const { getByText } = render(<CategoryUpdateHandler {...createProps()} />);
-      expect(getByText('Fetching Category...')).toBeTruthy();
+      render(<CategoryUpdateHandler {...createProps()} />);
+      expect(screen.getByText('Fetching Category...')).toBeTruthy();
     });
 
     it('should show the form after category data loads', async () => {
-      const { getByText } = render(<CategoryUpdateHandler {...createProps()} />);
+      render(<CategoryUpdateHandler {...createProps()} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(getByText('Submit')).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Submit' })).toBeTruthy();
     });
 
     it('should render pre-filled form when category is preloaded', () => {
-      const { getByDisplayValue } = render(
-        <CategoryUpdateHandler {...createProps({ preloaded: true })} />
-      );
-
-      expect(getByDisplayValue('Mock Category 1')).toBeTruthy();
+      render(<CategoryUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.getByDisplayValue('Mock Category 1')).toBeTruthy();
     });
 
     it('should show error state when category fetch fails', async () => {
-      const { getByText } = render(
-        <CategoryUpdateHandler {...createProps({ shouldFail: true })} />
-      );
+      render(<CategoryUpdateHandler {...createProps({ shouldFail: true })} />);
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(getByText('Failed to Fetch Category')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Failed to Fetch Category' })).toBeTruthy();
     });
   });
 
   describe('navigation', () => {
     it('should navigate to "/categories" after successful update', async () => {
-      const { container, getByText } = render(
-        <CategoryUpdateHandler {...createProps({ preloaded: true })} />
-      );
+      const user = userEvent.setup();
+      render(<CategoryUpdateHandler {...createProps({ preloaded: true })} />);
 
-      const nameInput = container.querySelector('#name') as HTMLInputElement;
-      fireEvent.change(nameInput, { target: { value: 'Updated Category' } });
-      fireEvent.click(getByText('Submit'));
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Category');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await act(async () => {
         await flushPromises();
@@ -98,6 +94,7 @@ describe('CategoryUpdateHandler', () => {
     });
 
     it('should not navigate when update fails', async () => {
+      const user = userEvent.setup();
       const categoryRepo = new MockCategoryRepository();
       // Allow fetch to succeed but fail on update
       const preloadedCategory = categoryRepo.categories[0];
@@ -108,16 +105,17 @@ describe('CategoryUpdateHandler', () => {
       // Set shouldFail after usecase is created (affects updateCategory)
       categoryRepo.setShouldFail(true);
 
-      const { container, getByText } = render(
+      render(
         <CategoryUpdateHandler
           authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
           categoryUpdateUsecase={categoryUpdateUsecase}
         />
       );
 
-      const nameInput = container.querySelector('#name') as HTMLInputElement;
-      fireEvent.change(nameInput, { target: { value: 'Updated Category' } });
-      fireEvent.click(getByText('Submit'));
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Category');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
 
       await act(async () => {
         await flushPromises();
@@ -139,10 +137,11 @@ describe('CategoryUpdateHandler', () => {
 
   describe('error recovery', () => {
     it('should refetch category when retry button is pressed after error', async () => {
+      const user = userEvent.setup();
       const categoryRepo = new MockCategoryRepository();
       categoryRepo.setShouldFail(true);
 
-      const { getByText } = render(
+      render(
         <CategoryUpdateHandler
           authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
           categoryUpdateUsecase={new CategoryUpdateUsecase(categoryRepo, {
@@ -156,18 +155,18 @@ describe('CategoryUpdateHandler', () => {
         await flushPromises();
       });
 
-      expect(getByText('Failed to Fetch Category')).toBeTruthy();
+      expect(screen.getByRole('heading', { name: 'Failed to Fetch Category' })).toBeTruthy();
 
       // Fix repo so retry succeeds
       categoryRepo.setShouldFail(false);
 
-      fireEvent.click(getByText('Retry'));
+      await user.click(screen.getByRole('button', { name: 'Retry' }));
 
       await act(async () => {
         await flushPromises();
       });
 
-      expect(getByText('Submit')).toBeTruthy();
+      expect(screen.getByRole('button', { name: 'Submit' })).toBeTruthy();
     });
   });
 });

--- a/libs/ui/src/utils/testUtils.tsx
+++ b/libs/ui/src/utils/testUtils.tsx
@@ -1,0 +1,19 @@
+/**
+ * Shared test utilities for handler integration tests.
+ *
+ * Usage pattern:
+ *   1. Create mock repos
+ *   2. Create real usecases with mock repos
+ *   3. Pass usecases as props to Handler
+ *   4. render(<Handler {...usecaseProps} />)
+ *   5. Use act() + flushPromises() for async state transitions
+ *   6. Assert UI text, navigation calls, toast calls
+ */
+
+/**
+ * Flushes all pending promises (microtasks and macrotasks).
+ * Use inside `await act(async () => { await flushPromises(); })` to
+ * wait for async usecase state transitions to complete.
+ */
+export const flushPromises = (): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, 0));

--- a/package-lock.json
+++ b/package-lock.json
@@ -83,6 +83,7 @@
         "@testing-library/jest-native": "~5.4.3",
         "@testing-library/react": "15.0.6",
         "@testing-library/react-native": "~12.5.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/jest": "^29.4.0",
         "@types/node": "18.16.9",
         "@types/react": "^18.2.0",
@@ -13036,6 +13037,20 @@
         "jest": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tokenizer/token": {

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@testing-library/jest-native": "~5.4.3",
     "@testing-library/react": "15.0.6",
     "@testing-library/react-native": "~12.5.0",
+    "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^29.4.0",
     "@types/node": "18.16.9",
     "@types/react": "^18.2.0",


### PR DESCRIPTION
## Summary
Refactored all handler integration tests to use real usecase instances with mock repositories instead of mocking controllers and state. This approach provides better test coverage by exercising actual business logic while maintaining test isolation through mock data layers.

## Key Changes

- **Removed controller mocks**: Eliminated `jest.mock('../controllers')` patterns that mocked internal state management, allowing tests to verify actual state transitions
- **Introduced real usecases**: Tests now instantiate actual usecase classes (e.g., `CategoryListUsecase`, `AuthLoginUsecase`) with mock repositories, enabling end-to-end handler behavior verification
- **Added `flushPromises` utility**: Created `libs/ui/src/utils/testUtils.tsx` with a helper function to properly await async state transitions in tests
- **Enhanced test interactions**: Updated tests to use `fireEvent` for user interactions (clicks, form input changes) instead of manually manipulating controller state
- **Improved mock repositories**: Mock repos now support `setShouldFail()` method to simulate error scenarios without test setup complexity
- **Updated Tamagui mocks**: Enhanced mock components to support `onPress` handlers, `id` attributes on inputs, and proper `AlertDialog` context for modal testing

## Test Files Modified

- `CategoryListHandler.test.tsx`: Refactored from 137 to 204 lines with comprehensive scenarios (loading, data, delete modal, navigation, error recovery)
- `CategoryCreateHandler.test.tsx`: Simplified from 119 to 96 lines, now tests actual form submission flow
- `AuthLoginHandler.test.tsx`: Simplified from 108 to 96 lines, now tests real login flow with form interaction
- `CategoryUpdateHandler.test.tsx`: New file with 173 lines covering fetch, update, and error scenarios

## Notable Implementation Details

- Tests follow a consistent pattern: create props with optional mock repo configuration → render handler → use `act()` + `flushPromises()` for async operations → assert UI state
- Modal and menu interactions now use actual `fireEvent.click()` on rendered elements rather than state manipulation
- Error scenarios are testable by configuring mock repos to fail before rendering, then fixing them to test retry flows
- Form validation is tested through actual user input and submission rather than state inspection

https://claude.ai/code/session_01WyzbomYaDxg9vvbvvgLCzZ