### PR TITLE
Replace ts-jest with @swc/jest for faster test compilation

### DIFF
--- a/libs/ui/jest.config.ts
+++ b/libs/ui/jest.config.ts
@@ -3,6 +3,7 @@ export default {
   displayName: 'ui',
   preset: '../../jest.preset.js',
   coverageDirectory: '../../coverage/libs/ui',
+  maxWorkers: '50%',
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'mjs', 'html'],
   moduleNameMapper: {
     '^react-native$': '<rootDir>/src/__mocks__/react-native.ts',
@@ -17,9 +18,15 @@ export default {
     '^react-markdown$': '<rootDir>/src/__mocks__/react-markdown.ts',
   },
   transform: {
-    '^.+\\.(ts|tsx|js|jsx|html)$': [
-      'ts-jest',
-      { tsconfig: '<rootDir>/tsconfig.spec.json', diagnostics: { warnOnly: true } },
+    '^.+\\.(ts|tsx|js|jsx)$': [
+      '@swc/jest',
+      {
+        jsc: {
+          parser: { syntax: 'typescript', tsx: true },
+          transform: { react: { runtime: 'automatic' } },
+          target: 'es2022',
+        },
+      },
     ],
   },
   transformIgnorePatterns: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "@swc/cli": "~0.3.12",
         "@swc/core": "~1.5.7",
         "@swc/helpers": "~0.5.11",
+        "@swc/jest": "^0.2.39",
         "@tamagui/animations-css": "^2.0.0-rc.29",
         "@tamagui/vite-plugin": "^1.111.13",
         "@testing-library/jest-native": "~5.4.3",
@@ -3728,6 +3729,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -10067,6 +10092,76 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
     },
+    "node_modules/@swc/jest": {
+      "version": "0.2.39",
+      "resolved": "https://registry.npmjs.org/@swc/jest/-/jest-0.2.39.tgz",
+      "integrity": "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/create-cache-key-function": "^30.0.0",
+        "@swc/counter": "^0.1.3",
+        "jsonc-parser": "^3.2.0"
+      },
+      "engines": {
+        "npm": ">= 7.0.0"
+      },
+      "peerDependencies": {
+        "@swc/core": "*"
+      }
+    },
+    "node_modules/@swc/jest/node_modules/@jest/create-cache-key-function": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-30.3.0.tgz",
+      "integrity": "sha512-hTupmOWylzeyqbMNeSNi7ZDprpjrcroAOOG+qCEW66st3+Z5RnYHVYkUt+zjIcLmrTUi2lPY79hJz8mB3L2oXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.3.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@swc/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@swc/jest/node_modules/@jest/types": {
+      "version": "30.3.0",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+      "integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@swc/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.48",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.48.tgz",
+      "integrity": "sha512-kKJTNuK3AQOrgjjotVxMrCn1sUJwM76wMszfq1kdU4uYVJjvEWuFQ6HgvLt4Xz3fSmZlTOxJ/Ie13KnIcWQXFA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@swc/types": {
       "version": "0.1.25",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.25.tgz",
@@ -14922,9 +15017,10 @@
       }
     },
     "node_modules/@types/yargs": {
-      "version": "17.0.32",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
-      "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
+      "version": "17.0.35",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
+      "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+      "license": "MIT",
       "dependencies": {
         "@types/yargs-parser": "*"
       }

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@swc/cli": "~0.3.12",
     "@swc/core": "~1.5.7",
     "@swc/helpers": "~0.5.11",
+    "@swc/jest": "^0.2.39",
     "@tamagui/animations-css": "^2.0.0-rc.29",
     "@tamagui/vite-plugin": "^1.111.13",
     "@testing-library/jest-native": "~5.4.3",


### PR DESCRIPTION
## Summary
This PR migrates the UI library's Jest configuration from ts-jest to @swc/jest for improved test performance and faster TypeScript compilation.

## Key Changes
- **Jest transformer**: Replaced `ts-jest` with `@swc/jest` for faster TypeScript/JSX transformation
- **Transform patterns**: Updated regex pattern from `^.+\\.(ts|tsx|js|jsx|html)$` to `^.+\\.(ts|tsx|js|jsx)$` (removed HTML from SWC transformation)
- **SWC configuration**: Added comprehensive SWC parser and transform settings:
  - TypeScript syntax support with JSX enabled
  - React automatic runtime for JSX transformation
  - ES2022 target
- **Worker optimization**: Added `maxWorkers: '50%'` to Jest configuration to optimize parallel test execution
- **Dependencies**: Added `@swc/jest` as a dev dependency

## Implementation Details
The migration leverages SWC's superior performance characteristics compared to ts-jest while maintaining equivalent TypeScript and React support. The configuration explicitly targets ES2022 and uses React's automatic JSX runtime, eliminating the need for manual React imports in JSX files.

https://claude.ai/code/session_01GN68xq1vE3ogTJZ9mvDybJ