### PR TITLE
Add product CRUD e2e tests and fix selector stability

### DIFF
--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -1,7 +1,10 @@
 import { defineConfig, devices } from '@playwright/test';
 import { nxE2EPreset } from '@nx/playwright/preset';
+import * as path from 'path';
 
 import { workspaceRoot } from '@nx/devkit';
+
+const STORAGE_STATE = path.join(__dirname, 'src/.auth/storageState.json');
 
 // For CI, you may want to set BASE_URL to the deployed application.
 const baseURL = process.env['BASE_URL'] || 'http://127.0.0.1:3000';
@@ -26,7 +29,7 @@ export default defineConfig({
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     /* Reuse authenticated state from global setup (overridden per-project in auth.spec.ts) */
-    storageState: 'apps/web-e2e/src/.auth/storageState.json',
+    storageState: STORAGE_STATE,
     /* Navigation timeout */
     navigationTimeout: 15_000,
     /* Action timeout */
@@ -54,7 +57,7 @@ export default defineConfig({
       use: {
         ...devices['Desktop Chrome'],
         /* Use saved auth state for all tests except auth.spec.ts */
-        storageState: 'apps/web-e2e/src/.auth/storageState.json',
+        storageState: STORAGE_STATE,
       },
       testIgnore: /auth\.spec\.ts/,
     },
@@ -76,8 +79,7 @@ export default defineConfig({
             name: 'firefox',
             use: {
               ...devices['Desktop Firefox'],
-              storageState:
-                'apps/web-e2e/src/.auth/storageState.json' as string,
+              storageState: STORAGE_STATE,
             },
             testIgnore: /auth\.spec\.ts/,
           },
@@ -85,8 +87,7 @@ export default defineConfig({
             name: 'webkit',
             use: {
               ...devices['Desktop Safari'],
-              storageState:
-                'apps/web-e2e/src/.auth/storageState.json' as string,
+              storageState: STORAGE_STATE,
             },
             testIgnore: /auth\.spec\.ts/,
           },

--- a/apps/web-e2e/src/global-setup.ts
+++ b/apps/web-e2e/src/global-setup.ts
@@ -25,8 +25,8 @@ export default async function globalSetup(config: FullConfig) {
   const baseURL =
     config.projects[0]?.use?.baseURL ?? 'http://127.0.0.1:3000';
 
-  const username = process.env['E2E_USERNAME'] ?? 'admin';
-  const password = process.env['E2E_PASSWORD'] ?? 'password';
+  const username = process.env['E2E_USERNAME'] ?? 'mnindrazaka';
+  const password = process.env['E2E_PASSWORD'] ?? '((mnindrazaka))';
 
   // Ensure the .auth directory exists
   const authDir = path.dirname(AUTH_STATE_PATH);
@@ -52,6 +52,14 @@ export default async function globalSetup(config: FullConfig) {
 
     // Persist auth cookies so all other tests skip login
     await context.storageState({ path: AUTH_STATE_PATH });
+
+    // Strip the Secure flag from saved cookies so that Playwright's APIRequestContext
+    // (used in beforeAll/afterAll for test-data setup) can send them over HTTP in dev.
+    const state = JSON.parse(fs.readFileSync(AUTH_STATE_PATH, 'utf-8'));
+    for (const cookie of state.cookies ?? []) {
+      cookie.secure = false;
+    }
+    fs.writeFileSync(AUTH_STATE_PATH, JSON.stringify(state, null, 2));
 
     console.log(`[global-setup] Auth state saved to ${AUTH_STATE_PATH}`);
   } catch (error) {

--- a/apps/web-e2e/src/products.spec.ts
+++ b/apps/web-e2e/src/products.spec.ts
@@ -1,0 +1,189 @@
+/**
+ * Phase 3: Product CRUD Flow
+ *
+ * Tests the full create → list → update → delete cycle with the real API.
+ * Tests run serially — each builds on the previous test's state.
+ *
+ * Prerequisites:
+ * - A test category is created via API in beforeAll and cleaned up in afterAll.
+ * - Authentication is handled via storageState from global-setup.ts.
+ *
+ * Why this matters:
+ * - Products are a dependency for the transaction flow (Phase 5)
+ * - Validates the full SSR data-fetching pipeline: getServerSideProps → API → render
+ * - Cross-page navigation (create → list → edit → list) with real database state
+ */
+
+import { test, expect } from '@playwright/test';
+import * as api from './utils/api';
+import * as sel from './utils/selectors';
+
+// Unique names keyed by timestamp to avoid collisions with existing data
+const TS = Date.now();
+const PRODUCT_NAME = `E2E Product ${TS}`;
+const UPDATED_PRODUCT_NAME = `E2E Product Updated ${TS}`;
+const CATEGORY_NAME = `E2E Category ${TS}`;
+const IMAGE_URL = 'https://placehold.co/400x400.jpg';
+
+test.describe.serial('Product Management', () => {
+  let testCategory: api.Category;
+  // Tracks the product ID so afterAll can clean up if a test fails mid-way
+  let createdProductId: number | undefined;
+
+  test.beforeAll(async ({ request }) => {
+    testCategory = await api.createCategory(request, { name: CATEGORY_NAME });
+  });
+
+  test.afterAll(async ({ request }) => {
+    // Clean up the product if it was not deleted by the delete test
+    if (createdProductId !== undefined) {
+      await api.deleteProduct(request, createdProductId).catch(() => {
+        // Ignore — product may already be gone
+      });
+    }
+    await api.deleteCategory(request, testCategory.id);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 1: Create
+  // ---------------------------------------------------------------------------
+
+  test('should create a new product with name and category', async ({
+    page,
+  }) => {
+    await page.goto('/products/create');
+
+    // Wait for the form to be loaded (categories fetched from API)
+    await expect(sel.productForm.submitButton(page)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Fill in required fields
+    await sel.productForm.nameInput(page).fill(PRODUCT_NAME);
+    await sel.productForm.imageUrlInput(page).fill(IMAGE_URL);
+
+    // Select the test category from the dropdown
+    await sel.productForm.categorySelect(page).click();
+    await page.getByText(CATEGORY_NAME, { exact: true }).click();
+
+    // The form validation requires at least one option — add one via the Options tab
+    await page.getByRole('tab', { name: 'Options' }).click();
+    await page.getByRole('button', { name: 'Create Option' }).click();
+
+    // Submit the form
+    await sel.productForm.submitButton(page).click();
+
+    // After successful creation the handler redirects to /products
+    await page.waitForURL('/products', { timeout: 15_000 });
+    await expect(page).toHaveURL('/products');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 2: Verify in list
+  // ---------------------------------------------------------------------------
+
+  test('should display the created product in the product list', async ({
+    page,
+  }) => {
+    await page.goto('/products');
+
+    await expect(
+      sel.productList.productItem(page, PRODUCT_NAME)
+    ).toBeVisible({ timeout: 15_000 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 3: Search
+  // ---------------------------------------------------------------------------
+
+  test('should search and find the product by name', async ({ page }) => {
+    await page.goto('/products');
+
+    await sel.productList.searchInput(page).fill(PRODUCT_NAME);
+
+    // The matching product should remain visible
+    await expect(
+      sel.productList.productItem(page, PRODUCT_NAME)
+    ).toBeVisible({ timeout: 10_000 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 4: Update
+  // ---------------------------------------------------------------------------
+
+  test('should update the product name', async ({ page }) => {
+    await page.goto('/products');
+
+    // Open the context menu for the product
+    await sel.productList.menuButton(page, PRODUCT_NAME).click();
+    await sel.productList.menuOption(page, 'Edit').click();
+
+    // Wait for navigation to the edit page and capture the product ID from the URL
+    await page.waitForURL(/\/products\/\d+$/, { timeout: 15_000 });
+    const urlMatch = page.url().match(/\/products\/(\d+)$/);
+    if (urlMatch) {
+      createdProductId = parseInt(urlMatch[1]);
+    }
+
+    // Wait for the form to load with current product data
+    await expect(sel.productForm.nameInput(page)).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Update the name field
+    await sel.productForm.nameInput(page).clear();
+    await sel.productForm.nameInput(page).fill(UPDATED_PRODUCT_NAME);
+
+    // Submit the updated form
+    await sel.productForm.submitButton(page).click();
+
+    // Should redirect back to product list on success
+    await page.waitForURL('/products', { timeout: 15_000 });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 5: Verify persisted update after reload
+  // ---------------------------------------------------------------------------
+
+  test('should verify updated data persists after page reload', async ({
+    page,
+  }) => {
+    await page.goto('/products');
+    await page.reload();
+
+    // Updated name should be visible
+    await expect(
+      sel.productList.productItem(page, UPDATED_PRODUCT_NAME)
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Old name should no longer appear
+    await expect(
+      sel.productList.productItem(page, PRODUCT_NAME)
+    ).not.toBeVisible();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Test 6: Delete
+  // ---------------------------------------------------------------------------
+
+  test('should delete the product and verify it is removed from the list', async ({
+    page,
+  }) => {
+    await page.goto('/products');
+
+    // Open context menu and trigger delete
+    await sel.productList.menuButton(page, UPDATED_PRODUCT_NAME).click();
+    await sel.productList.menuOption(page, 'Delete').click();
+
+    // Confirm the delete alert dialog
+    await sel.common.confirmButton(page).click();
+
+    // Product should disappear from the list
+    await expect(
+      sel.productList.productItem(page, UPDATED_PRODUCT_NAME)
+    ).not.toBeVisible({ timeout: 10_000 });
+
+    // Mark as successfully deleted so afterAll doesn't try to delete again
+    createdProductId = undefined;
+  });
+});

--- a/apps/web-e2e/src/utils/selectors.ts
+++ b/apps/web-e2e/src/utils/selectors.ts
@@ -75,7 +75,7 @@ export const productList = {
       .last(),
   /** Menu option text (Edit / Delete) rendered inside a popover */
   menuOption: (page: Page, label: 'Edit' | 'Delete') =>
-    page.getByRole('button', { name: label }).last(),
+    page.locator('[data-state="open"] li').filter({ hasText: label }).last(),
 };
 
 // ---------------------------------------------------------------------------
@@ -84,7 +84,7 @@ export const productList = {
 
 export const productForm = {
   nameInput: (page: Page) => page.getByLabel('Name'),
-  categorySelect: (page: Page) => page.getByLabel('Category'),
+  categorySelect: (page: Page) => page.getByLabel('Category', { exact: true }),
   saleTypeSelect: (page: Page) => page.getByLabel('Sale Type'),
   imageUrlInput: (page: Page) => page.getByLabel('Image URL'),
   submitButton: (page: Page) => page.getByRole('button', { name: 'Submit' }),
@@ -107,7 +107,7 @@ export const walletList = {
       .getByRole('button')
       .last(),
   menuOption: (page: Page, label: 'Transfer' | 'Edit' | 'Delete') =>
-    page.getByRole('button', { name: label }).last(),
+    page.locator('[data-state="open"] li').filter({ hasText: label }).last(),
   /** Balance text for a wallet (rendered as subtitle paragraph) */
   walletBalance: (page: Page, name: string) =>
     page

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,0 +1,13 @@
+{
+  "name": "web2",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "web2",
+      "version": "1.0.0",
+      "license": "ISC"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive end-to-end tests for the product management flow and improves selector reliability in the e2e test suite.

## Key Changes

### New Product CRUD E2E Tests (`products.spec.ts`)
- Added serial test suite covering the full product lifecycle: create → list → search → update → verify persistence → delete
- Tests validate the SSR data-fetching pipeline (getServerSideProps → API → render)
- Includes proper setup/teardown with test category creation and cleanup
- Tests cross-page navigation with real database state
- Captures product ID during edit flow for proper cleanup in afterAll

### Global Setup Improvements (`global-setup.ts`)
- Updated default test credentials to `mnindrazaka` / `((mnindrazaka))`
- Added cookie security flag stripping to allow APIRequestContext to send auth cookies over HTTP in development
- Enables test-data setup via API calls in beforeAll/afterAll hooks

### Selector Stability Fixes (`selectors.ts`)
- Fixed menu option selectors to use `[data-state="open"] li` filter instead of generic button role
  - Prevents flaky matches when multiple buttons with same label exist on page
- Made category select label matching exact to avoid partial matches
- Applied same menu selector fix to wallet list for consistency

## Implementation Details
- Product tests run serially to maintain state dependencies between test cases
- Uses timestamp-based naming to avoid collisions with existing test data
- Properly handles cleanup even if tests fail mid-way via `createdProductId` tracking
- Validates both immediate UI updates and data persistence after page reload

https://claude.ai/code/session_01LoKQW2FDsuwAWV9ym6Wx3H