### PR TITLE
Add E2E test infrastructure with API helpers and auth setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,8 @@ __generated__
 
 # react-native-config codegen
 ios/tmp.xcconfig
+
+# Playwright E2E auth state (contains sensitive cookies)
+apps/web-e2e/src/.auth/storageState.json
+playwright-report/
+test-results/

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -17,53 +17,79 @@ const baseURL = process.env['BASE_URL'] || 'http://127.0.0.1:3000';
  */
 export default defineConfig({
   ...nxE2EPreset(__filename, { testDir: './src' }),
+  /* Global setup/teardown for auth state preparation */
+  globalSetup: './src/global-setup.ts',
+  globalTeardown: './src/global-teardown.ts',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     baseURL,
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
+    /* Reuse authenticated state from global setup (overridden per-project in auth.spec.ts) */
+    storageState: 'apps/web-e2e/src/.auth/storageState.json',
+    /* Navigation timeout */
+    navigationTimeout: 15_000,
+    /* Action timeout */
+    actionTimeout: 10_000,
   },
+  /* Timeouts */
+  timeout: 30_000,
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: 'npx nx start web2',
+    command: 'npx nx dev web',
     url: 'http://127.0.0.1:3000',
     reuseExistingServer: !process.env.CI,
     cwd: workspaceRoot,
+    timeout: 120_000,
   },
   projects: [
+    /* Setup project — runs global-setup logic as a named project for auth.spec.ts */
+    {
+      name: 'setup',
+      testMatch: /global-setup\.ts/,
+    },
+    /* Default: Chromium only for local dev and CI per-PR */
     {
       name: 'chromium',
-      use: { ...devices['Desktop Chrome'] },
+      use: {
+        ...devices['Desktop Chrome'],
+        /* Use saved auth state for all tests except auth.spec.ts */
+        storageState: 'apps/web-e2e/src/.auth/storageState.json',
+      },
+      testIgnore: /auth\.spec\.ts/,
+    },
+    /* Auth tests run without saved state (they test login/logout themselves) */
+    {
+      name: 'chromium-no-auth',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: undefined,
+      },
+      testMatch: /auth\.spec\.ts/,
     },
 
-    {
-      name: 'firefox',
-      use: { ...devices['Desktop Firefox'] },
-    },
-
-    {
-      name: 'webkit',
-      use: { ...devices['Desktop Safari'] },
-    },
-
-    // Uncomment for mobile browsers support
-    /* {
-      name: 'Mobile Chrome',
-      use: { ...devices['Pixel 5'] },
-    },
-    {
-      name: 'Mobile Safari',
-      use: { ...devices['iPhone 12'] },
-    }, */
-
-    // Uncomment for branded browsers
-    /* {
-      name: 'Microsoft Edge',
-      use: { ...devices['Desktop Edge'], channel: 'msedge' },
-    },
-    {
-      name: 'Google Chrome',
-      use: { ...devices['Desktop Chrome'], channel: 'chrome' },
-    } */
+    /* Cross-browser projects — enabled for CI nightly runs via FULL_BROWSER_MATRIX=true */
+    ...(process.env['FULL_BROWSER_MATRIX']
+      ? [
+          {
+            name: 'firefox',
+            use: {
+              ...devices['Desktop Firefox'],
+              storageState:
+                'apps/web-e2e/src/.auth/storageState.json' as string,
+            },
+            testIgnore: /auth\.spec\.ts/,
+          },
+          {
+            name: 'webkit',
+            use: {
+              ...devices['Desktop Safari'],
+              storageState:
+                'apps/web-e2e/src/.auth/storageState.json' as string,
+            },
+            testIgnore: /auth\.spec\.ts/,
+          },
+        ]
+      : []),
   ],
 });

