### PR TITLE
Add context-aware error logging to database operations

### DIFF
--- a/apps/api/data/mysql/auth_repo.go
+++ b/apps/api/data/mysql/auth_repo.go
@@ -15,5 +15,5 @@ func (repo Repository) GetUserByUsername(ctx context.Context, username string) (
 	db := GetDbFromCtx(ctx, repo.db)
 	var user User
 	result := db.Table("users").Where("username = ?", username).First(&user)
-	return ToUserDomain(user), ToError(result.Error)
+	return ToUserDomain(user), ToErrorCtx(ctx, result.Error, "GetUserByUsername")
 }

--- a/apps/api/data/mysql/base_repo.go
+++ b/apps/api/data/mysql/base_repo.go
@@ -2,9 +2,11 @@ package mysql
 
 import (
 	"apps/api/domain"
+	"apps/api/pkg/logger"
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 
 	"gorm.io/driver/mysql"
 	"gorm.io/gorm"
@@ -16,14 +18,23 @@ type Repository struct {
 
 func (repo Repository) BeginTransaction(ctx context.Context, callback func(ctxWithTx context.Context) *domain.Error) *domain.Error {
 	var baseError *domain.Error = nil
+	log := logger.FromCtx(ctx, slog.Default())
+
+	log.DebugContext(ctx, "transaction begin")
 
 	repo.db.Transaction(func(tx *gorm.DB) error {
 		ctxWithTx := context.WithValue(ctx, "tx", tx)
 		baseError = callback(ctxWithTx)
 
 		if baseError != nil {
-			return errors.New(baseError.Message)
+			txErr := errors.New(baseError.Message)
+			log.ErrorContext(ctx, "transaction rollback",
+				slog.String("reason", txErr.Error()),
+			)
+			return txErr
 		}
+
+		log.DebugContext(ctx, "transaction commit")
 		return nil
 	})
 

--- a/apps/api/data/mysql/base_transformer.go
+++ b/apps/api/data/mysql/base_transformer.go
@@ -2,7 +2,10 @@ package mysql
 
 import (
 	"apps/api/domain"
+	"apps/api/pkg/logger"
+	"context"
 	"errors"
+	"log/slog"
 
 	"gorm.io/gorm"
 )
@@ -27,6 +30,28 @@ func ToOrderColumn(order domain.Order) string {
 	}
 }
 
+// ToErrorCtx converts a GORM error to a domain.Error. When the error represents
+// an unexpected DB failure (i.e. not ErrRecordNotFound), it logs the raw error
+// at ERROR level so the details are captured before the opaque domain error is
+// returned up the stack.
+func ToErrorCtx(ctx context.Context, err error, operation string) *domain.Error {
+	if err == nil {
+		return nil
+	}
+
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return &domain.Error{Type: domain.NotFound, Message: err.Error()}
+	}
+
+	logger.FromCtx(ctx, slog.Default()).ErrorContext(ctx, "database error",
+		slog.String("operation", operation),
+		slog.String("raw_error", err.Error()),
+	)
+	return &domain.Error{Type: domain.InternalServerError, Message: err.Error()}
+}
+
+// ToError is kept for callers that do not yet have a context available.
+// Prefer ToErrorCtx when ctx is available.
 func ToError(err error) *domain.Error {
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {

--- a/apps/api/data/mysql/budget_repo.go
+++ b/apps/api/data/mysql/budget_repo.go
@@ -16,43 +16,43 @@ func (repo Repository) GetBudgetList(ctx context.Context) ([]domain.Budget, *dom
 	db := GetDbFromCtx(ctx, repo.db)
 	var budgets []Budget
 	result := db.Table("budgets").Where("deleted_at is NULL").Find(&budgets)
-	return ToBudgetsListDomain(budgets), ToError(result.Error)
+	return ToBudgetsListDomain(budgets), ToErrorCtx(ctx, result.Error, "GetBudgetList")
 }
 
 func (repo Repository) GetBudgetById(ctx context.Context, id int64) (domain.Budget, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var budget Budget
 	result := db.Table("budgets").Where("id = ?", id).First(&budget)
-	return ToBudgetDomain(budget), ToError(result.Error)
+	return ToBudgetDomain(budget), ToErrorCtx(ctx, result.Error, "GetBudgetById")
 }
 
 func (repo Repository) CreateBudget(ctx context.Context, budget domain.Budget) (domain.Budget, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	budgetPayload := ToBudgetDB(budget)
 	if result := db.Table("budgets").Create(&budgetPayload); result.Error != nil {
-		return domain.Budget{}, ToError(result.Error)
+		return domain.Budget{}, ToErrorCtx(ctx, result.Error, "CreateBudget")
 	}
 
 	var createdBudget Budget
 	fetchResult := db.Table("budgets").Where("id = ?", budgetPayload.Id).First(&createdBudget)
-	return ToBudgetDomain(createdBudget), ToError(fetchResult.Error)
+	return ToBudgetDomain(createdBudget), ToErrorCtx(ctx, fetchResult.Error, "CreateBudget")
 }
 
 func (repo Repository) UpdateBudgetById(ctx context.Context, budget domain.Budget, id int64) (domain.Budget, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	budgetPayload := ToBudgetDB(budget)
 	if result := db.Table("budgets").Where("id = ?", id).Updates(&budgetPayload); result.Error != nil {
-		return domain.Budget{}, ToError(result.Error)
+		return domain.Budget{}, ToErrorCtx(ctx, result.Error, "UpdateBudgetById")
 	}
 
 	var updatedBudget Budget
 	fetchResult := db.Table("budgets").Where("id = ?", id).First(&updatedBudget)
-	return ToBudgetDomain(updatedBudget), ToError(fetchResult.Error)
+	return ToBudgetDomain(updatedBudget), ToErrorCtx(ctx, fetchResult.Error, "UpdateBudgetById")
 }
 
 func (repo Repository) DeleteBudgetById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("budgets").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteBudgetById")
 }

--- a/apps/api/data/mysql/calculation_repo.go
+++ b/apps/api/data/mysql/calculation_repo.go
@@ -28,14 +28,14 @@ func (repo Repository) GetCalculationList(ctx context.Context, sortBy domain.Sor
 
 	result = result.Find(&calculations)
 
-	return ToCalculationsListDomain(calculations), ToError(result.Error)
+	return ToCalculationsListDomain(calculations), ToErrorCtx(ctx, result.Error, "GetCalculationList")
 }
 
 func (repo Repository) GetCalculationById(ctx context.Context, id int64) (domain.Calculation, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var calculation Calculation
 	result := db.Table("calculations").Where("id = ?", id).Preload("CalculationItems").Preload("Wallet").First(&calculation)
-	return ToCalculationDomain(calculation), ToError(result.Error)
+	return ToCalculationDomain(calculation), ToErrorCtx(ctx, result.Error, "GetCalculationById")
 }
 
 func (repo Repository) CreateCalculation(ctx context.Context, calculation domain.Calculation) (domain.Calculation, *domain.Error) {
@@ -43,12 +43,12 @@ func (repo Repository) CreateCalculation(ctx context.Context, calculation domain
 	payload := ToCalculationDB(calculation)
 	result := db.Table("calculations").Create(&payload)
 	if result.Error != nil {
-		return domain.Calculation{}, ToError(result.Error)
+		return domain.Calculation{}, ToErrorCtx(ctx, result.Error, "CreateCalculation")
 	}
 
 	var created Calculation
 	fetchResult := db.Table("calculations").Where("id = ?", payload.Id).Preload("CalculationItems").Preload("Wallet").First(&created)
-	return ToCalculationDomain(created), ToError(fetchResult.Error)
+	return ToCalculationDomain(created), ToErrorCtx(ctx, fetchResult.Error, "CreateCalculation")
 }
 
 func (repo Repository) UpdateCalculationById(ctx context.Context, calculation domain.Calculation, id int64) (domain.Calculation, *domain.Error) {
@@ -59,7 +59,7 @@ func (repo Repository) UpdateCalculationById(ctx context.Context, calculation do
 	calculationPayload := ToCalculationDB(calculation)
 	result := db.Session(&gorm.Session{FullSaveAssociations: true}).Table("calculations").Where("id = ?", id).Updates(&calculationPayload)
 	if result.Error != nil {
-		return domain.Calculation{}, ToError(result.Error)
+		return domain.Calculation{}, ToErrorCtx(ctx, result.Error, "UpdateCalculationById")
 	}
 
 	// Determine which existing item IDs to keep (those that are present in the incoming payload)
@@ -73,31 +73,31 @@ func (repo Repository) UpdateCalculationById(ctx context.Context, calculation do
 	if len(idsToKeep) > 0 {
 		// delete items that were present before but are not in the incoming idsToKeep
 		if err := db.Table("calculation_items").Where("calculation_id = ? AND id NOT IN ?", id, idsToKeep).Delete(&CalculationItem{}).Error; err != nil {
-			return domain.Calculation{}, ToError(err)
+			return domain.Calculation{}, ToErrorCtx(ctx, err, "UpdateCalculationById")
 		}
 	} else {
 		// If incoming payload has no existing IDs, remove all previously existing items
 		if err := db.Table("calculation_items").Where("calculation_id = ?", id).Delete(&CalculationItem{}).Error; err != nil {
-			return domain.Calculation{}, ToError(err)
+			return domain.Calculation{}, ToErrorCtx(ctx, err, "UpdateCalculationById")
 		}
 	}
 
 	// fetch updated record to return complete domain object with all associations
 	var updated Calculation
 	fetchResult := db.Table("calculations").Where("id = ?", id).Preload("CalculationItems").Preload("Wallet").First(&updated)
-	return ToCalculationDomain(updated), ToError(fetchResult.Error)
+	return ToCalculationDomain(updated), ToErrorCtx(ctx, fetchResult.Error, "UpdateCalculationById")
 }
 
 func (repo Repository) DeleteCalculationById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("calculations").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteCalculationById")
 }
 
 func (repo Repository) CompleteCalculationById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("calculations").Where("id = ?", id).Update("completed_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "CompleteCalculationById")
 }

--- a/apps/api/data/mysql/category_repo.go
+++ b/apps/api/data/mysql/category_repo.go
@@ -16,38 +16,38 @@ func (repo Repository) GetCategoryList(ctx context.Context) ([]domain.Category, 
 	db := GetDbFromCtx(ctx, repo.db)
 	var categories []Category
 	result := db.Table("categories").Where("deleted_at", nil).Find(&categories)
-	return ToCategoryListDomain(categories), ToError(result.Error)
+	return ToCategoryListDomain(categories), ToErrorCtx(ctx, result.Error, "GetCategoryList")
 }
 
 func (repo Repository) GetCategoryById(ctx context.Context, id int64) (domain.Category, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var category Category
 	result := db.Table("categories").Where("id = ?", id).First(&category)
-	return ToCategoryDomain(category), ToError(result.Error)
+	return ToCategoryDomain(category), ToErrorCtx(ctx, result.Error, "GetCategoryById")
 }
 
 func (repo Repository) CreateCategory(ctx context.Context, category domain.Category) (domain.Category, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	categoryPayload := ToCategoryDB(category)
 	result := db.Table("categories").Create(&categoryPayload)
-	return ToCategoryDomain(categoryPayload), ToError(result.Error)
+	return ToCategoryDomain(categoryPayload), ToErrorCtx(ctx, result.Error, "CreateCategory")
 }
 
 func (repo Repository) UpdateCategoryById(ctx context.Context, category domain.Category, id int64) (domain.Category, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	categoryPayload := ToCategoryDB(category)
 	if result := db.Table("categories").Where("id = ?", id).Updates(&categoryPayload); result.Error != nil {
-		return domain.Category{}, ToError(result.Error)
+		return domain.Category{}, ToErrorCtx(ctx, result.Error, "UpdateCategoryById")
 	}
 
 	var updatedCategory Category
 	fetchResult := db.Table("categories").Where("id = ?", id).First(&updatedCategory)
-	return ToCategoryDomain(updatedCategory), ToError(fetchResult.Error)
+	return ToCategoryDomain(updatedCategory), ToErrorCtx(ctx, fetchResult.Error, "UpdateCategoryById")
 }
 
 func (repo Repository) DeleteCategoryById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("categories").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteCategoryById")
 }

--- a/apps/api/data/mysql/coupon_repo.go
+++ b/apps/api/data/mysql/coupon_repo.go
@@ -16,38 +16,38 @@ func (repo Repository) GetCouponList(ctx context.Context) ([]domain.Coupon, *dom
 	db := GetDbFromCtx(ctx, repo.db)
 	var coupons []Coupon
 	result := db.Table("coupons").Where("deleted_at", nil).Find(&coupons)
-	return ToCouponListDomain(coupons), ToError(result.Error)
+	return ToCouponListDomain(coupons), ToErrorCtx(ctx, result.Error, "GetCouponList")
 }
 
 func (repo Repository) GetCouponById(ctx context.Context, id int64) (domain.Coupon, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var coupon Coupon
 	result := db.Table("coupons").Where("id = ?", id).First(&coupon)
-	return ToCouponDomain(coupon), ToError(result.Error)
+	return ToCouponDomain(coupon), ToErrorCtx(ctx, result.Error, "GetCouponById")
 }
 
 func (repo Repository) CreateCoupon(ctx context.Context, coupon domain.Coupon) (domain.Coupon, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	couponPayload := ToCouponDB(coupon)
 	result := db.Table("coupons").Create(&couponPayload)
-	return ToCouponDomain(couponPayload), ToError(result.Error)
+	return ToCouponDomain(couponPayload), ToErrorCtx(ctx, result.Error, "CreateCoupon")
 }
 
 func (repo Repository) UpdateCouponById(ctx context.Context, coupon domain.Coupon, id int64) (domain.Coupon, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	couponPayload := ToCouponDB(coupon)
 	if result := db.Table("coupons").Where("id = ?", id).Updates(&couponPayload); result.Error != nil {
-		return domain.Coupon{}, ToError(result.Error)
+		return domain.Coupon{}, ToErrorCtx(ctx, result.Error, "UpdateCouponById")
 	}
 
 	var updatedCoupon Coupon
 	fetchResult := db.Table("coupons").Where("id = ?", id).First(&updatedCoupon)
-	return ToCouponDomain(updatedCoupon), ToError(fetchResult.Error)
+	return ToCouponDomain(updatedCoupon), ToErrorCtx(ctx, fetchResult.Error, "UpdateCouponById")
 }
 
 func (repo Repository) DeleteCouponById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("coupons").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteCouponById")
 }

--- a/apps/api/data/mysql/expense_repo.go
+++ b/apps/api/data/mysql/expense_repo.go
@@ -40,7 +40,7 @@ func (repo Repository) GetExpenseList(ctx context.Context, query string, sortBy 
 
 	result = result.Find(&expenses)
 
-	return ToExpensesListDomain(expenses), ToError(result.Error)
+	return ToExpensesListDomain(expenses), ToErrorCtx(ctx, result.Error, "GetExpenseList")
 }
 
 func (repo Repository) GetExpenseListTotal(ctx context.Context, query string, walletId *int, budgetId *int) (int64, *domain.Error) {
@@ -61,26 +61,26 @@ func (repo Repository) GetExpenseListTotal(ctx context.Context, query string, wa
 
 	result = result.Count(&count)
 
-	return count, ToError(result.Error)
+	return count, ToErrorCtx(ctx, result.Error, "GetExpenseListTotal")
 }
 
 func (repo Repository) GetExpenseById(ctx context.Context, id int64) (domain.Expense, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var expense Expense
 	result := db.Table("expenses").Where("id = ?", id).Preload("ExpenseItems").Preload("Wallet").Preload("Budget").First(&expense)
-	return ToExpenseDomain(expense), ToError(result.Error)
+	return ToExpenseDomain(expense), ToErrorCtx(ctx, result.Error, "GetExpenseById")
 }
 
 func (repo Repository) CreateExpense(ctx context.Context, expense domain.Expense) (domain.Expense, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	payload := ToExpenseDB(expense)
 	if result := db.Table("expenses").Create(&payload); result.Error != nil {
-		return domain.Expense{}, ToError(result.Error)
+		return domain.Expense{}, ToErrorCtx(ctx, result.Error, "CreateExpense")
 	}
 
 	var created Expense
 	fetchResult := db.Table("expenses").Where("id = ?", payload.Id).Preload("ExpenseItems").Preload("Wallet").Preload("Budget").First(&created)
-	return ToExpenseDomain(created), ToError(fetchResult.Error)
+	return ToExpenseDomain(created), ToErrorCtx(ctx, fetchResult.Error, "CreateExpense")
 }
 
 func (repo Repository) UpdateExpenseById(ctx context.Context, expense domain.Expense, id int64) (domain.Expense, *domain.Error) {
@@ -90,7 +90,7 @@ func (repo Repository) UpdateExpenseById(ctx context.Context, expense domain.Exp
 	// Perform update with full save associations to insert/update items automatically
 	expensePayload := ToExpenseDB(expense)
 	if result := db.Session(&gorm.Session{FullSaveAssociations: true}).Table("expenses").Where("id = ?", id).Updates(&expensePayload); result.Error != nil {
-		return domain.Expense{}, ToError(result.Error)
+		return domain.Expense{}, ToErrorCtx(ctx, result.Error, "UpdateExpenseById")
 	}
 
 	// Determine which existing item IDs to keep (those that are present in the incoming payload)
@@ -104,24 +104,24 @@ func (repo Repository) UpdateExpenseById(ctx context.Context, expense domain.Exp
 	if len(idsToKeep) > 0 {
 		// delete items that were present before but are not in the incoming idsToKeep
 		if result := db.Table("expense_items").Where("expense_id = ? AND id NOT IN ?", id, idsToKeep).Delete(&ExpenseItem{}); result.Error != nil {
-			return domain.Expense{}, ToError(result.Error)
+			return domain.Expense{}, ToErrorCtx(ctx, result.Error, "UpdateExpenseById")
 		}
 	} else {
 		// If incoming payload has no existing IDs, remove all previously existing items
 		if result := db.Table("expense_items").Where("expense_id = ?", id).Delete(&ExpenseItem{}); result.Error != nil {
-			return domain.Expense{}, ToError(result.Error)
+			return domain.Expense{}, ToErrorCtx(ctx, result.Error, "UpdateExpenseById")
 		}
 	}
 
 	// Fetch updated record to return complete domain object with all associations
 	var updated Expense
 	fetchResult := db.Table("expenses").Where("id = ?", id).Preload("ExpenseItems").Preload("Wallet").Preload("Budget").First(&updated)
-	return ToExpenseDomain(updated), ToError(fetchResult.Error)
+	return ToExpenseDomain(updated), ToErrorCtx(ctx, fetchResult.Error, "UpdateExpenseById")
 }
 
 func (repo Repository) DeleteExpenseById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Clauses(clause.OnConflict{UpdateAll: true}).Table("expenses").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteExpenseById")
 }

--- a/apps/api/data/mysql/material_repo.go
+++ b/apps/api/data/mysql/material_repo.go
@@ -32,7 +32,7 @@ func (repo Repository) GetMaterialList(ctx context.Context, query string, sortBy
 
 	result = result.Find(&materials)
 
-	return ToMaterialListDomain(materials), ToError(result.Error)
+	return ToMaterialListDomain(materials), ToErrorCtx(ctx, result.Error, "GetMaterialList")
 }
 
 func (repo Repository) GetMaterialListTotal(ctx context.Context, query string) (int64, *domain.Error) {
@@ -46,7 +46,7 @@ func (repo Repository) GetMaterialListTotal(ctx context.Context, query string) (
 
 	result = result.Count(&count)
 
-	return count, ToError(result.Error)
+	return count, ToErrorCtx(ctx, result.Error, "GetMaterialListTotal")
 }
 
 func (repo Repository) GetMaterialsWeeklyUsage(ctx context.Context, ids []int64) (map[int64]float32, *domain.Error) {
@@ -72,7 +72,7 @@ func (repo Repository) GetMaterialsWeeklyUsage(ctx context.Context, ids []int64)
 		Scan(&results).Error
 
 	if err != nil {
-		return nil, ToError(err)
+		return nil, ToErrorCtx(ctx, err, "GetMaterialsWeeklyUsage")
 	}
 
 	usageMap := make(map[int64]float32)
@@ -87,7 +87,7 @@ func (repo Repository) GetMaterialById(ctx context.Context, id int64) (domain.Ma
 	db := GetDbFromCtx(ctx, repo.db)
 	var material Material
 	result := db.Table("materials").Where("id = ?", id).Where("deleted_at", nil).First(&material)
-	return ToMaterialDomain(material), ToError(result.Error)
+	return ToMaterialDomain(material), ToErrorCtx(ctx, result.Error, "GetMaterialById")
 }
 
 func (repo Repository) CreateMaterial(ctx context.Context, material domain.Material) (domain.Material, *domain.Error) {
@@ -96,7 +96,7 @@ func (repo Repository) CreateMaterial(ctx context.Context, material domain.Mater
 	result := db.Table("materials").Create(&materialPayload)
 
 	if result.Error != nil {
-		return domain.Material{}, ToError(result.Error)
+		return domain.Material{}, ToErrorCtx(ctx, result.Error, "CreateMaterial")
 	}
 
 	return ToMaterialDomain(materialPayload), nil
@@ -106,18 +106,18 @@ func (repo Repository) UpdateMaterialById(ctx context.Context, material domain.M
 	db := GetDbFromCtx(ctx, repo.db)
 	materialPayload := ToMaterialDB(material)
 	if result := db.Table("materials").Where("id = ?", id).Updates(&materialPayload); result.Error != nil {
-		return domain.Material{}, ToError(result.Error)
+		return domain.Material{}, ToErrorCtx(ctx, result.Error, "UpdateMaterialById")
 	}
 
 	// Fetch the updated material to get all fields including timestamps
 	var updatedMaterial Material
 	fetchResult := db.Table("materials").Where("id = ?", id).First(&updatedMaterial)
-	return ToMaterialDomain(updatedMaterial), ToError(fetchResult.Error)
+	return ToMaterialDomain(updatedMaterial), ToErrorCtx(ctx, fetchResult.Error, "UpdateMaterialById")
 }
 
 func (repo Repository) DeleteMaterialById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("materials").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteMaterialById")
 }

--- a/apps/api/data/mysql/product_repo.go
+++ b/apps/api/data/mysql/product_repo.go
@@ -42,7 +42,7 @@ func (repo Repository) GetProductList(ctx context.Context, query string, sortBy 
 
 	result = result.Find(&products)
 
-	return ToProductListDomain(products), ToError(result.Error)
+	return ToProductListDomain(products), ToErrorCtx(ctx, result.Error, "GetProductList")
 }
 
 func (repo Repository) GetProductListTotal(ctx context.Context, query string, saleType *domain.SaleType) (int64, *domain.Error) {
@@ -65,27 +65,27 @@ func (repo Repository) GetProductListTotal(ctx context.Context, query string, sa
 
 	result = result.Count(&count)
 
-	return count, ToError(result.Error)
+	return count, ToErrorCtx(ctx, result.Error, "GetProductListTotal")
 }
 
 func (repo Repository) GetProductById(ctx context.Context, id int64) (domain.Product, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var product Product
 	result := db.Table("products").Preload("Category").Preload("Options").Preload("Options.Values").Where("id = ?", id).First(&product)
-	return ToProductDomain(product), ToError(result.Error)
+	return ToProductDomain(product), ToErrorCtx(ctx, result.Error, "GetProductById")
 }
 
 func (repo Repository) CreateProduct(ctx context.Context, product domain.Product) (domain.Product, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	payload := ToProductDB(product)
 	if result := db.Table("products").Create(&payload); result.Error != nil {
-		return domain.Product{}, ToError(result.Error)
+		return domain.Product{}, ToErrorCtx(ctx, result.Error, "CreateProduct")
 	}
 
 	// Fetch the created product with all relations
 	var createdProduct Product
 	fetchResult := db.Table("products").Preload("Category").Preload("Options").Preload("Options.Values").Where("id = ?", payload.Id).First(&createdProduct)
-	return ToProductDomain(createdProduct), ToError(fetchResult.Error)
+	return ToProductDomain(createdProduct), ToErrorCtx(ctx, fetchResult.Error, "CreateProduct")
 }
 
 func (repo Repository) UpdateProductById(ctx context.Context, product domain.Product, id int64) (domain.Product, *domain.Error) {
@@ -95,7 +95,7 @@ func (repo Repository) UpdateProductById(ctx context.Context, product domain.Pro
 	// update product
 	productPayload := ToProductDB(product)
 	if result := db.Session(&gorm.Session{FullSaveAssociations: true}).Table("products").Where("id = ?", id).Updates(&productPayload); result.Error != nil {
-		return domain.Product{}, ToError(result.Error)
+		return domain.Product{}, ToErrorCtx(ctx, result.Error, "UpdateProductById")
 	}
 
 	// Collect IDs of options and option values that should be kept (those that are present in the incoming payload)
@@ -115,44 +115,45 @@ func (repo Repository) UpdateProductById(ctx context.Context, product domain.Pro
 	if len(optionIdsToKeep) > 0 {
 		// delete items that were present before but are not in the incoming idsToKeep
 		if err := db.Table("options").Where("product_id = ? AND id NOT IN ?", id, optionIdsToKeep).Delete(&Option{}).Error; err != nil {
-			return domain.Product{}, ToError(err)
+			return domain.Product{}, ToErrorCtx(ctx, err, "UpdateProductById")
 		}
 	} else {
 		// If incoming payload has no existing IDs, remove all previously existing items
 		if err := db.Table("options").Where("product_id = ?", id).Delete(&Option{}).Error; err != nil {
-			return domain.Product{}, ToError(err)
+			return domain.Product{}, ToErrorCtx(ctx, err, "UpdateProductById")
 		}
 	}
 
 	if len(optionValueIdsToKeep) > 0 {
 		// delete items that were present before but are not in the incoming idsToKeep
 		if err := db.Table("option_values").Where("option_id IN (SELECT id FROM options WHERE product_id = ?) AND id NOT IN ?", id, optionValueIdsToKeep).Delete(&OptionValue{}).Error; err != nil {
-			return domain.Product{}, ToError(err)
+			return domain.Product{}, ToErrorCtx(ctx, err, "UpdateProductById")
 		}
 	} else {
 		// If incoming payload has no existing IDs, remove all previously existing items
 		if err := db.Table("option_values").Where("option_id IN (SELECT id FROM options WHERE product_id = ?)", id).Delete(&OptionValue{}).Error; err != nil {
-			return domain.Product{}, ToError(err)
+			return domain.Product{}, ToErrorCtx(ctx, err, "UpdateProductById")
 		}
 	}
 
 	// Fetch the updated product with all relations
 	var updatedProduct Product
 	fetchResult := db.Table("products").Preload("Category").Preload("Options").Preload("Options.Values").Where("id = ?", id).First(&updatedProduct)
-	return ToProductDomain(updatedProduct), ToError(fetchResult.Error)
+	return ToProductDomain(updatedProduct), ToErrorCtx(ctx, fetchResult.Error, "UpdateProductById")
 }
 
 func (repo Repository) DeleteProductById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("products").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteProductById")
 }
 
 func (repo Repository) DeleteUnusedOptions(ctx context.Context, productId int64, idsToKeep []int64) *domain.Error {
 	if len(idsToKeep) > 0 {
 		db := GetDbFromCtx(ctx, repo.db)
-		return ToError(db.Where("product_id = ? AND id NOT IN ?", productId, idsToKeep).Delete(&domain.Option{}).Error)
+		err := db.Where("product_id = ? AND id NOT IN ?", productId, idsToKeep).Delete(&domain.Option{}).Error
+		return ToErrorCtx(ctx, err, "DeleteUnusedOptions")
 	} else {
 		return nil
 	}
@@ -161,7 +162,8 @@ func (repo Repository) DeleteUnusedOptions(ctx context.Context, productId int64,
 func (repo Repository) DeleteUnusedOptionValues(ctx context.Context, optionId int64, idsToKeep []int64) *domain.Error {
 	if len(idsToKeep) > 0 {
 		db := GetDbFromCtx(ctx, repo.db)
-		return ToError(db.Where("option_id = ? AND id NOT IN ?", optionId, idsToKeep).Delete(&domain.OptionValue{}).Error)
+		err := db.Where("option_id = ? AND id NOT IN ?", optionId, idsToKeep).Delete(&domain.OptionValue{}).Error
+		return ToErrorCtx(ctx, err, "DeleteUnusedOptionValues")
 	} else {
 		return nil
 	}

--- a/apps/api/data/mysql/rental_repo.go
+++ b/apps/api/data/mysql/rental_repo.go
@@ -40,7 +40,7 @@ func (repo Repository) GetRentalList(ctx context.Context, query string, sortBy d
 
 	result = result.Find(&transactionResults)
 
-	return ToRentalListDomain(transactionResults), ToError(result.Error)
+	return ToRentalListDomain(transactionResults), ToErrorCtx(ctx, result.Error, "GetRentalList")
 }
 
 func (repo Repository) GetRentalListTotal(ctx context.Context, query string, checkoutStatus domain.CheckoutStatus) (int64, *domain.Error) {
@@ -61,7 +61,7 @@ func (repo Repository) GetRentalListTotal(ctx context.Context, query string, che
 
 	result = result.Count(&count)
 
-	return count, ToError(result.Error)
+	return count, ToErrorCtx(ctx, result.Error, "GetRentalListTotal")
 }
 
 func (repo Repository) GetRentalById(ctx context.Context, id int64) (domain.Rental, *domain.Error) {
@@ -69,7 +69,7 @@ func (repo Repository) GetRentalById(ctx context.Context, id int64) (domain.Rent
 
 	var rental Rental
 	result := db.Table("rentals").Where("id = ?", id).Preload("Variant").Preload("Variant.Materials").Preload("Variant.Materials.Material").Preload("Variant.VariantValues").Preload("Variant.VariantValues.OptionValue").Preload("Variant.Product").First(&rental)
-	return ToRentalDomain(rental), ToError(result.Error)
+	return ToRentalDomain(rental), ToErrorCtx(ctx, result.Error, "GetRentalById")
 }
 
 func (repo Repository) CheckinRentals(ctx context.Context, rentals []domain.Rental) ([]domain.Rental, *domain.Error) {
@@ -77,7 +77,7 @@ func (repo Repository) CheckinRentals(ctx context.Context, rentals []domain.Rent
 
 	dbRentals := ToRentalListDB(rentals)
 	if result := db.Table("rentals").Create(&dbRentals); result.Error != nil {
-		return []domain.Rental{}, ToError(result.Error)
+		return []domain.Rental{}, ToErrorCtx(ctx, result.Error, "CheckinRentals")
 	}
 
 	var ids []int64
@@ -87,18 +87,18 @@ func (repo Repository) CheckinRentals(ctx context.Context, rentals []domain.Rent
 
 	var created []Rental
 	fetch := db.Table("rentals").Where("id IN ?", ids).Preload("Variant").Preload("Variant.Materials").Preload("Variant.Materials.Material").Preload("Variant.VariantValues").Preload("Variant.VariantValues.OptionValue").Preload("Variant.Product").Find(&created)
-	return ToRentalListDomain(created), ToError(fetch.Error)
+	return ToRentalListDomain(created), ToErrorCtx(ctx, fetch.Error, "CheckinRentals")
 }
 
 func (repo Repository) CheckoutRental(ctx context.Context, rentalId int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	result := db.Table("rentals").Where("id = ?", rentalId).Update("checkout_at", time.Now())
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "CheckoutRental")
 }
 
 func (repo Repository) DeleteRentalById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("rentals").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteRentalById")
 }

--- a/apps/api/data/mysql/supplier_repo.go
+++ b/apps/api/data/mysql/supplier_repo.go
@@ -32,7 +32,7 @@ func (repo Repository) GetSupplierList(ctx context.Context, query string, sortBy
 
 	result = result.Find(&suppliers)
 
-	return ToSupplierListDomain(suppliers), ToError(result.Error)
+	return ToSupplierListDomain(suppliers), ToErrorCtx(ctx, result.Error, "GetSupplierList")
 }
 
 func (repo Repository) GetSupplierListTotal(ctx context.Context, query string) (int64, *domain.Error) {
@@ -46,38 +46,38 @@ func (repo Repository) GetSupplierListTotal(ctx context.Context, query string) (
 
 	result = result.Count(&count)
 
-	return count, ToError(result.Error)
+	return count, ToErrorCtx(ctx, result.Error, "GetSupplierListTotal")
 }
 
 func (repo Repository) GetSupplierById(ctx context.Context, id int64) (domain.Supplier, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var supplier Supplier
 	result := db.Table("suppliers").Where("id = ?", id).Where("deleted_at", nil).First(&supplier)
-	return ToSupplierDomain(supplier), ToError(result.Error)
+	return ToSupplierDomain(supplier), ToErrorCtx(ctx, result.Error, "GetSupplierById")
 }
 
 func (repo Repository) CreateSupplier(ctx context.Context, supplier domain.Supplier) (domain.Supplier, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	supplierPayload := ToSupplierDB(supplier)
 	result := db.Table("suppliers").Create(&supplierPayload)
-	return ToSupplierDomain(supplierPayload), ToError(result.Error)
+	return ToSupplierDomain(supplierPayload), ToErrorCtx(ctx, result.Error, "CreateSupplier")
 }
 
 func (repo Repository) UpdateSupplierById(ctx context.Context, supplier domain.Supplier, id int64) (domain.Supplier, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	supplierPayload := ToSupplierDB(supplier)
 	if result := db.Table("suppliers").Where("id = ?", id).Updates(&supplierPayload); result.Error != nil {
-		return domain.Supplier{}, ToError(result.Error)
+		return domain.Supplier{}, ToErrorCtx(ctx, result.Error, "UpdateSupplierById")
 	}
 
 	var updatedSupplier Supplier
 	result := db.Table("suppliers").Where("id = ?", id).First(&updatedSupplier)
-	return ToSupplierDomain(updatedSupplier), ToError(result.Error)
+	return ToSupplierDomain(updatedSupplier), ToErrorCtx(ctx, result.Error, "UpdateSupplierById")
 }
 
 func (repo Repository) DeleteSupplierById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("suppliers").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteSupplierById")
 }

--- a/apps/api/data/mysql/transaction_repo.go
+++ b/apps/api/data/mysql/transaction_repo.go
@@ -44,7 +44,7 @@ func (repo Repository) GetTransactionList(ctx context.Context, query string, sor
 
 	result = result.Find(&transactionResults)
 
-	return ToTransactionsListDomain(transactionResults), ToError(result.Error)
+	return ToTransactionsListDomain(transactionResults), ToErrorCtx(ctx, result.Error, "GetTransactionList")
 }
 
 func (repo Repository) GetTransactionListTotal(ctx context.Context, query string, paymentStatus domain.PaymentStatus, walletId *int) (int64, *domain.Error) {
@@ -69,7 +69,7 @@ func (repo Repository) GetTransactionListTotal(ctx context.Context, query string
 
 	result = result.Count(&count)
 
-	return count, ToError(result.Error)
+	return count, ToErrorCtx(ctx, result.Error, "GetTransactionListTotal")
 }
 
 func (repo Repository) GetTransactionById(ctx context.Context, id int64) (domain.Transaction, *domain.Error) {
@@ -77,7 +77,7 @@ func (repo Repository) GetTransactionById(ctx context.Context, id int64) (domain
 
 	var transaction Transaction
 	result := db.Table("transactions").Where("id = ?", id).Preload("TransactionItems").Preload("Wallet").Preload("TransactionItems.Variant").Preload("TransactionItems.Variant.Materials").Preload("TransactionItems.Variant.Materials.Material").Preload("TransactionItems.Variant.VariantValues").Preload("TransactionItems.Variant.VariantValues.OptionValue").Preload("TransactionItems.Variant.Product").Preload("TransactionCoupons").Preload("TransactionCoupons.Coupon").First(&transaction)
-	return ToTransactionDomain(transaction), ToError(result.Error)
+	return ToTransactionDomain(transaction), ToErrorCtx(ctx, result.Error, "GetTransactionById")
 }
 
 func (repo Repository) CreateTransaction(ctx context.Context, transaction domain.Transaction) (domain.Transaction, *domain.Error) {
@@ -85,12 +85,12 @@ func (repo Repository) CreateTransaction(ctx context.Context, transaction domain
 
 	dbTransaction := ToTransactionDB(transaction)
 	if result := db.Table("transactions").Create(&dbTransaction); result.Error != nil {
-		return domain.Transaction{}, ToError(result.Error)
+		return domain.Transaction{}, ToErrorCtx(ctx, result.Error, "CreateTransaction")
 	}
 
 	var created Transaction
 	fetch := db.Table("transactions").Where("id = ?", dbTransaction.Id).Preload("TransactionItems").Preload("TransactionItems.Variant").Preload("TransactionItems.Variant.VariantValues").Preload("TransactionItems.Variant.VariantValues.OptionValue").Preload("TransactionItems.Variant.Product").Preload("TransactionCoupons").Preload("TransactionCoupons.Coupon").Preload("Wallet").First(&created)
-	return ToTransactionDomain(created), ToError(fetch.Error)
+	return ToTransactionDomain(created), ToErrorCtx(ctx, fetch.Error, "CreateTransaction")
 }
 
 func (repo Repository) UpdateTransactionById(ctx context.Context, transaction domain.Transaction, id int64) (domain.Transaction, *domain.Error) {
@@ -99,7 +99,7 @@ func (repo Repository) UpdateTransactionById(ctx context.Context, transaction do
 
 	dbTransaction := ToTransactionDB(transaction)
 	if result := db.Session(&gorm.Session{FullSaveAssociations: true}).Table("transactions").Where("id = ?", id).Updates(&dbTransaction); result.Error != nil {
-		return domain.Transaction{}, ToError(result.Error)
+		return domain.Transaction{}, ToErrorCtx(ctx, result.Error, "UpdateTransactionById")
 	}
 
 	if dbTransaction.TransactionItems != nil {
@@ -114,12 +114,12 @@ func (repo Repository) UpdateTransactionById(ctx context.Context, transaction do
 		if len(transactionItemIdsToKeep) > 0 {
 			// delete items that were present before but are not in the incoming idsToKeep
 			if result := db.Table("transaction_items").Where("transaction_id = ? AND id NOT IN ?", id, transactionItemIdsToKeep).Delete(&TransactionItem{}); result.Error != nil {
-				return domain.Transaction{}, ToError(result.Error)
+				return domain.Transaction{}, ToErrorCtx(ctx, result.Error, "UpdateTransactionById")
 			}
 		} else {
 			// If incoming payload has no existing IDs, remove all previously existing items
 			if result := db.Table("transaction_items").Where("transaction_id = ?", id).Delete(&TransactionItem{}); result.Error != nil {
-				return domain.Transaction{}, ToError(result.Error)
+				return domain.Transaction{}, ToErrorCtx(ctx, result.Error, "UpdateTransactionById")
 			}
 		}
 	}
@@ -136,32 +136,32 @@ func (repo Repository) UpdateTransactionById(ctx context.Context, transaction do
 		if len(transactionCouponIdsToKeep) > 0 {
 			// delete coupons that were present before but are not in the incoming idsToKeep
 			if result := db.Table("transaction_coupons").Where("transaction_id = ? AND id NOT IN ?", id, transactionCouponIdsToKeep).Delete(&TransactionCoupon{}); result.Error != nil {
-				return domain.Transaction{}, ToError(result.Error)
+				return domain.Transaction{}, ToErrorCtx(ctx, result.Error, "UpdateTransactionById")
 			}
 		} else {
 			// If incoming payload has no existing IDs, remove all previously existing items
 			if result := db.Table("transaction_coupons").Where("transaction_id = ?", id).Delete(&TransactionCoupon{}); result.Error != nil {
-				return domain.Transaction{}, ToError(result.Error)
+				return domain.Transaction{}, ToErrorCtx(ctx, result.Error, "UpdateTransactionById")
 			}
 		}
 	}
 
 	var updated Transaction
 	fetch := db.Table("transactions").Where("id = ?", id).Preload("TransactionItems").Preload("TransactionItems.Variant").Preload("TransactionItems.Variant.Materials").Preload("TransactionItems.Variant.Materials.Material").Preload("TransactionItems.Variant.VariantValues").Preload("TransactionItems.Variant.VariantValues.OptionValue").Preload("TransactionItems.Variant.Product").Preload("TransactionCoupons").Preload("TransactionCoupons.Coupon").Preload("Wallet").First(&updated)
-	return ToTransactionDomain(updated), ToError(fetch.Error)
+	return ToTransactionDomain(updated), ToErrorCtx(ctx, fetch.Error, "UpdateTransactionById")
 }
 
 func (repo Repository) DeleteTransactionById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("transactions").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteTransactionById")
 }
 
 func (repo Repository) PayTransaction(ctx context.Context, walletId int64, paidAt time.Time, paidAmount float32, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	result := db.Table("transactions").Where("id = ?", id).Updates(Transaction{WalletId: &walletId, PaidAt: &paidAt, PaidAmount: paidAmount})
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "PayTransaction")
 }
 
 func (repo Repository) UnpayTransaction(ctx context.Context, id int64) *domain.Error {
@@ -172,7 +172,7 @@ func (repo Repository) UnpayTransaction(ctx context.Context, id int64) *domain.E
 		"paid_at":      nil,
 		"paid_amount":  0,
 	})
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "UnpayTransaction")
 }
 
 func (repo Repository) GetTransactionStatistics(ctx context.Context, groupBy string) ([]domain.TransactionStatistic, *domain.Error) {
@@ -189,5 +189,5 @@ func (repo Repository) GetTransactionStatistics(ctx context.Context, groupBy str
 	var transactionStatistics []TransactionStatistic
 	result := db.Table("transactions").Select(fmt.Sprintf("DATE_FORMAT(created_at, '%s') as date, SUM(total) as total, SUM(total_income) as total_income", dateFormat)).Where("deleted_at is NULL").Group(fmt.Sprintf("DATE_FORMAT(created_at, '%s')", dateFormat)).Find(&transactionStatistics)
 
-	return ToTransactionStatisticsListDomain(transactionStatistics), ToError(result.Error)
+	return ToTransactionStatisticsListDomain(transactionStatistics), ToErrorCtx(ctx, result.Error, "GetTransactionStatistics")
 }

--- a/apps/api/data/mysql/variant_repo.go
+++ b/apps/api/data/mysql/variant_repo.go
@@ -41,7 +41,7 @@ func (repo Repository) GetVariantList(ctx context.Context, query string, sortBy 
 
 	result = result.Find(&variants)
 
-	return ToVariantsListDomain(variants), ToError(result.Error)
+	return ToVariantsListDomain(variants), ToErrorCtx(ctx, result.Error, "GetVariantList")
 }
 
 func (repo Repository) GetVariantListTotal(ctx context.Context, query string) (int64, *domain.Error) {
@@ -55,27 +55,27 @@ func (repo Repository) GetVariantListTotal(ctx context.Context, query string) (i
 
 	result = result.Count(&count)
 
-	return count, ToError(result.Error)
+	return count, ToErrorCtx(ctx, result.Error, "GetVariantListTotal")
 }
 
 func (repo Repository) GetVariantById(ctx context.Context, id int64) (domain.Variant, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var variant Variant
 	result := db.Table("variants").Preload("Product").Preload("Product.Category").Preload("Materials").Preload("Materials.Material").Preload("VariantValues").Preload("VariantValues.OptionValue").Where("id = ?", id).First(&variant)
-	return ToVariantDomain(variant), ToError(result.Error)
+	return ToVariantDomain(variant), ToErrorCtx(ctx, result.Error, "GetVariantById")
 }
 
 func (repo Repository) CreateVariant(ctx context.Context, variant domain.Variant) (domain.Variant, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	payload := ToVariantDB(variant)
 	if result := db.Table("variants").Create(&payload); result.Error != nil {
-		return domain.Variant{}, ToError(result.Error)
+		return domain.Variant{}, ToErrorCtx(ctx, result.Error, "CreateVariant")
 	}
 
 	// Fetch the created variant with all relations
 	var createdVariant Variant
 	fetchResult := db.Table("variants").Preload("Product").Preload("Product.Category").Preload("Materials").Preload("Materials.Material").Preload("VariantValues").Preload("VariantValues.OptionValue").Where("id = ?", payload.Id).First(&createdVariant)
-	return ToVariantDomain(createdVariant), ToError(fetchResult.Error)
+	return ToVariantDomain(createdVariant), ToErrorCtx(ctx, fetchResult.Error, "CreateVariant")
 }
 
 func (repo Repository) UpdateVariantById(ctx context.Context, variant domain.Variant, id int64) (domain.Variant, *domain.Error) {
@@ -85,7 +85,7 @@ func (repo Repository) UpdateVariantById(ctx context.Context, variant domain.Var
 	// Update the variant and its associations using FullSaveAssociations to ensure all related records are updated
 	variantPayload := ToVariantDB(variant)
 	if result := db.Session(&gorm.Session{FullSaveAssociations: true}).Table("variants").Where("id = ?", id).Updates(&variantPayload); result.Error != nil {
-		return domain.Variant{}, ToError(result.Error)
+		return domain.Variant{}, ToErrorCtx(ctx, result.Error, "UpdateVariantById")
 	}
 
 	// Handle deletion of removed materials
@@ -95,11 +95,11 @@ func (repo Repository) UpdateVariantById(ctx context.Context, variant domain.Var
 	}
 	if len(variantMaterialIdsToKeep) > 0 {
 		if result := db.Table("variant_materials").Where("variant_id = ? AND id NOT IN ?", id, variantMaterialIdsToKeep).Delete(&VariantMaterial{}); result.Error != nil {
-			return domain.Variant{}, ToError(result.Error)
+			return domain.Variant{}, ToErrorCtx(ctx, result.Error, "UpdateVariantById")
 		}
 	} else {
 		if result := db.Table("variant_materials").Where("variant_id = ?", id).Delete(&VariantMaterial{}); result.Error != nil {
-			return domain.Variant{}, ToError(result.Error)
+			return domain.Variant{}, ToErrorCtx(ctx, result.Error, "UpdateVariantById")
 		}
 	}
 
@@ -110,23 +110,23 @@ func (repo Repository) UpdateVariantById(ctx context.Context, variant domain.Var
 	}
 	if len(variantValueIdsToKeep) > 0 {
 		if result := db.Table("variant_values").Where("variant_id = ? AND id NOT IN ?", id, variantValueIdsToKeep).Delete(&VariantValue{}); result.Error != nil {
-			return domain.Variant{}, ToError(result.Error)
+			return domain.Variant{}, ToErrorCtx(ctx, result.Error, "UpdateVariantById")
 		}
 	} else {
 		if result := db.Table("variant_values").Where("variant_id = ?", id).Delete(&VariantValue{}); result.Error != nil {
-			return domain.Variant{}, ToError(result.Error)
+			return domain.Variant{}, ToErrorCtx(ctx, result.Error, "UpdateVariantById")
 		}
 	}
 
 	// Fetch the updated variant with all relations
 	var updatedVariant Variant
 	fetchResult := db.Table("variants").Preload("Product").Preload("Product.Category").Preload("Materials").Preload("Materials.Material").Preload("VariantValues").Preload("VariantValues.OptionValue").Where("id = ?", id).First(&updatedVariant)
-	return ToVariantDomain(updatedVariant), ToError(fetchResult.Error)
+	return ToVariantDomain(updatedVariant), ToErrorCtx(ctx, fetchResult.Error, "UpdateVariantById")
 }
 
 func (repo Repository) DeleteVariantById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("variants").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteVariantById")
 }

--- a/apps/api/data/mysql/wallet_repo.go
+++ b/apps/api/data/mysql/wallet_repo.go
@@ -17,21 +17,21 @@ func (repo Repository) GetWalletList(ctx context.Context) ([]domain.Wallet, *dom
 	db := GetDbFromCtx(ctx, repo.db)
 	var wallets []Wallet
 	result := db.Table("wallets").Where("deleted_at", nil).Find(&wallets)
-	return ToWalletListDomain(wallets), ToError(result.Error)
+	return ToWalletListDomain(wallets), ToErrorCtx(ctx, result.Error, "GetWalletList")
 }
 
 func (repo Repository) GetWalletById(ctx context.Context, id int64) (domain.Wallet, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var wallet Wallet
 	result := db.Table("wallets").Where("id = ?", id).First(&wallet)
-	return ToWalletDomain(wallet), ToError(result.Error)
+	return ToWalletDomain(wallet), ToErrorCtx(ctx, result.Error, "GetWalletById")
 }
 
 func (repo Repository) CreateWallet(ctx context.Context, wallet domain.Wallet) (domain.Wallet, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	walletPayload := ToWalletDB(wallet)
 	result := db.Table("wallets").Create(&walletPayload)
-	return ToWalletDomain(walletPayload), ToError(result.Error)
+	return ToWalletDomain(walletPayload), ToErrorCtx(ctx, result.Error, "CreateWallet")
 }
 
 func (repo Repository) UpdateWalletById(ctx context.Context, wallet domain.Wallet, id int64) (domain.Wallet, *domain.Error) {
@@ -45,14 +45,14 @@ func (repo Repository) UpdateWalletById(ctx context.Context, wallet domain.Walle
 
 	var updatedWallet Wallet
 	result = db.Table("wallets").Where("id = ?", id).First(&updatedWallet)
-	return ToWalletDomain(updatedWallet), ToError(result.Error)
+	return ToWalletDomain(updatedWallet), ToErrorCtx(ctx, result.Error, "UpdateWalletById")
 }
 
 func (repo Repository) DeleteWalletById(ctx context.Context, id int64) *domain.Error {
 	db := GetDbFromCtx(ctx, repo.db)
 	currentTime := time.Now()
 	result := db.Table("wallets").Where("id = ?", id).Update("deleted_at", currentTime)
-	return ToError(result.Error)
+	return ToErrorCtx(ctx, result.Error, "DeleteWalletById")
 }
 
 func (repo Repository) GetWalletTransferList(ctx context.Context, walletId int64, sortBy domain.SortBy, order domain.Order, skip int, limit int) ([]domain.WalletTransfer, *domain.Error) {
@@ -71,7 +71,7 @@ func (repo Repository) GetWalletTransferList(ctx context.Context, walletId int64
 
 	result = result.Find(&walletTransfers)
 
-	return ToWalletTransferListDomain(walletTransfers), ToError(result.Error)
+	return ToWalletTransferListDomain(walletTransfers), ToErrorCtx(ctx, result.Error, "GetWalletTransferList")
 }
 
 func (repo Repository) CreateWalletTransfer(ctx context.Context, walletTransfer domain.WalletTransfer, fromWalletId int64) (domain.WalletTransfer, *domain.Error) {
@@ -79,10 +79,10 @@ func (repo Repository) CreateWalletTransfer(ctx context.Context, walletTransfer 
 	walletTransferPayload := ToWalletTransferDB(walletTransfer)
 
 	if result := db.Table("wallet_transfers").Create(&walletTransferPayload); result.Error != nil {
-		return domain.WalletTransfer{}, ToError(result.Error)
+		return domain.WalletTransfer{}, ToErrorCtx(ctx, result.Error, "CreateWalletTransfer")
 	}
 
 	var createdWalletTransfer WalletTransfer
 	result := db.Table("wallet_transfers").Preload("FromWallet").Preload("ToWallet").Where("id = ?", walletTransferPayload.Id).First(&createdWalletTransfer)
-	return ToWalletTransferDomain(createdWalletTransfer), ToError(result.Error)
+	return ToWalletTransferDomain(createdWalletTransfer), ToErrorCtx(ctx, result.Error, "CreateWalletTransfer")
 }


### PR DESCRIPTION
## Summary
Enhanced error handling across all MySQL repository operations by introducing context-aware error logging. This change ensures that database errors are properly logged with operation context before being converted to domain errors, improving observability and debugging capabilities.

## Key Changes
- **New `ToErrorCtx` function**: Added context-aware error conversion in `base_transformer.go` that:
  - Logs database errors at ERROR level with operation name and raw error details
  - Distinguishes between `ErrRecordNotFound` (returns NotFound domain error) and other errors (returns InternalServerError)
  - Provides better error traceability by capturing error details before returning opaque domain errors
  
- **Updated all repository methods**: Replaced `ToError()` calls with `ToErrorCtx(ctx, err, "OperationName")` across all repository files:
  - `product_repo.go`
  - `transaction_repo.go`
  - `variant_repo.go`
  - `calculation_repo.go`
  - `expense_repo.go`
  - `material_repo.go`
  - `wallet_repo.go`
  - `budget_repo.go`
  - `rental_repo.go`
  - `supplier_repo.go`
  - `category_repo.go`
  - `coupon_repo.go`
  - `auth_repo.go`

- **Enhanced transaction logging**: Updated `base_repo.go` to add debug and error logging for transaction lifecycle:
  - Logs transaction begin
  - Logs transaction rollback with reason on error
  - Logs transaction commit on success

## Implementation Details
- The `ToErrorCtx` function uses the logger from context (`logger.FromCtx`) to ensure logs are properly associated with request context
- Each database operation is tagged with its operation name for better error tracking
- The old `ToError()` function is retained for backward compatibility with callers that don't have context available
- Error logging happens before domain error conversion, ensuring raw database error details are captured in logs

https://claude.ai/code/session_01VML2RwBhbwN464yYGY23Cr