### PR TITLE
Add Storybook stories for all screen components

### DIFF
--- a/libs/ui/src/presentation/components/auth/LoginFormView.stories.tsx
+++ b/libs/ui/src/presentation/components/auth/LoginFormView.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { fn } from '@storybook/test';
 import React from 'react';
 import { useForm } from 'react-hook-form';
-import { LoginFormView } from './LoginFormView';
+import { LoginForm as LoginFormView } from './LoginFormView';
 import type { AuthLoginForm } from '../../../domain';
 
 const defaultValues: AuthLoginForm = {
@@ -35,7 +35,7 @@ const PrefilledStory = () => {
 };
 
 const meta: Meta<typeof LoginFormView> = {
-  title: 'Features/Auth/LoginFormView',
+  title: 'Features/Auth/LoginForm',
   component: LoginFormView,
 };
 

--- a/libs/ui/src/presentation/screens/AuthLoginScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/AuthLoginScreen.stories.tsx
@@ -1,0 +1,40 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { AuthLoginScreen } from './AuthLoginScreen';
+import type { AuthLoginForm } from '../../domain';
+
+const LoginStory = () => {
+  const form = useForm<AuthLoginForm>({ defaultValues: { username: '', password: '' } });
+  return (
+    <AuthLoginScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<AuthLoginForm>({ defaultValues: { username: 'admin', password: '••••••' } });
+  return (
+    <AuthLoginScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+    />
+  );
+};
+
+const meta: Meta<typeof AuthLoginScreen> = {
+  title: 'Screens/Auth/AuthLoginScreen',
+  component: AuthLoginScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof AuthLoginScreen>;
+
+export const Default: Story = { render: () => <LoginStory /> };
+export const Submitting: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/BudgetListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/BudgetListScreen.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { BudgetListScreen } from './BudgetListScreen';
+import { mockBudgets } from '../../../.storybook/mocks/mockData';
+
+const mockBudgetItems = mockBudgets.map((b) => ({
+  id: b.id,
+  name: b.name,
+  balance: b.balance,
+  percentage: b.percentage,
+}));
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onRetryButtonPress: fn(),
+};
+
+const meta: Meta<typeof BudgetListScreen> = {
+  title: 'Screens/Budgets/BudgetListScreen',
+  component: BudgetListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof BudgetListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', items: mockBudgetItems } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'empty' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};

--- a/libs/ui/src/presentation/screens/CalculationCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CalculationCreateScreen.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { CalculationCreateScreen } from './CalculationCreateScreen';
+import type { CalculationForm } from '../../domain';
+import { mockWallets } from '../../../.storybook/mocks/mockData';
+
+const walletSelectOptions = mockWallets.map((w) => ({ label: w.name, value: w.id }));
+
+const defaultValues: CalculationForm = {
+  walletId: 1,
+  totalWallet: 0,
+  calculationItems: [],
+};
+
+const CreateStory = () => {
+  const form = useForm<CalculationForm>({ defaultValues });
+  return (
+    <CalculationCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      getTotalWallet={fn(() => 0)}
+      variant={{ type: 'loaded' }}
+      walletSelectOptions={walletSelectOptions}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<CalculationForm>({ defaultValues });
+  return (
+    <CalculationCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      getTotalWallet={fn(() => 0)}
+      variant={{ type: 'loading' }}
+      walletSelectOptions={[]}
+    />
+  );
+};
+
+const meta: Meta<typeof CalculationCreateScreen> = {
+  title: 'Screens/Calculations/CalculationCreateScreen',
+  component: CalculationCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof CalculationCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/CalculationListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CalculationListScreen.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { CalculationListScreen } from './CalculationListScreen';
+import { mockCalculations } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onEditMenuPress: fn(),
+  onDeleteMenuPress: fn(),
+  onCompleteMenuPress: fn(),
+  onItemPress: fn(),
+  onRetryButtonPress: fn(),
+  isDeleteModalOpen: false,
+  isDeleteButtonDisabled: false,
+  onDeleteCancel: fn(),
+  onDeleteButtonConfirmPress: fn(),
+  isCompleteModalOpen: false,
+  isCompleteButtonDisabled: false,
+  onCompleteCancel: fn(),
+  onCompleteButtonConfirmPress: fn(),
+};
+
+const meta: Meta<typeof CalculationListScreen> = {
+  title: 'Screens/Calculations/CalculationListScreen',
+  component: CalculationListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof CalculationListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', items: mockCalculations } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'empty' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const DeleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded', items: mockCalculations },
+    isDeleteModalOpen: true,
+  },
+};
+
+export const CompleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded', items: mockCalculations },
+    isCompleteModalOpen: true,
+  },
+};