--- a/apps/web-e2e/src/global-setup.ts
+++ b/apps/web-e2e/src/global-setup.ts
@@ -1,0 +1,63 @@
+/**
+ * Playwright Global Setup
+ *
+ * Runs once before the entire test suite. Logs in via the UI, then saves the
+ * browser storage state (cookies + localStorage) to a JSON file so that every
+ * subsequent test can start pre-authenticated — no repeated login roundtrips.
+ *
+ * Auth spec tests (auth.spec.ts) are excluded from using storageState so they
+ * can test the login/logout flow themselves.
+ *
+ * See playwright.config.ts → `globalSetup` and `use.storageState`.
+ */
+
+import { chromium, type FullConfig } from '@playwright/test';
+import * as path from 'path';
+import * as fs from 'fs';
+
+const AUTH_STATE_PATH = path.join(
+  __dirname,
+  '.auth',
+  'storageState.json'
+);
+
+export default async function globalSetup(config: FullConfig) {
+  const baseURL =
+    config.projects[0]?.use?.baseURL ?? 'http://127.0.0.1:3000';
+
+  const username = process.env['E2E_USERNAME'] ?? 'admin';
+  const password = process.env['E2E_PASSWORD'] ?? 'password';
+
+  // Ensure the .auth directory exists
+  const authDir = path.dirname(AUTH_STATE_PATH);
+  if (!fs.existsSync(authDir)) {
+    fs.mkdirSync(authDir, { recursive: true });
+  }
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  try {
+    // Navigate to login page
+    await page.goto(`${baseURL}/auth/login`);
+
+    // Fill in credentials
+    await page.getByLabel('Username').fill(username);
+    await page.getByLabel('Password').fill(password);
+    await page.getByRole('button', { name: 'Submit' }).click();
+
+    // Wait for redirect to dashboard — confirms login was successful
+    await page.waitForURL(`${baseURL}/`, { timeout: 15_000 });
+
+    // Persist auth cookies so all other tests skip login
+    await context.storageState({ path: AUTH_STATE_PATH });
+
+    console.log(`[global-setup] Auth state saved to ${AUTH_STATE_PATH}`);
+  } catch (error) {
+    console.error('[global-setup] Login failed:', error);
+    throw error;
+  } finally {
+    await browser.close();
+  }
+}

--- a/apps/web-e2e/src/global-teardown.ts
+++ b/apps/web-e2e/src/global-teardown.ts
@@ -1,0 +1,17 @@
+/**
+ * Playwright Global Teardown
+ *
+ * Runs once after the entire test suite completes.
+ * Currently a no-op — test data cleanup is handled per-spec in afterAll hooks
+ * via the API helpers in utils/api.ts.
+ *
+ * This file exists as an extension point for future global cleanup tasks
+ * (e.g. wiping a test-only database schema, rotating test credentials, etc.).
+ */
+
+import type { FullConfig } from '@playwright/test';
+
+export default async function globalTeardown(_config: FullConfig) {
+  // No global teardown needed — each spec manages its own test data cleanup.
+  // Add global cleanup logic here if required in future phases.
+}

--- a/apps/web-e2e/src/utils/api.ts
+++ b/apps/web-e2e/src/utils/api.ts
@@ -1,0 +1,229 @@
+/**
+ * Direct API helpers for creating and deleting test data.
+ *
+ * These helpers use Playwright's APIRequestContext (which carries auth cookies
+ * from storageState) to call the backend API directly — no UI interaction
+ * needed. This keeps test setup fast and deterministic.
+ *
+ * Usage in test files:
+ *   test.beforeAll(async ({ request }) => {
+ *     testCategory = await api.createCategory(request, { name: 'E2E Category' });
+ *   });
+ *   test.afterAll(async ({ request }) => {
+ *     await api.deleteCategory(request, testCategory.id);
+ *   });
+ */
+
+import { type APIRequestContext } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Types (minimal — mirrors the OpenAPI schema shapes we care about)
+// ---------------------------------------------------------------------------
+
+export interface Category {
+  id: number;
+  name: string;
+  createdAt: string;
+}
+
+export interface Wallet {
+  id: number;
+  name: string;
+  balance: number;
+  paymentCostPercentage: number;
+  isCashless: boolean;
+  createdAt: string;
+}
+
+export interface Product {
+  id: number;
+  categoryId: number;
+  name: string;
+  imageUrl: string;
+  saleType: 'purchase' | 'rental';
+  options: Option[];
+  createdAt: string;
+}
+
+export interface Option {
+  id: number;
+  name: string;
+  values: OptionValue[];
+}
+
+export interface OptionValue {
+  id: number;
+  name: string;
+}
+
+export interface Budget {
+  id: number;
+  name: string;
+  percentage: number;
+  balance: number;
+  createdAt: string;
+}
+
+export interface Expense {
+  id: number;
+  walletId: number;
+  budgetId: number;
+  createdAt: string;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helper
+// ---------------------------------------------------------------------------
+
+async function apiPost<T>(
+  request: APIRequestContext,
+  path: string,
+  body: unknown
+): Promise<T> {
+  const response = await request.post(path, { data: body });
+  if (!response.ok()) {
+    throw new Error(
+      `POST ${path} failed: ${response.status()} ${await response.text()}`
+    );
+  }
+  const json = await response.json();
+  return json.data as T;
+}
+
+async function apiDelete(
+  request: APIRequestContext,
+  path: string
+): Promise<void> {
+  const response = await request.delete(path);
+  if (!response.ok()) {
+    throw new Error(
+      `DELETE ${path} failed: ${response.status()} ${await response.text()}`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Category
+// ---------------------------------------------------------------------------
+
+export async function createCategory(
+  request: APIRequestContext,
+  data: { name: string }
+): Promise<Category> {
+  return apiPost<Category>(request, '/api/categories', data);
+}
+
+export async function deleteCategory(
+  request: APIRequestContext,
+  id: number
+): Promise<void> {
+  return apiDelete(request, `/api/categories/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Wallet
+// ---------------------------------------------------------------------------
+
+export interface CreateWalletInput {
+  name: string;
+  balance: number;
+  paymentCostPercentage: number;
+  isCashless: boolean;
+}
+
+export async function createWallet(
+  request: APIRequestContext,
+  data: CreateWalletInput
+): Promise<Wallet> {
+  return apiPost<Wallet>(request, '/api/wallets', data);
+}
+
+export async function deleteWallet(
+  request: APIRequestContext,
+  id: number
+): Promise<void> {
+  return apiDelete(request, `/api/wallets/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Product
+// ---------------------------------------------------------------------------
+
+export interface CreateProductInput {
+  categoryId: number;
+  name: string;
+  imageUrl: string;
+  description?: string;
+  saleType: 'purchase' | 'rental';
+  options: Array<{
+    name: string;
+    values: Array<{ name: string }>;
+  }>;
+}
+
+export async function createProduct(
+  request: APIRequestContext,
+  data: CreateProductInput
+): Promise<Product> {
+  return apiPost<Product>(request, '/api/products', data);
+}
+
+export async function deleteProduct(
+  request: APIRequestContext,
+  id: number
+): Promise<void> {
+  return apiDelete(request, `/api/products/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Budget
+// ---------------------------------------------------------------------------
+
+export interface CreateBudgetInput {
+  name: string;
+  percentage: number;
+  balance: number;
+}
+
+export async function createBudget(
+  request: APIRequestContext,
+  data: CreateBudgetInput
+): Promise<Budget> {
+  return apiPost<Budget>(request, '/api/budgets', data);
+}
+
+export async function deleteBudget(
+  request: APIRequestContext,
+  id: number
+): Promise<void> {
+  return apiDelete(request, `/api/budgets/${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// Expense
+// ---------------------------------------------------------------------------
+
+export interface CreateExpenseInput {
+  walletId: number;
+  budgetId: number;
+  expenseItems: Array<{
+    name: string;
+    unit: string;
+    price: number;
+    amount: number;
+  }>;
+}
+
+export async function createExpense(
+  request: APIRequestContext,
+  data: CreateExpenseInput
+): Promise<Expense> {
+  return apiPost<Expense>(request, '/api/expenses', data);
+}
+
+export async function deleteExpense(
+  request: APIRequestContext,
+  id: number
+): Promise<void> {
+  return apiDelete(request, `/api/expenses/${id}`);
+}

--- a/apps/web-e2e/src/utils/auth.ts
+++ b/apps/web-e2e/src/utils/auth.ts
@@ -1,0 +1,58 @@
+import { type Page, type APIRequestContext } from '@playwright/test';
+
+const DEFAULT_USERNAME = process.env['E2E_USERNAME'] ?? 'admin';
+const DEFAULT_PASSWORD = process.env['E2E_PASSWORD'] ?? 'password';
+
+export const credentials = {
+  username: DEFAULT_USERNAME,
+  password: DEFAULT_PASSWORD,
+};
+
+/**
+ * Log in via the UI login form.
+ * Use this in auth.spec.ts tests that exercise the login flow itself.
+ */
+export async function loginViaUI(
+  page: Page,
+  username = DEFAULT_USERNAME,
+  password = DEFAULT_PASSWORD
+): Promise<void> {
+  await page.goto('/auth/login');
+  await page.getByPlaceholder('Username').fill(username);
+  await page.getByPlaceholder('Password').fill(password);
+  await page.getByRole('button', { name: 'Login' }).click();
+  // Wait for redirect to dashboard after successful login
+  await page.waitForURL('/', { timeout: 15_000 });
+}
+
+/**
+ * Log in directly via the API (bypasses UI for faster test setup).
+ * Returns the cookie string that can be used in subsequent requests.
+ */
+export async function loginViaApi(
+  request: APIRequestContext,
+  username = DEFAULT_USERNAME,
+  password = DEFAULT_PASSWORD
+): Promise<string> {
+  const response = await request.post('/api/auth/login', {
+    data: { username, password },
+  });
+
+  if (!response.ok()) {
+    throw new Error(
+      `Login failed: ${response.status()} ${await response.text()}`
+    );
+  }
+
+  const cookies = response.headers()['set-cookie'] ?? '';
+  return cookies;
+}
+
+/**
+ * Log out via the API.
+ */
+export async function logoutViaApi(
+  request: APIRequestContext
+): Promise<void> {
+  await request.get('/api/auth/logout');
+}

--- a/apps/web-e2e/src/utils/selectors.ts
+++ b/apps/web-e2e/src/utils/selectors.ts
@@ -1,0 +1,194 @@
+/**
+ * Shared locator helpers organized by feature area.
+ *
+ * Design: lightweight functions returning Playwright Locators — no full Page
+ * Object classes. Keep this file as the single source of truth for element
+ * discovery so that UI changes only require updates here.
+ *
+ * Convention:
+ *   import * as sel from './utils/selectors';
+ *   await sel.auth.usernameInput(page).fill('admin');
+ */
+
+import { type Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Auth
+// ---------------------------------------------------------------------------
+
+export const auth = {
+  usernameInput: (page: Page) => page.getByLabel('Username'),
+  passwordInput: (page: Page) => page.getByLabel('Password'),
+  submitButton: (page: Page) => page.getByRole('button', { name: 'Submit' }),
+};
+
+// ---------------------------------------------------------------------------
+// Sidebar / Navigation
+// ---------------------------------------------------------------------------
+
+export const sidebar = {
+  logoutButton: (page: Page) => page.getByRole('button', { name: 'Logout' }),
+  navItem: (page: Page, name: string) =>
+    page.getByRole('button', { name, exact: true }),
+  /** Open the sidebar if it is collapsed (the toggle is a ChevronsRight icon) */
+  toggleButton: (page: Page) => page.locator('button[data-state]').first(),
+};
+
+// ---------------------------------------------------------------------------
+// Shared / Generic
+// ---------------------------------------------------------------------------
+
+export const common = {
+  /** The "Submit" button used in all forms */
+  submitButton: (page: Page) => page.getByRole('button', { name: 'Submit' }),
+  /** Confirmation dialog "Yes" button */
+  confirmButton: (page: Page) => page.getByRole('button', { name: 'Yes' }),
+  /** Confirmation dialog "No" button */
+  cancelButton: (page: Page) => page.getByRole('button', { name: 'No' }),
+  /** The MoreVertical "⋮" popover trigger on a list item that contains `itemName` */
+  listItemMenuTrigger: (page: Page, itemName: string) =>
+    page
+      .locator('[data-testid="list-item"], [role="listitem"]')
+      .filter({ hasText: itemName })
+      .getByRole('button')
+      .last(),
+};
+
+// ---------------------------------------------------------------------------
+// Product list page (/products)
+// ---------------------------------------------------------------------------
+
+export const productList = {
+  searchInput: (page: Page) =>
+    page.getByPlaceholder('Search Products by Name'),
+  createLink: (page: Page) => page.locator('a[href="/products/create"]'),
+  /** A product card identified by its name heading */
+  productItem: (page: Page, name: string) =>
+    page.locator('h4').filter({ hasText: name }).first(),
+  /** The MoreVertical menu button on the list item with the given product name */
+  menuButton: (page: Page, name: string) =>
+    page
+      .locator('h4')
+      .filter({ hasText: name })
+      .locator('../../../..')
+      .getByRole('button')
+      .last(),
+  /** Menu option text (Edit / Delete) rendered inside a popover */
+  menuOption: (page: Page, label: 'Edit' | 'Delete') =>
+    page.getByRole('button', { name: label }).last(),
+};
+
+// ---------------------------------------------------------------------------
+// Product form page (/products/create, /products/[id]/edit)
+// ---------------------------------------------------------------------------
+
+export const productForm = {
+  nameInput: (page: Page) => page.getByLabel('Name'),
+  categorySelect: (page: Page) => page.getByLabel('Category'),
+  saleTypeSelect: (page: Page) => page.getByLabel('Sale Type'),
+  imageUrlInput: (page: Page) => page.getByLabel('Image URL'),
+  submitButton: (page: Page) => page.getByRole('button', { name: 'Submit' }),
+};
+
+// ---------------------------------------------------------------------------
+// Wallet list page (/wallets)
+// ---------------------------------------------------------------------------
+
+export const walletList = {
+  createLink: (page: Page) => page.locator('a[href="/wallets/create"]'),
+  /** A wallet card identified by its name heading */
+  walletItem: (page: Page, name: string) =>
+    page.locator('h4').filter({ hasText: name }).first(),
+  menuButton: (page: Page, name: string) =>
+    page
+      .locator('h4')
+      .filter({ hasText: name })
+      .locator('../../../..')
+      .getByRole('button')
+      .last(),
+  menuOption: (page: Page, label: 'Transfer' | 'Edit' | 'Delete') =>
+    page.getByRole('button', { name: label }).last(),
+  /** Balance text for a wallet (rendered as subtitle paragraph) */
+  walletBalance: (page: Page, name: string) =>
+    page
+      .locator('h4')
+      .filter({ hasText: name })
+      .locator('..')
+      .locator('p')
+      .first(),
+};
+
+// ---------------------------------------------------------------------------
+// Wallet form page (/wallets/create, /wallets/[id]/edit)
+// ---------------------------------------------------------------------------
+
+export const walletForm = {
+  nameInput: (page: Page) => page.getByLabel('Name'),
+  balanceInput: (page: Page) => page.getByLabel('Balance'),
+  paymentCostInput: (page: Page) =>
+    page.getByLabel('Payment Cost Percentage'),
+  cashlessSwitch: (page: Page) => page.getByLabel('Cashless'),
+  submitButton: (page: Page) => page.getByRole('button', { name: 'Submit' }),
+};
+
+// ---------------------------------------------------------------------------
+// Transaction list page (/transactions)
+// ---------------------------------------------------------------------------
+
+export const transactionList = {
+  createLink: (page: Page) =>
+    page.locator('a[href="/transactions/create"]'),
+  transactionItem: (page: Page, name: string) =>
+    page.locator('h4').filter({ hasText: name }).first(),
+};
+
+// ---------------------------------------------------------------------------
+// Transaction create page (/transactions/create)
+// ---------------------------------------------------------------------------
+
+export const transactionForm = {
+  customerNameInput: (page: Page) => page.getByLabel('Customer Name'),
+  orderNumberInput: (page: Page) => page.getByLabel('Order Number'),
+  productSearchInput: (page: Page) =>
+    page.getByPlaceholder('Search Products by Name'),
+  /** A product card in the item selector panel (left side) */
+  productCard: (page: Page, name: string) =>
+    page.locator('h4').filter({ hasText: name }).first(),
+  addCouponButton: (page: Page) =>
+    page.getByRole('button', { name: /coupons/i }).last(),
+  submitButton: (page: Page) => page.getByRole('button', { name: 'Submit' }),
+  totalHeading: (page: Page) => page.locator('h3').last(),
+};
+
+// ---------------------------------------------------------------------------
+// Budget list / form pages (/budgets)
+// ---------------------------------------------------------------------------
+
+export const budgetList = {
+  createLink: (page: Page) => page.locator('a[href="/budgets/create"]'),
+  budgetItem: (page: Page, name: string) =>
+    page.locator('h4').filter({ hasText: name }).first(),
+};
+
+export const budgetForm = {
+  nameInput: (page: Page) => page.getByLabel('Name'),
+  percentageInput: (page: Page) => page.getByLabel('Percentage'),
+  balanceInput: (page: Page) => page.getByLabel('Balance'),
+  submitButton: (page: Page) => page.getByRole('button', { name: 'Submit' }),
+};
+
+// ---------------------------------------------------------------------------
+// Expense list / form pages (/expenses)
+// ---------------------------------------------------------------------------
+
+export const expenseList = {
+  createLink: (page: Page) => page.locator('a[href="/expenses/create"]'),
+  expenseItem: (page: Page, index = 0) =>
+    page.locator('h4').nth(index),
+};
+
+export const expenseForm = {
+  walletSelect: (page: Page) => page.getByLabel('Wallet'),
+  budgetSelect: (page: Page) => page.getByLabel('Budget'),
+  submitButton: (page: Page) => page.getByRole('button', { name: 'Submit' }),
+};


### PR DESCRIPTION
## Summary
Establish a comprehensive E2E testing foundation for the web application by introducing authenticated test sessions, direct API helpers for test data management, and shared UI selectors. This enables tests to run faster and more reliably by skipping repetitive login flows and using API calls for deterministic test setup.

## Key Changes

- **Global Auth Setup/Teardown** (`global-setup.ts`, `global-teardown.ts`)
  - Runs once before the test suite to log in via UI and persist auth state to `storageState.json`
  - All subsequent tests reuse the saved auth state, eliminating repeated login roundtrips
  - Auth-specific tests (`auth.spec.ts`) bypass saved state to test login/logout flows themselves

- **API Test Helpers** (`utils/api.ts`)
  - Direct API request functions for creating and deleting test data (categories, wallets, products, budgets, expenses)
  - Uses Playwright's `APIRequestContext` with inherited auth cookies from global setup
  - Enables fast, deterministic test setup without UI interaction
  - Includes TypeScript interfaces mirroring backend schema shapes

- **Auth Utilities** (`utils/auth.ts`)
  - `loginViaUI()` — for tests that exercise the login flow
  - `loginViaApi()` — for direct API authentication when needed
  - `logoutViaApi()` — for API-based logout
  - Configurable via `E2E_USERNAME` and `E2E_PASSWORD` environment variables

- **UI Selector Helpers** (`utils/selectors.ts`)
  - Lightweight locator functions organized by feature area (auth, sidebar, products, wallets, transactions, budgets, expenses)
  - Single source of truth for element discovery to minimize UI change impact
  - Consistent naming convention: `sel.<feature>.<element>(page)`

- **Playwright Config Updates** (`playwright.config.ts`)
  - Added global setup/teardown hooks
  - Configured `storageState` for auth state reuse
  - Set appropriate timeouts (30s test, 15s navigation, 10s action)
  - Added setup project to run global-setup logic
  - Separated auth tests (`chromium-no-auth`) from regular tests (`chromium`)
  - Optional cross-browser matrix (Firefox, Safari) via `FULL_BROWSER_MATRIX` env var
  - Updated web server command from `start web2` to `dev web`

- **Git Configuration** (`.gitignore`)
  - Excluded `storageState.json` (contains sensitive cookies)
  - Excluded Playwright report and test results directories

## Implementation Details

- Auth state is persisted to `apps/web-e2e/src/.auth/storageState.json` (git-ignored)
- Tests inherit auth cookies automatically via Playwright's context isolation
- API helpers follow a consistent pattern: `apiPost<T>()` and `apiDelete()` with error handling
- Selectors use Playwright's modern query APIs (`getByLabel`, `getByRole`, `getByPlaceholder`) for resilience
- Test data cleanup is handled per-spec in `afterAll` hooks using the API helpers

https://claude.ai/code/session_01VLkU7whbTyz6PRFtDrY7YL