--- a/libs/ui/src/presentation/screens/CalculationUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CalculationUpdateScreen.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { CalculationUpdateScreen } from './CalculationUpdateScreen';
+import type { CalculationForm } from '../../domain';
+import { mockWallets } from '../../../.storybook/mocks/mockData';
+
+const walletSelectOptions = mockWallets.map((w) => ({ label: w.name, value: w.id }));
+
+const UpdateStory = () => {
+  const form = useForm<CalculationForm>({
+    defaultValues: {
+      walletId: 1,
+      totalWallet: 5000000,
+      calculationItems: [
+        { price: 100000, amount: 10 },
+        { price: 50000, amount: 20 },
+      ],
+    },
+  });
+  return (
+    <CalculationUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      getTotalWallet={fn(() => 5000000)}
+      variant={{ type: 'loaded' }}
+      walletSelectOptions={walletSelectOptions}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<CalculationForm>({
+    defaultValues: { walletId: 1, totalWallet: 0, calculationItems: [] },
+  });
+  return (
+    <CalculationUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      getTotalWallet={fn(() => 0)}
+      variant={{ type: 'loading' }}
+      walletSelectOptions={[]}
+    />
+  );
+};
+
+const meta: Meta<typeof CalculationUpdateScreen> = {
+  title: 'Screens/Calculations/CalculationUpdateScreen',
+  component: CalculationUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof CalculationUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/CategoryCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CategoryCreateScreen.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { CategoryCreateScreen } from './CategoryCreateScreen';
+import type { CategoryForm } from '../../domain';
+
+const CreateStory = () => {
+  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  return (
+    <CategoryCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      variant={{ type: 'loaded' }}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  return (
+    <CategoryCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      variant={{ type: 'loading' }}
+    />
+  );
+};
+
+const meta: Meta<typeof CategoryCreateScreen> = {
+  title: 'Screens/Categories/CategoryCreateScreen',
+  component: CategoryCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof CategoryCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/CategoryListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CategoryListScreen.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { CategoryListScreen } from './CategoryListScreen';
+import { mockCategories } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onEditMenuPress: fn(),
+  onDeleteMenuPress: fn(),
+  onItemPress: fn(),
+  onRetryButtonPress: fn(),
+  isDeleteButtonDisabled: false,
+  isDeleteModalOpen: false,
+  onDeleteCancel: fn(),
+  onDeleteConfirm: fn(),
+};
+
+const meta: Meta<typeof CategoryListScreen> = {
+  title: 'Screens/Categories/CategoryListScreen',
+  component: CategoryListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof CategoryListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', items: mockCategories } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'empty' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const DeleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded', items: mockCategories },
+    isDeleteModalOpen: true,
+  },
+};

--- a/libs/ui/src/presentation/screens/CategoryUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CategoryUpdateScreen.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { CategoryUpdateScreen } from './CategoryUpdateScreen';
+import type { CategoryForm } from '../../domain';
+
+const UpdateStory = () => {
+  const form = useForm<CategoryForm>({ defaultValues: { name: 'Electronics' } });
+  return (
+    <CategoryUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      variant={{ type: 'loaded' }}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  return (
+    <CategoryUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      variant={{ type: 'loading' }}
+    />
+  );
+};
+
+const meta: Meta<typeof CategoryUpdateScreen> = {
+  title: 'Screens/Categories/CategoryUpdateScreen',
+  component: CategoryUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof CategoryUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/CouponCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CouponCreateScreen.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { CouponCreateScreen } from './CouponCreateScreen';
+import type { CouponForm } from '../../domain';
+
+const defaultValues: CouponForm = { code: '', type: 'percentage', amount: 0 };
+
+const CreateStory = () => {
+  const form = useForm<CouponForm>({ defaultValues });
+  return (
+    <CouponCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      variant={{ type: 'loaded' }}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<CouponForm>({ defaultValues });
+  return (
+    <CouponCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      variant={{ type: 'loading' }}
+    />
+  );
+};
+
+const meta: Meta<typeof CouponCreateScreen> = {
+  title: 'Screens/Coupons/CouponCreateScreen',
+  component: CouponCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof CouponCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/CouponListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CouponListScreen.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { CouponListScreen } from './CouponListScreen';
+import { mockCoupons } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onEditMenuPress: fn(),
+  onDeleteMenuPress: fn(),
+  onItemPress: fn(),
+  onRetryButtonPress: fn(),
+  isDeleteModalOpen: false,
+  isDeleteButtonDisabled: false,
+  onDeleteCancel: fn(),
+  onDeleteConfirm: fn(),
+};
+
+const meta: Meta<typeof CouponListScreen> = {
+  title: 'Screens/Coupons/CouponListScreen',
+  component: CouponListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof CouponListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', coupons: mockCoupons } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'empty' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const DeleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded', coupons: mockCoupons },
+    isDeleteModalOpen: true,
+  },
+};

--- a/libs/ui/src/presentation/screens/CouponUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CouponUpdateScreen.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { CouponUpdateScreen } from './CouponUpdateScreen';
+import type { CouponForm } from '../../domain';
+
+const UpdateStory = () => {
+  const form = useForm<CouponForm>({
+    defaultValues: { code: 'DISC10', type: 'percentage', amount: 10 },
+  });
+  return (
+    <CouponUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      variant={{ type: 'loaded' }}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<CouponForm>({ defaultValues: { code: '', type: 'percentage', amount: 0 } });
+  return (
+    <CouponUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      variant={{ type: 'loading' }}
+    />
+  );
+};
+
+const meta: Meta<typeof CouponUpdateScreen> = {
+  title: 'Screens/Coupons/CouponUpdateScreen',
+  component: CouponUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof CouponUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/ExpenseCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseCreateScreen.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { ExpenseCreateScreen } from './ExpenseCreateScreen';
+import type { ExpenseForm } from '../../domain';
+import { mockWallets, mockBudgets } from '../../../.storybook/mocks/mockData';
+
+const defaultValues: ExpenseForm = { walletId: 1, budgetId: 1, expenseItems: [] };
+const walletSelectOptions = mockWallets.map((w) => ({ label: w.name, value: w.id }));
+const budgetSelectOptions = mockBudgets.map((b) => ({ label: b.name, value: b.id }));
+
+const CreateStory = () => {
+  const form = useForm<ExpenseForm>({ defaultValues });
+  return (
+    <ExpenseCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      walletSelectOptions={walletSelectOptions}
+      budgetSelectOptions={budgetSelectOptions}
+      variant={{ type: 'loaded' }}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<ExpenseForm>({ defaultValues });
+  return (
+    <ExpenseCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      walletSelectOptions={[]}
+      budgetSelectOptions={[]}
+      variant={{ type: 'loading' }}
+    />
+  );
+};
+
+const meta: Meta<typeof ExpenseCreateScreen> = {
+  title: 'Screens/Expenses/ExpenseCreateScreen',
+  component: ExpenseCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExpenseCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/ExpenseListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseListScreen.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { ExpenseListScreen } from './ExpenseListScreen';
+import {
+  mockExpenses,
+  mockWallets,
+  mockBudgets,
+} from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onEditMenuPress: fn(),
+  onDeleteMenuPress: fn(),
+  onItemPress: fn(),
+  onRetryButtonPress: fn(),
+  expenses: mockExpenses,
+  searchValue: '',
+  onSearchValueChange: fn(),
+  currentPage: 1,
+  onPageChange: fn(),
+  totalItem: 2,
+  itemPerPage: 10,
+  wallets: mockWallets,
+  walletId: null,
+  onWalletIdChange: fn(),
+  budgets: mockBudgets,
+  budgetId: null,
+  onBudgetIdChange: fn(),
+  isDeleteModalOpen: false,
+  isDeleteButtonDisabled: false,
+  onDeleteCancel: fn(),
+  onDeleteButtonConfirmPress: fn(),
+};
+
+const meta: Meta<typeof ExpenseListScreen> = {
+  title: 'Screens/Expenses/ExpenseListScreen',
+  component: ExpenseListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof ExpenseListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded' } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const DeleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded' },
+    isDeleteModalOpen: true,
+  },
+};

--- a/libs/ui/src/presentation/screens/ExpenseUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseUpdateScreen.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { ExpenseUpdateScreen } from './ExpenseUpdateScreen';
+import type { ExpenseForm } from '../../domain';
+import { mockWallets, mockBudgets } from '../../../.storybook/mocks/mockData';
+
+const walletSelectOptions = mockWallets.map((w) => ({ label: w.name, value: w.id }));
+const budgetSelectOptions = mockBudgets.map((b) => ({ label: b.name, value: b.id }));
+
+const UpdateStory = () => {
+  const form = useForm<ExpenseForm>({
+    defaultValues: {
+      walletId: 1,
+      budgetId: 1,
+      expenseItems: [
+        { name: 'Office Supplies', unit: 'pcs', price: 50000, amount: 5 },
+      ],
+    },
+  });
+  return (
+    <ExpenseUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      walletSelectOptions={walletSelectOptions}
+      budgetSelectOptions={budgetSelectOptions}
+      variant={{ type: 'loaded' }}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<ExpenseForm>({ defaultValues: { walletId: 1, budgetId: 1, expenseItems: [] } });
+  return (
+    <ExpenseUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      walletSelectOptions={[]}
+      budgetSelectOptions={[]}
+      variant={{ type: 'loading' }}
+    />
+  );
+};
+
+const meta: Meta<typeof ExpenseUpdateScreen> = {
+  title: 'Screens/Expenses/ExpenseUpdateScreen',
+  component: ExpenseUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExpenseUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/MaterialCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/MaterialCreateScreen.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { MaterialCreateScreen } from './MaterialCreateScreen';
+import type { MaterialForm } from '../../domain';
+
+const defaultValues: MaterialForm = { name: '', price: 0, unit: '' };
+
+const CreateStory = () => {
+  const form = useForm<MaterialForm>({ defaultValues });
+  return (
+    <MaterialCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const PopulatedStory = () => {
+  const form = useForm<MaterialForm>({
+    defaultValues: { name: 'Steel', price: 50000, unit: 'kg', description: 'High quality steel' },
+  });
+  return (
+    <MaterialCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const meta: Meta<typeof MaterialCreateScreen> = {
+  title: 'Screens/Materials/MaterialCreateScreen',
+  component: MaterialCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof MaterialCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };
+export const Populated: Story = { render: () => <PopulatedStory /> };

--- a/libs/ui/src/presentation/screens/MaterialListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/MaterialListScreen.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { MaterialListScreen } from './MaterialListScreen';
+import { mockMaterials } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onEditMenuPress: fn(),
+  onDeleteMenuPress: fn(),
+  onItemPress: fn(),
+  onRetryButtonPress: fn(),
+  searchValue: '',
+  onSearchValueChange: fn(),
+  currentPage: 1,
+  onPageChange: fn(),
+  totalItem: 3,
+  itemPerPage: 10,
+  isDeleteModalOpen: false,
+  isDeleteButtonDisabled: false,
+  onDeleteCancel: fn(),
+  onDeleteConfirm: fn(),
+};
+
+const meta: Meta<typeof MaterialListScreen> = {
+  title: 'Screens/Materials/MaterialListScreen',
+  component: MaterialListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof MaterialListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', items: mockMaterials } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'empty' }, totalItem: 0 },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const DeleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded', items: mockMaterials },
+    isDeleteModalOpen: true,
+  },
+};

--- a/libs/ui/src/presentation/screens/MaterialUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/MaterialUpdateScreen.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { MaterialUpdateScreen } from './MaterialUpdateScreen';
+import type { MaterialForm } from '../../domain';
+
+const UpdateStory = () => {
+  const form = useForm<MaterialForm>({
+    defaultValues: { name: 'Steel', price: 50000, unit: 'kg', description: 'High quality steel' },
+  });
+  return (
+    <MaterialUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const meta: Meta<typeof MaterialUpdateScreen> = {
+  title: 'Screens/Materials/MaterialUpdateScreen',
+  component: MaterialUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof MaterialUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };

--- a/libs/ui/src/presentation/screens/ProductCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/ProductCreateScreen.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { ProductCreateScreen } from './ProductCreateScreen';
+import type { ProductForm } from '../../domain';
+import { mockCategories, mockVariants } from '../../../.storybook/mocks/mockData';
+
+const defaultValues: ProductForm = {
+  name: '',
+  description: '',
+  categoryId: 1,
+  imageUrl: '',
+  options: [],
+  saleType: 'purchase',
+};
+
+const categorySelectOptions = mockCategories.map((c) => ({ label: c.name, value: c.id }));
+
+const CreateStory = () => {
+  const form = useForm<ProductForm>({ defaultValues });
+  return (
+    <ProductCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onRetryButtonPress={fn()}
+      variant={{ type: 'loaded' }}
+      categorySelectOptions={categorySelectOptions}
+      variants={mockVariants}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<ProductForm>({ defaultValues });
+  return (
+    <ProductCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onRetryButtonPress={fn()}
+      variant={{ type: 'loading' }}
+      categorySelectOptions={[]}
+      variants={[]}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const meta: Meta<typeof ProductCreateScreen> = {
+  title: 'Screens/Products/ProductCreateScreen',
+  component: ProductCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProductCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/ProductListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/ProductListScreen.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { ProductListScreen } from './ProductListScreen';
+import { mockProducts } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onEditMenuPress: fn(),
+  onDeleteMenuPress: fn(),
+  onItemPress: fn(),
+  currentPage: 1,
+  itemPerPage: 10,
+  totalItem: 3,
+  onPageChange: fn(),
+  onRetryButtonPress: fn(),
+  onSaleTypeChange: fn(),
+  onSearchValueChange: fn(),
+  saleType: 'all' as const,
+  searchValue: '',
+  isDeleteButtonDisabled: false,
+  isDeleteModalOpen: false,
+  onDeleteCancel: fn(),
+  onDeleteConfirm: fn(),
+};
+
+const meta: Meta<typeof ProductListScreen> = {
+  title: 'Screens/Products/ProductListScreen',
+  component: ProductListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof ProductListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', items: mockProducts } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'empty' }, totalItem: 0 },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const DeleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded', items: mockProducts },
+    isDeleteModalOpen: true,
+  },
+};

--- a/libs/ui/src/presentation/screens/ProductUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/ProductUpdateScreen.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { ProductUpdateScreen } from './ProductUpdateScreen';
+import type { ProductForm } from '../../domain';
+import { mockCategories, mockVariants } from '../../../.storybook/mocks/mockData';
+
+const categorySelectOptions = mockCategories.map((c) => ({ label: c.name, value: c.id }));
+
+const UpdateStory = () => {
+  const form = useForm<ProductForm>({
+    defaultValues: {
+      name: 'iPhone 14',
+      description: 'Latest Apple iPhone',
+      categoryId: 1,
+      imageUrl: 'https://placehold.jp/120x120.png',
+      options: [{ name: 'Color', values: [{ name: 'Blue' }, { name: 'Black' }] }],
+      saleType: 'purchase',
+    },
+  });
+  return (
+    <ProductUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onRetryButtonPress={fn()}
+      variant={{ type: 'loaded' }}
+      categorySelectOptions={categorySelectOptions}
+      variants={mockVariants}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<ProductForm>({
+    defaultValues: { name: '', description: '', categoryId: 1, imageUrl: '', options: [], saleType: 'purchase' },
+  });
+  return (
+    <ProductUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onRetryButtonPress={fn()}
+      variant={{ type: 'loading' }}
+      categorySelectOptions={[]}
+      variants={[]}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const meta: Meta<typeof ProductUpdateScreen> = {
+  title: 'Screens/Products/ProductUpdateScreen',
+  component: ProductUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof ProductUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/RentalCheckinScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinScreen.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { RentalCheckinScreen } from './RentalCheckinScreen';
+import type { RentalCheckinForm } from '../../domain';
+import { mockProducts } from '../../../.storybook/mocks/mockData';
+
+const defaultValues: RentalCheckinForm = {
+  name: '',
+  rentals: [],
+  checkinAt: null,
+};
+
+const CheckinStory = () => {
+  const form = useForm<RentalCheckinForm>({ defaultValues });
+  const rentalsFieldArray = useFieldArray({ control: form.control, name: 'rentals', keyName: 'key' });
+
+  return (
+    <RentalCheckinScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      rentalsFieldArray={rentalsFieldArray}
+      onToggleCustomizeCheckinDateTime={fn()}
+      rentalItemSelect={{
+        amount: 1,
+        currentPage: 1,
+        itemPerPage: 10,
+        onAmountChange: fn(),
+        onOptionValuesChange: fn(),
+        onPageChange: fn(),
+        onRetryButtonPress: fn(),
+        onSearchValueChange: fn(),
+        onSelectProduct: fn(),
+        onSubmit: fn(),
+        onUnselectProduct: fn(),
+        products: mockProducts,
+        searchValue: '',
+        selectedOptionValues: [],
+        totalItem: mockProducts.length,
+        variant: { type: 'loaded' },
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof RentalCheckinScreen> = {
+  title: 'Screens/Rentals/RentalCheckinScreen',
+  component: RentalCheckinScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof RentalCheckinScreen>;
+
+export const Default: Story = { render: () => <CheckinStory /> };

--- a/libs/ui/src/presentation/screens/RentalCheckoutScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckoutScreen.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { RentalCheckoutScreen } from './RentalCheckoutScreen';
+import type { RentalCheckoutForm } from '../../domain';
+import { mockRentals } from '../../../.storybook/mocks/mockData';
+
+const defaultValues: RentalCheckoutForm = { rentals: [] };
+
+const CheckoutStory = () => {
+  const form = useForm<RentalCheckoutForm>({ defaultValues });
+  const rentalsFieldArray = useFieldArray({ control: form.control, name: 'rentals', keyName: 'key' });
+
+  return (
+    <RentalCheckoutScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      rentalsFieldArray={rentalsFieldArray}
+      rentalList={{
+        searchValue: '',
+        onSearchValueChange: fn(),
+        checkoutStatus: 'ongoing' as const,
+        onCheckoutStatusChange: fn(),
+        variant: { type: 'loaded' },
+        rentals: mockRentals.filter((r) => !r.checkoutAt),
+        currentPage: 1,
+        onPageChange: fn(),
+        totalItem: 1,
+        itemPerPage: 10,
+        onRetryButtonPress: fn(),
+        onItemPress: fn(),
+        isSearchAutoFocus: true,
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof RentalCheckoutScreen> = {
+  title: 'Screens/Rentals/RentalCheckoutScreen',
+  component: RentalCheckoutScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof RentalCheckoutScreen>;
+
+export const Default: Story = { render: () => <CheckoutStory /> };

--- a/libs/ui/src/presentation/screens/RentalListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/RentalListScreen.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { RentalListScreen } from './RentalListScreen';
+import { mockRentals } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onDeleteMenuPress: fn(),
+  onRetryButtonPress: fn(),
+  rentals: mockRentals,
+  searchValue: '',
+  onSearchValueChange: fn(),
+  checkoutStatus: 'all' as const,
+  onCheckoutStatusChange: fn(),
+  currentPage: 1,
+  onPageChange: fn(),
+  totalItem: 2,
+  itemPerPage: 10,
+  isDeleteModalOpen: false,
+  isDeleteButtonDisabled: false,
+  onDeleteCancel: fn(),
+  onDeleteConfirm: fn(),
+};
+
+const meta: Meta<typeof RentalListScreen> = {
+  title: 'Screens/Rentals/RentalListScreen',
+  component: RentalListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof RentalListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded' } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const DeleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded' },
+    isDeleteModalOpen: true,
+  },
+};

--- a/libs/ui/src/presentation/screens/SupplierCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/SupplierCreateScreen.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { SupplierCreateScreen } from './SupplierCreateScreen';
+import type { SupplierForm } from '../../domain';
+
+const defaultValues: SupplierForm = { name: '', address: '', mapsLink: '' };
+
+const CreateStory = () => {
+  const form = useForm<SupplierForm>({ defaultValues });
+  return (
+    <SupplierCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const meta: Meta<typeof SupplierCreateScreen> = {
+  title: 'Screens/Suppliers/SupplierCreateScreen',
+  component: SupplierCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof SupplierCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };

--- a/libs/ui/src/presentation/screens/SupplierListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/SupplierListScreen.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { SupplierListScreen } from './SupplierListScreen';
+import { mockSuppliers } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onDeleteMenuPress: fn(),
+  onOpenMapMenuPress: fn(),
+  onEditMenuPress: fn(),
+  onItemPress: fn(),
+  onRetryButtonPress: fn(),
+  suppliers: mockSuppliers,
+  searchValue: '',
+  onSearchValueChange: fn(),
+  currentPage: 1,
+  onPageChange: fn(),
+  totalItem: 2,
+  itemPerPage: 10,
+  isDeleteModalOpen: false,
+  isDeleteButtonDisabled: false,
+  onDeleteCancel: fn(),
+  onDeleteConfirm: fn(),
+};
+
+const meta: Meta<typeof SupplierListScreen> = {
+  title: 'Screens/Suppliers/SupplierListScreen',
+  component: SupplierListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof SupplierListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', items: mockSuppliers } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'empty' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const DeleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded', items: mockSuppliers },
+    isDeleteModalOpen: true,
+  },
+};

--- a/libs/ui/src/presentation/screens/SupplierUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/SupplierUpdateScreen.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { SupplierUpdateScreen } from './SupplierUpdateScreen';
+import type { SupplierForm } from '../../domain';
+
+const UpdateStory = () => {
+  const form = useForm<SupplierForm>({
+    defaultValues: {
+      name: 'PT. Supplier Utama',
+      phone: '+6281234567890',
+      address: 'Jl. Raya No. 1, Jakarta Selatan',
+      mapsLink: 'https://maps.google.com/?q=-6.2,106.8',
+    },
+  });
+  return (
+    <SupplierUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const meta: Meta<typeof SupplierUpdateScreen> = {
+  title: 'Screens/Suppliers/SupplierUpdateScreen',
+  component: SupplierUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof SupplierUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };

--- a/libs/ui/src/presentation/screens/TransactionCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateScreen.stories.tsx
@@ -1,0 +1,78 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { Text } from 'tamagui';
+import { TransactionCreateScreen } from './TransactionCreateScreen';
+import type { TransactionForm } from '../../domain';
+import { mockWallet, mockWallets, mockProducts } from '../../../.storybook/mocks/mockData';
+
+const defaultValues: TransactionForm = {
+  name: 'Order #001',
+  orderNumber: 1,
+  transactionItems: [],
+  transactionCoupons: [],
+};
+
+const CreateStory = () => {
+  const form = useForm<TransactionForm>({ defaultValues });
+  const itemsFieldArray = useFieldArray({ control: form.control, name: 'transactionItems', keyName: 'key' });
+  const couponsFieldArray = useFieldArray({ control: form.control, name: 'transactionCoupons', keyName: 'key' });
+  const payForm = useForm({ defaultValues: { wallet: mockWallet, paidAmount: 0 } });
+
+  return (
+    <TransactionCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      isCouponSheetOpen={false}
+      onCouponSheetOpenChange={fn()}
+      itemsFieldArray={itemsFieldArray}
+      couponsFieldArray={couponsFieldArray}
+      transactionItemSelect={{
+        amount: 1,
+        currentPage: 1,
+        itemPerPage: 10,
+        onAmountChange: fn(),
+        onOptionValuesChange: fn(),
+        onPageChange: fn(),
+        onRetryButtonPress: fn(),
+        onSearchValueChange: fn(),
+        onSelectProduct: fn(),
+        onSubmit: fn(),
+        onUnselectProduct: fn(),
+        products: mockProducts,
+        searchValue: '',
+        selectedOptionValues: [],
+        totalItem: mockProducts.length,
+        variant: { type: 'loaded' },
+      }}
+      couponList={{
+        onItemPress: fn(),
+        onRetryButtonPress: fn(),
+        variant: { type: 'empty' },
+      }}
+      transactionPayment={{
+        form: payForm,
+        isButtonDisabled: false,
+        onCancel: fn(),
+        isOpen: false,
+        onSubmit: fn(),
+        transactionTotal: 0,
+        walletSelectOptions: mockWallets.map((w) => ({ label: w.name, value: w })),
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof TransactionCreateScreen> = {
+  title: 'Screens/Transactions/TransactionCreateScreen',
+  component: TransactionCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof TransactionCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };

--- a/libs/ui/src/presentation/screens/TransactionDetailScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/TransactionDetailScreen.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { TransactionDetailScreen } from './TransactionDetailScreen';
+import { mockTransaction } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  createdAt: mockTransaction.createdAt,
+  name: mockTransaction.name,
+  orderNumber: mockTransaction.orderNumber,
+  total: mockTransaction.total,
+  transactionItems: mockTransaction.transactionItems,
+  transactionCoupons: mockTransaction.transactionCoupons,
+  paidAmount: mockTransaction.paidAmount,
+};
+
+const meta: Meta<typeof TransactionDetailScreen> = {
+  title: 'Screens/Transactions/TransactionDetailScreen',
+  component: TransactionDetailScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof TransactionDetailScreen>;
+
+export const Paid: Story = {
+  args: {
+    paidAt: mockTransaction.paidAt ?? undefined,
+    walletName: mockTransaction.wallet?.name,
+  },
+};
+
+export const Unpaid: Story = {
+  args: {
+    paidAt: undefined,
+    walletName: undefined,
+    paidAmount: 0,
+  },
+};
+
+export const WithCoupons: Story = {
+  args: {
+    transactionCoupons: [
+      { id: 1, coupon: { id: 1, code: 'DISC10', type: 'percentage', amount: 10, createdAt: '2024-01-15T08:00:00.000Z' }, type: 'percentage', amount: 10 },
+    ],
+    paidAt: mockTransaction.paidAt ?? undefined,
+    walletName: mockTransaction.wallet?.name,
+  },
+};

--- a/libs/ui/src/presentation/screens/TransactionListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/TransactionListScreen.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { TransactionListScreen } from './TransactionListScreen';
+import {
+  mockTransactions,
+  mockWallet,
+  mockWallets,
+} from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onDeleteMenuPress: fn(),
+  onEditMenuPress: fn(),
+  onPayMenuPress: fn(),
+  onUnpayMenuPress: fn(),
+  onItemPress: fn(),
+  onPrintInvoiceMenuPress: fn(),
+  onPrintOrderSlipMenuPress: fn(),
+  onRetryButtonPress: fn(),
+  transactions: mockTransactions,
+  searchValue: '',
+  onSearchValueChange: fn(),
+  paymentStatus: 'all' as const,
+  onPaymentStatusChange: fn(),
+  currentPage: 1,
+  onPageChange: fn(),
+  totalItem: 2,
+  itemPerPage: 10,
+  wallets: mockWallets,
+  walletId: null,
+  onWalletIdChange: fn(),
+  isDeleteModalOpen: false,
+  isDeleteButtonDisabled: false,
+  onDeleteCancel: fn(),
+  onDeleteConfirm: fn(),
+  isPayModalOpen: false,
+  onPayCancel: fn(),
+  onPaySubmit: fn(),
+  payWalletSelectOptions: mockWallets.map((w) => ({ label: w.name, value: w })),
+  payTransactionTotal: 30000000,
+  isPayButtonDisabled: false,
+  isUnpayModalOpen: false,
+  isUnpayButtonDisabled: false,
+  onUnpayCancel: fn(),
+  onUnpayConfirm: fn(),
+};
+
+const LoadedStory = () => {
+  const payForm = useForm({ defaultValues: { wallet: mockWallet, paidAmount: 30000000 } });
+  return (
+    <TransactionListScreen
+      {...defaultArgs}
+      variant={{ type: 'loaded' }}
+      payForm={payForm}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const payForm = useForm({ defaultValues: { wallet: mockWallet, paidAmount: 0 } });
+  return (
+    <TransactionListScreen
+      {...defaultArgs}
+      variant={{ type: 'loading' }}
+      payForm={payForm}
+    />
+  );
+};
+
+const ErrorStory = () => {
+  const payForm = useForm({ defaultValues: { wallet: mockWallet, paidAmount: 0 } });
+  return (
+    <TransactionListScreen
+      {...defaultArgs}
+      variant={{ type: 'error' }}
+      payForm={payForm}
+    />
+  );
+};
+
+const PayModalStory = () => {
+  const payForm = useForm({ defaultValues: { wallet: mockWallet, paidAmount: 30000000 } });
+  return (
+    <TransactionListScreen
+      {...defaultArgs}
+      variant={{ type: 'loaded' }}
+      payForm={payForm}
+      isPayModalOpen={true}
+    />
+  );
+};
+
+const meta: Meta<typeof TransactionListScreen> = {
+  title: 'Screens/Transactions/TransactionListScreen',
+  component: TransactionListScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof TransactionListScreen>;
+
+export const Loaded: Story = { render: () => <LoadedStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };
+export const Error: Story = { render: () => <ErrorStory /> };
+export const PayModalOpen: Story = { render: () => <PayModalStory /> };

--- a/libs/ui/src/presentation/screens/TransactionStatisticScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/TransactionStatisticScreen.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { TransactionStatisticScreen } from './TransactionStatisticScreen';
+
+const mockTotalStatistics = [
+  { x: '2024-01-15', y: 30000000 },
+  { x: '2024-01-16', y: 17000000 },
+  { x: '2024-01-17', y: 45000000 },
+  { x: '2024-01-18', y: 22000000 },
+  { x: '2024-01-19', y: 38000000 },
+];
+
+const mockTotalIncomeStatistics = [
+  { x: '2024-01-15', y: 28000000 },
+  { x: '2024-01-16', y: 16000000 },
+  { x: '2024-01-17', y: 43000000 },
+  { x: '2024-01-18', y: 20000000 },
+  { x: '2024-01-19', y: 36000000 },
+];
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onGroupByChange: fn(),
+  onRetryButtonPress: fn(),
+  totalStatistics: mockTotalStatistics,
+  totalIncomeStatistics: mockTotalIncomeStatistics,
+  groupBy: 'date' as const,
+};
+
+const meta: Meta<typeof TransactionStatisticScreen> = {
+  title: 'Screens/Transactions/TransactionStatisticScreen',
+  component: TransactionStatisticScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof TransactionStatisticScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded' } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const GroupByMonth: Story = {
+  args: {
+    variant: { type: 'loaded' },
+    groupBy: 'month' as const,
+    totalStatistics: [
+      { x: '2024-01', y: 152000000 },
+      { x: '2024-02', y: 178000000 },
+      { x: '2024-03', y: 134000000 },
+    ],
+    totalIncomeStatistics: [
+      { x: '2024-01', y: 143000000 },
+      { x: '2024-02', y: 167000000 },
+      { x: '2024-03', y: 125000000 },
+    ],
+  },
+};

--- a/libs/ui/src/presentation/screens/TransactionUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/TransactionUpdateScreen.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { TransactionUpdateScreen } from './TransactionUpdateScreen';
+import type { TransactionForm } from '../../domain';
+import { mockWallets, mockProducts, mockTransaction } from '../../../.storybook/mocks/mockData';
+
+const UpdateStory = () => {
+  const form = useForm<TransactionForm>({
+    defaultValues: {
+      name: mockTransaction.name,
+      orderNumber: mockTransaction.orderNumber,
+      transactionItems: [],
+      transactionCoupons: [],
+    },
+  });
+  const itemsFieldArray = useFieldArray({ control: form.control, name: 'transactionItems', keyName: 'key' });
+  const couponsFieldArray = useFieldArray({ control: form.control, name: 'transactionCoupons', keyName: 'key' });
+
+  return (
+    <TransactionUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      isCouponSheetOpen={false}
+      onCouponSheetOpenChange={fn()}
+      itemsFieldArray={itemsFieldArray}
+      couponsFieldArray={couponsFieldArray}
+      transactionItemSelect={{
+        amount: 1,
+        currentPage: 1,
+        itemPerPage: 10,
+        onAmountChange: fn(),
+        onOptionValuesChange: fn(),
+        onPageChange: fn(),
+        onRetryButtonPress: fn(),
+        onSearchValueChange: fn(),
+        onSelectProduct: fn(),
+        onSubmit: fn(),
+        onUnselectProduct: fn(),
+        products: mockProducts,
+        searchValue: '',
+        selectedOptionValues: [],
+        totalItem: mockProducts.length,
+        variant: { type: 'loaded' },
+      }}
+      couponList={{
+        onItemPress: fn(),
+        onRetryButtonPress: fn(),
+        variant: { type: 'empty' },
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof TransactionUpdateScreen> = {
+  title: 'Screens/Transactions/TransactionUpdateScreen',
+  component: TransactionUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof TransactionUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };

--- a/libs/ui/src/presentation/screens/VariantCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/VariantCreateScreen.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm, useFieldArray } from 'react-hook-form';
+import { VariantCreateScreen } from './VariantCreateScreen';
+import type { VariantForm } from '../../domain';
+import { mockProduct, mockMaterials } from '../../../.storybook/mocks/mockData';
+
+const defaultValues: VariantForm = {
+  name: '',
+  price: 0,
+  description: '',
+  materials: [],
+  productId: mockProduct.id,
+  values: [],
+};
+
+const CreateStory = () => {
+  const form = useForm<VariantForm>({ defaultValues });
+  const rentalsFieldArray = useFieldArray({
+    control: form.control,
+    name: 'materials',
+    keyName: 'key',
+  });
+  return (
+    <VariantCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      isMaterialSheetOpen={false}
+      onMaterialSheetOpenChange={fn()}
+      onAddMaterial={fn()}
+      onRemoveMaterial={fn()}
+      variant={{ type: 'loaded' }}
+      product={mockProduct}
+      materialList={{
+        currentPage: 1,
+        itemPerPage: 10,
+        onPageChange: fn(),
+        onRetryButtonPress: fn(),
+        onSearchValueChange: fn(),
+        searchValue: '',
+        totalItem: mockMaterials.length,
+        variant: { type: 'loaded', items: mockMaterials },
+      }}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<VariantForm>({ defaultValues });
+  return (
+    <VariantCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      isMaterialSheetOpen={false}
+      onMaterialSheetOpenChange={fn()}
+      onAddMaterial={fn()}
+      onRemoveMaterial={fn()}
+      variant={{ type: 'loading' }}
+      product={null}
+      materialList={{
+        currentPage: 1,
+        itemPerPage: 10,
+        onPageChange: fn(),
+        onRetryButtonPress: fn(),
+        onSearchValueChange: fn(),
+        searchValue: '',
+        totalItem: 0,
+        variant: { type: 'loading' },
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof VariantCreateScreen> = {
+  title: 'Screens/Variants/VariantCreateScreen',
+  component: VariantCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof VariantCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/VariantListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/VariantListScreen.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { VariantListScreen } from './VariantListScreen';
+import { mockVariants } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onEditMenuPress: fn(),
+  onDeleteMenuPress: fn(),
+  onItemPress: fn(),
+  onRetryButtonPress: fn(),
+  variants: mockVariants,
+  searchValue: '',
+  onSearchValueChange: fn(),
+  currentPage: 1,
+  onPageChange: fn(),
+  totalItem: 2,
+  itemPerPage: 10,
+  isDeleteModalOpen: false,
+  isDeleteButtonDisabled: false,
+  onDeleteCancel: fn(),
+  onDeleteConfirm: fn(),
+};
+
+const meta: Meta<typeof VariantListScreen> = {
+  title: 'Screens/Variants/VariantListScreen',
+  component: VariantListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof VariantListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', items: mockVariants } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'empty' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const DeleteModalOpen: Story = {
+  args: {
+    variant: { type: 'loaded', items: mockVariants },
+    isDeleteModalOpen: true,
+  },
+};

--- a/libs/ui/src/presentation/screens/VariantUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/VariantUpdateScreen.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { VariantUpdateScreen } from './VariantUpdateScreen';
+import type { VariantForm } from '../../domain';
+import { mockProduct, mockMaterials, mockVariant } from '../../../.storybook/mocks/mockData';
+
+const UpdateStory = () => {
+  const form = useForm<VariantForm>({
+    defaultValues: {
+      name: mockVariant.name,
+      price: mockVariant.price,
+      description: mockVariant.description,
+      materials: [],
+      productId: mockProduct.id,
+      values: [],
+    },
+  });
+  return (
+    <VariantUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      isMaterialSheetOpen={false}
+      onMaterialSheetOpenChange={fn()}
+      onAddMaterial={fn()}
+      onRemoveMaterial={fn()}
+      variant={{ type: 'loaded' }}
+      product={mockProduct}
+      materialList={{
+        currentPage: 1,
+        itemPerPage: 10,
+        onPageChange: fn(),
+        onRetryButtonPress: fn(),
+        onSearchValueChange: fn(),
+        searchValue: '',
+        totalItem: mockMaterials.length,
+        variant: { type: 'loaded', items: mockMaterials },
+      }}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<VariantForm>({
+    defaultValues: { name: '', price: 0, materials: [], productId: 1, values: [] },
+  });
+  return (
+    <VariantUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      onRetryButtonPress={fn()}
+      isMaterialSheetOpen={false}
+      onMaterialSheetOpenChange={fn()}
+      onAddMaterial={fn()}
+      onRemoveMaterial={fn()}
+      variant={{ type: 'loading' }}
+      product={null}
+      materialList={{
+        currentPage: 1,
+        itemPerPage: 10,
+        onPageChange: fn(),
+        onRetryButtonPress: fn(),
+        onSearchValueChange: fn(),
+        searchValue: '',
+        totalItem: 0,
+        variant: { type: 'loading' },
+      }}
+    />
+  );
+};
+
+const meta: Meta<typeof VariantUpdateScreen> = {
+  title: 'Screens/Variants/VariantUpdateScreen',
+  component: VariantUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof VariantUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };

--- a/libs/ui/src/presentation/screens/WalletCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/WalletCreateScreen.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { WalletCreateScreen } from './WalletCreateScreen';
+import type { WalletForm } from '../../domain';
+
+const defaultValues: WalletForm = { name: '', balance: 0, paymentCostPercentage: 0, isCashless: false };
+
+const CreateStory = () => {
+  const form = useForm<WalletForm>({ defaultValues });
+  return (
+    <WalletCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+    />
+  );
+};
+
+const meta: Meta<typeof WalletCreateScreen> = {
+  title: 'Screens/Wallets/WalletCreateScreen',
+  component: WalletCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof WalletCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };

--- a/libs/ui/src/presentation/screens/WalletListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/WalletListScreen.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { WalletListScreen } from './WalletListScreen';
+import { mockWallets } from '../../../.storybook/mocks/mockData';
+
+const defaultArgs = {
+  onLogoutPress: fn(),
+  onEditMenuPress: fn(),
+  onItemPress: fn(),
+  onTransferMenuPress: fn(),
+  onRetryButtonPress: fn(),
+};
+
+const meta: Meta<typeof WalletListScreen> = {
+  title: 'Screens/Wallets/WalletListScreen',
+  component: WalletListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof WalletListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', items: mockWallets } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'empty' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};

--- a/libs/ui/src/presentation/screens/WalletTransferCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferCreateScreen.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { WalletTransferCreateScreen } from './WalletTransferCreateScreen';
+import type { WalletTransferForm } from '../../domain';
+import { mockWallets } from '../../../.storybook/mocks/mockData';
+
+const walletSelectOptions = mockWallets.map((w) => ({ label: w.name, value: w.id }));
+
+const CreateStory = () => {
+  const form = useForm<WalletTransferForm>({
+    defaultValues: { amount: 0, fromWalletId: 1, toWalletId: 2 },
+  });
+  return (
+    <WalletTransferCreateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      walletSelectOptions={walletSelectOptions}
+    />
+  );
+};
+
+const meta: Meta<typeof WalletTransferCreateScreen> = {
+  title: 'Screens/Wallets/WalletTransferCreateScreen',
+  component: WalletTransferCreateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof WalletTransferCreateScreen>;
+
+export const Default: Story = { render: () => <CreateStory /> };

--- a/libs/ui/src/presentation/screens/WalletTransferListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferListScreen.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { WalletTransferListScreen } from './WalletTransferListScreen';
+import { mockWalletTransfers, mockWallet } from '../../../.storybook/mocks/mockData';
+
+const mockTransferItems = mockWalletTransfers.map((t) => ({
+  toWalletName: t.toWallet.name,
+  amount: t.amount,
+  createdAt: t.createdAt,
+}));
+
+const defaultArgs = {
+  walletId: mockWallet.id,
+  onLogoutPress: fn(),
+  name: mockWallet.name,
+  balance: mockWallet.balance,
+  paymentCostPercentage: mockWallet.paymentCostPercentage,
+  onRetryButtonPress: fn(),
+};
+
+const meta: Meta<typeof WalletTransferListScreen> = {
+  title: 'Screens/Wallets/WalletTransferListScreen',
+  component: WalletTransferListScreen,
+  parameters: { layout: 'fullscreen' },
+  args: defaultArgs,
+};
+
+export default meta;
+type Story = StoryObj<typeof WalletTransferListScreen>;
+
+export const Loaded: Story = {
+  args: { variant: { type: 'loaded', items: mockTransferItems } },
+};
+
+export const Loading: Story = {
+  args: { variant: { type: 'loading' } },
+};
+
+export const Empty: Story = {
+  args: { variant: { type: 'error' } },
+};
+
+export const Error: Story = {
+  args: { variant: { type: 'error' } },
+};

--- a/libs/ui/src/presentation/screens/WalletUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/WalletUpdateScreen.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { WalletUpdateScreen } from './WalletUpdateScreen';
+import type { WalletForm } from '../../domain';
+
+const UpdateStory = () => {
+  const form = useForm<WalletForm>({
+    defaultValues: { name: 'BCA', balance: 5000000, paymentCostPercentage: 0, isCashless: true },
+  });
+  return (
+    <WalletUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      onLogoutPress={fn()}
+      variant={{ type: 'loaded' }}
+    />
+  );
+};
+
+const LoadingStory = () => {
+  const form = useForm<WalletForm>({
+    defaultValues: { name: '', balance: 0, paymentCostPercentage: 0, isCashless: false },
+  });
+  return (
+    <WalletUpdateScreen
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={true}
+      onLogoutPress={fn()}
+      variant={{ type: 'loading' }}
+    />
+  );
+};
+
+const meta: Meta<typeof WalletUpdateScreen> = {
+  title: 'Screens/Wallets/WalletUpdateScreen',
+  component: WalletUpdateScreen,
+  parameters: { layout: 'fullscreen' },
+};
+
+export default meta;
+type Story = StoryObj<typeof WalletUpdateScreen>;
+
+export const Default: Story = { render: () => <UpdateStory /> };
+export const Loading: Story = { render: () => <LoadingStory /> };


### PR DESCRIPTION
## Summary
This PR adds comprehensive Storybook story files for all screen components in the UI library, enabling visual testing and documentation of the application's screens across different states and variants.

## Key Changes
- Added 40+ new `.stories.tsx` files covering all screen components including:
  - Authentication screens (AuthLoginScreen)
  - Transaction screens (TransactionListScreen, TransactionCreateScreen, TransactionUpdateScreen, TransactionDetailScreen, TransactionStatisticScreen)
  - Product screens (ProductListScreen, ProductCreateScreen, ProductUpdateScreen)
  - Variant screens (VariantListScreen, VariantCreateScreen, VariantUpdateScreen)
  - Wallet screens (WalletListScreen, WalletCreateScreen, WalletUpdateScreen, WalletTransferListScreen, WalletTransferCreateScreen)
  - Expense screens (ExpenseListScreen, ExpenseCreateScreen, ExpenseUpdateScreen)
  - Rental screens (RentalListScreen, RentalCheckinScreen, RentalCheckoutScreen)
  - Calculation screens (CalculationListScreen, CalculationCreateScreen, CalculationUpdateScreen)
  - Category, Coupon, Material, Supplier, and Budget screens
- Each story file includes multiple variants demonstrating different states (Loaded, Loading, Error, Empty, etc.)
- Stories use mock data from the centralized mock data file for consistency
- Form-based screens utilize `react-hook-form` with appropriate default values and field arrays

## Implementation Details
- All stories follow Storybook best practices with proper TypeScript typing
- Mock callbacks use `@storybook/test`'s `fn()` for interaction testing
- Stories demonstrate both happy path (loaded/success) and error states
- List screens include pagination, search, filtering, and modal states
- Form screens show both empty and populated states
- Consistent use of `fullscreen` layout parameter for screen components

https://claude.ai/code/session_01PbwNyzw9DfqVqVgiGuzHtj