### PR TITLE
Add database seeders for products, variants, transactions, expenses, and rentals

### DIFF
--- a/apps/api/seeds/expense_seeder.go
+++ b/apps/api/seeds/expense_seeder.go
@@ -1,0 +1,149 @@
+package seeds
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// ExpenseSeeder seeds sample expenses linked to wallets and budgets, along with their line items.
+type ExpenseSeeder struct{}
+
+func (ExpenseSeeder) Name() string { return "ExpenseSeeder" }
+
+func (ExpenseSeeder) Seed(tx *gorm.DB) error {
+	type Wallet struct {
+		Id   int64
+		Name string
+	}
+	type Budget struct {
+		Id   int64
+		Name string
+	}
+	type Expense struct {
+		Id        int64
+		CreatedAt time.Time
+		DeletedAt *time.Time
+		WalletId  int64
+		BudgetId  int64
+		Total     float32
+	}
+	type ExpenseItem struct {
+		Id        int64
+		ExpenseId int64
+		Name      string
+		Unit      string
+		Price     float32
+		Amount    float32
+		Subtotal  float32
+	}
+
+	getWalletId := func(name string) (int64, error) {
+		var w Wallet
+		if err := tx.Table("wallets").Where("name = ?", name).First(&w).Error; err != nil {
+			return 0, fmt.Errorf("wallet %q not found: %w", name, err)
+		}
+		return w.Id, nil
+	}
+
+	getBudgetId := func(name string) (int64, error) {
+		var b Budget
+		if err := tx.Table("budgets").Where("name = ?", name).First(&b).Error; err != nil {
+			return 0, fmt.Errorf("budget %q not found: %w", name, err)
+		}
+		return b.Id, nil
+	}
+
+	type expenseItemDef struct {
+		Name   string
+		Unit   string
+		Price  float32
+		Amount float32
+	}
+	type expenseDef struct {
+		WalletName string
+		BudgetName string
+		Items      []expenseItemDef
+	}
+
+	expenses := []expenseDef{
+		{
+			WalletName: "Cash",
+			BudgetName: "Operational",
+			Items: []expenseItemDef{
+				{Name: "Coffee Beans Restock", Unit: "kg", Price: 150000, Amount: 2},
+				{Name: "Milk Restock", Unit: "liter", Price: 18000, Amount: 10},
+			},
+		},
+		{
+			WalletName: "Cash",
+			BudgetName: "Marketing",
+			Items: []expenseItemDef{
+				{Name: "Banner Printing", Unit: "pcs", Price: 75000, Amount: 2},
+				{Name: "Social Media Ads", Unit: "campaign", Price: 200000, Amount: 1},
+			},
+		},
+		{
+			WalletName: "GoPay",
+			BudgetName: "Operational",
+			Items: []expenseItemDef{
+				{Name: "Disposable Cups", Unit: "pack", Price: 50000, Amount: 5},
+				{Name: "Cup Lids", Unit: "pack", Price: 30000, Amount: 5},
+				{Name: "Sugar Restock", Unit: "kg", Price: 14000, Amount: 3},
+			},
+		},
+	}
+
+	// Idempotency: skip if at least as many expenses as defined already exist.
+	var existingCount int64
+	if err := tx.Table("expenses").Count(&existingCount).Error; err != nil {
+		return err
+	}
+	if existingCount >= int64(len(expenses)) {
+		return nil
+	}
+
+	for _, ed := range expenses {
+		walletId, err := getWalletId(ed.WalletName)
+		if err != nil {
+			return err
+		}
+		budgetId, err := getBudgetId(ed.BudgetName)
+		if err != nil {
+			return err
+		}
+
+		var total float32
+		for _, item := range ed.Items {
+			total += item.Price * item.Amount
+		}
+
+		expense := Expense{
+			CreatedAt: time.Now(),
+			WalletId:  walletId,
+			BudgetId:  budgetId,
+			Total:     total,
+		}
+		if err := tx.Table("expenses").Create(&expense).Error; err != nil {
+			return err
+		}
+
+		for _, id := range ed.Items {
+			subtotal := id.Price * id.Amount
+			item := ExpenseItem{
+				ExpenseId: expense.Id,
+				Name:      id.Name,
+				Unit:      id.Unit,
+				Price:     id.Price,
+				Amount:    id.Amount,
+				Subtotal:  subtotal,
+			}
+			if err := tx.Table("expense_items").Create(&item).Error; err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/apps/api/seeds/product_seeder.go
+++ b/apps/api/seeds/product_seeder.go
@@ -1,0 +1,156 @@
+package seeds
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// ProductSeeder seeds sample products together with their options and option values.
+type ProductSeeder struct{}
+
+func (ProductSeeder) Name() string { return "ProductSeeder" }
+
+func (ProductSeeder) Seed(tx *gorm.DB) error {
+	type Category struct {
+		Id   int64
+		Name string
+	}
+	type Product struct {
+		Id          int64
+		CategoryId  int64
+		Name        string
+		Description *string
+		ImageUrl    string
+		SaleType    string
+		CreatedAt   time.Time
+		DeletedAt   *time.Time
+	}
+	type Option struct {
+		Id        int64
+		ProductId int64
+		Name      string
+	}
+	type OptionValue struct {
+		Id       int64
+		OptionId int64
+		Name     string
+	}
+
+	getCategoryId := func(name string) (int64, error) {
+		var cat Category
+		if err := tx.Table("categories").Where("name = ?", name).First(&cat).Error; err != nil {
+			return 0, fmt.Errorf("category %q not found: %w", name, err)
+		}
+		return cat.Id, nil
+	}
+
+	desc := func(s string) *string { return &s }
+
+	type productDef struct {
+		Name        string
+		Category    string
+		Description string
+		SaleType    string
+		// ordered slice of [option name, value1, value2, ...]
+		Options [][]string
+	}
+
+	products := []productDef{
+		{
+			Name:        "Espresso",
+			Category:    "Beverages",
+			Description: "Rich and bold espresso shot",
+			SaleType:    "purchase",
+			Options:     [][]string{{"Size", "Small", "Medium", "Large"}},
+		},
+		{
+			Name:        "Cappuccino",
+			Category:    "Beverages",
+			Description: "Espresso with steamed milk foam",
+			SaleType:    "purchase",
+			Options:     [][]string{{"Size", "Small", "Medium", "Large"}},
+		},
+		{
+			Name:        "Matcha Latte",
+			Category:    "Beverages",
+			Description: "Premium matcha with steamed milk",
+			SaleType:    "purchase",
+			Options:     [][]string{{"Size", "Small", "Medium", "Large"}},
+		},
+		{
+			Name:        "Chocolate Cake",
+			Category:    "Desserts",
+			Description: "Moist chocolate layer cake",
+			SaleType:    "purchase",
+			Options:     [][]string{{"Serving", "Slice", "Whole"}},
+		},
+		{
+			Name:        "Chicken Sandwich",
+			Category:    "Food",
+			Description: "Grilled chicken in a soft bun",
+			SaleType:    "purchase",
+			Options:     [][]string{{"Spicy Level", "Mild", "Spicy", "Extra Spicy"}},
+		},
+		{
+			Name:        "Mineral Water",
+			Category:    "Beverages",
+			Description: "600ml bottled mineral water",
+			SaleType:    "purchase",
+			Options:     nil,
+		},
+	}
+
+	for _, pd := range products {
+		var count int64
+		if err := tx.Table("products").Where("name = ?", pd.Name).Count(&count).Error; err != nil {
+			return err
+		}
+		if count > 0 {
+			continue
+		}
+
+		catId, err := getCategoryId(pd.Category)
+		if err != nil {
+			return err
+		}
+
+		product := Product{
+			CategoryId:  catId,
+			Name:        pd.Name,
+			Description: desc(pd.Description),
+			ImageUrl:    "",
+			SaleType:    pd.SaleType,
+			CreatedAt:   time.Now(),
+		}
+		if err := tx.Table("products").Create(&product).Error; err != nil {
+			return err
+		}
+
+		for _, optDef := range pd.Options {
+			if len(optDef) < 2 {
+				continue
+			}
+			option := Option{
+				ProductId: product.Id,
+				Name:      optDef[0],
+			}
+			if err := tx.Table("options").Create(&option).Error; err != nil {
+				return err
+			}
+
+			for _, valName := range optDef[1:] {
+				ov := OptionValue{
+					OptionId: option.Id,
+					Name:     valName,
+				}
+				if err := tx.Table("option_values").Create(&ov).Error; err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}

--- a/apps/api/seeds/rental_seeder.go
+++ b/apps/api/seeds/rental_seeder.go
@@ -1,0 +1,95 @@
+package seeds
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// RentalSeeder seeds sample rentals: one currently active and one already checked out.
+type RentalSeeder struct{}
+
+func (RentalSeeder) Name() string { return "RentalSeeder" }
+
+func (RentalSeeder) Seed(tx *gorm.DB) error {
+	type Variant struct {
+		Id   int64
+		Name string
+	}
+	type Rental struct {
+		Id         int64
+		Code       string
+		Name       string
+		VariantId  int64
+		CheckinAt  time.Time
+		CheckoutAt *time.Time
+		CreatedAt  time.Time
+		DeletedAt  *time.Time
+	}
+
+	getVariantId := func(name string) (int64, error) {
+		var v Variant
+		if err := tx.Table("variants").Where("name = ?", name).First(&v).Error; err != nil {
+			return 0, fmt.Errorf("variant %q not found: %w", name, err)
+		}
+		return v.Id, nil
+	}
+
+	now := time.Now()
+	checkedOutAt := now.Add(-2 * time.Hour)
+
+	type rentalDef struct {
+		Code        string
+		Name        string
+		VariantName string
+		CheckinAt   time.Time
+		CheckoutAt  *time.Time
+	}
+
+	rentals := []rentalDef{
+		{
+			Code:        "RNT-001",
+			Name:        "Table 1 Rental",
+			VariantName: "Espresso Small",
+			CheckinAt:   now.Add(-3 * time.Hour),
+			CheckoutAt:  nil, // still active
+		},
+		{
+			Code:        "RNT-002",
+			Name:        "Table 2 Rental",
+			VariantName: "Cappuccino Medium",
+			CheckinAt:   now.Add(-5 * time.Hour),
+			CheckoutAt:  &checkedOutAt, // already checked out
+		},
+	}
+
+	for _, rd := range rentals {
+		var count int64
+		if err := tx.Table("rentals").Where("code = ?", rd.Code).Count(&count).Error; err != nil {
+			return err
+		}
+		if count > 0 {
+			continue
+		}
+
+		variantId, err := getVariantId(rd.VariantName)
+		if err != nil {
+			return err
+		}
+
+		rental := Rental{
+			Code:       rd.Code,
+			Name:       rd.Name,
+			VariantId:  variantId,
+			CheckinAt:  rd.CheckinAt,
+			CheckoutAt: rd.CheckoutAt,
+			CreatedAt:  now,
+		}
+		if err := tx.Table("rentals").Create(&rental).Error; err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/apps/api/seeds/seeder.go
+++ b/apps/api/seeds/seeder.go
@@ -37,6 +37,7 @@ func RunAll(db *gorm.DB, seeders []Seeder) error {
 // Independent tables are seeded first so that FK constraints are satisfied.
 func All() []Seeder {
 	return []Seeder{
+		// Phase 2: independent tables
 		UserSeeder{},
 		CategorySeeder{},
 		MaterialSeeder{},
@@ -44,5 +45,11 @@ func All() []Seeder {
 		WalletSeeder{},
 		BudgetSeeder{},
 		CouponSeeder{},
+		// Phase 3: relational tables (FK dependencies respected)
+		ProductSeeder{},     // depends on: categories
+		VariantSeeder{},     // depends on: products, materials, option_values
+		TransactionSeeder{}, // depends on: wallets, variants, coupons
+		ExpenseSeeder{},     // depends on: wallets, budgets
+		RentalSeeder{},      // depends on: variants
 	}
 }

--- a/apps/api/seeds/transaction_seeder.go
+++ b/apps/api/seeds/transaction_seeder.go
@@ -1,0 +1,263 @@
+package seeds
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// TransactionSeeder seeds sample transactions with items and applied coupons.
+type TransactionSeeder struct{}
+
+func (TransactionSeeder) Name() string { return "TransactionSeeder" }
+
+func (TransactionSeeder) Seed(tx *gorm.DB) error {
+	type Wallet struct {
+		Id   int64
+		Name string
+	}
+	type Variant struct {
+		Id    int64
+		Name  string
+		Price float32
+	}
+	type Coupon struct {
+		Id     int64
+		Code   string
+		Type   string
+		Amount int64
+	}
+	type Transaction struct {
+		Id          int64
+		CreatedAt   time.Time
+		Name        string
+		OrderNumber int64
+		WalletId    *int64
+		Total       float32
+		TotalIncome float32
+		PaidAmount  float32
+		PaidAt      *time.Time
+		DeletedAt   *time.Time
+	}
+	type TransactionItem struct {
+		Id             int64
+		TransactionId  int64
+		VariantId      int64
+		Amount         float32
+		Price          float32
+		DiscountAmount float32
+		Subtotal       float32
+		Note           string
+	}
+	type TransactionCoupon struct {
+		Id            int64
+		TransactionId int64
+		CouponId      int64
+		Type          string
+		Amount        int64
+	}
+
+	getWalletId := func(name string) (int64, error) {
+		var w Wallet
+		if err := tx.Table("wallets").Where("name = ?", name).First(&w).Error; err != nil {
+			return 0, fmt.Errorf("wallet %q not found: %w", name, err)
+		}
+		return w.Id, nil
+	}
+
+	getVariant := func(name string) (Variant, error) {
+		var v Variant
+		if err := tx.Table("variants").Where("name = ?", name).First(&v).Error; err != nil {
+			return v, fmt.Errorf("variant %q not found: %w", name, err)
+		}
+		return v, nil
+	}
+
+	getCoupon := func(code string) (Coupon, error) {
+		var c Coupon
+		if err := tx.Table("coupons").Where("code = ?", code).First(&c).Error; err != nil {
+			return c, fmt.Errorf("coupon %q not found: %w", code, err)
+		}
+		return c, nil
+	}
+
+	now := time.Now()
+	paidAt := now.Add(-1 * time.Hour)
+
+	type itemDef struct {
+		VariantName string
+		Amount      float32
+		Note        string
+	}
+	type couponDef struct {
+		Code string
+	}
+	type txDef struct {
+		OrderNumber int64
+		Name        string
+		WalletName  string
+		Paid        bool
+		Items       []itemDef
+		Coupons     []couponDef
+	}
+
+	transactions := []txDef{
+		{
+			OrderNumber: 1,
+			Name:        "Order #1",
+			WalletName:  "Cash",
+			Paid:        true,
+			Items: []itemDef{
+				{VariantName: "Espresso Small", Amount: 2},
+				{VariantName: "Cappuccino Medium", Amount: 1},
+			},
+			Coupons: nil,
+		},
+		{
+			OrderNumber: 2,
+			Name:        "Order #2",
+			WalletName:  "GoPay",
+			Paid:        true,
+			Items: []itemDef{
+				{VariantName: "Matcha Latte Medium", Amount: 1},
+				{VariantName: "Chocolate Cake Slice", Amount: 2},
+			},
+			Coupons: []couponDef{{"DISC10"}},
+		},
+		{
+			OrderNumber: 3,
+			Name:        "Order #3",
+			WalletName:  "Cash",
+			Paid:        true,
+			Items: []itemDef{
+				{VariantName: "Chicken Sandwich Mild", Amount: 1},
+				{VariantName: "Mineral Water 600ml", Amount: 2},
+			},
+			Coupons: []couponDef{{"FLAT5K"}},
+		},
+		{
+			OrderNumber: 4,
+			Name:        "Order #4",
+			WalletName:  "Cash",
+			Paid:        false, // unpaid / still open
+			Items: []itemDef{
+				{VariantName: "Cappuccino Large", Amount: 2},
+				{VariantName: "Chocolate Cake Whole", Amount: 1},
+			},
+			Coupons: nil,
+		},
+	}
+
+	for _, td := range transactions {
+		var count int64
+		if err := tx.Table("transactions").Where("order_number = ?", td.OrderNumber).Count(&count).Error; err != nil {
+			return err
+		}
+		if count > 0 {
+			continue
+		}
+
+		walletId, err := getWalletId(td.WalletName)
+		if err != nil {
+			return err
+		}
+
+		// Build items and calculate totals.
+		type resolvedItem struct {
+			variant  Variant
+			amount   float32
+			subtotal float32
+			note     string
+		}
+
+		var resolvedItems []resolvedItem
+		var total float32
+
+		for _, id := range td.Items {
+			v, err := getVariant(id.VariantName)
+			if err != nil {
+				return err
+			}
+			subtotal := v.Price * id.Amount
+			total += subtotal
+			resolvedItems = append(resolvedItems, resolvedItem{
+				variant:  v,
+				amount:   id.Amount,
+				subtotal: subtotal,
+				note:     id.Note,
+			})
+		}
+
+		// Apply coupon discounts.
+		var couponDiscount float32
+		for _, cd := range td.Coupons {
+			c, err := getCoupon(cd.Code)
+			if err != nil {
+				return err
+			}
+			switch c.Type {
+			case "percentage":
+				couponDiscount += total * float32(c.Amount) / 100
+			case "fixed":
+				couponDiscount += float32(c.Amount)
+			}
+		}
+
+		totalIncome := total - couponDiscount
+
+		var paidAtPtr *time.Time
+		paidAmount := float32(0)
+		if td.Paid {
+			paidAtPtr = &paidAt
+			paidAmount = totalIncome
+		}
+
+		transaction := Transaction{
+			CreatedAt:   now,
+			Name:        td.Name,
+			OrderNumber: td.OrderNumber,
+			WalletId:    &walletId,
+			Total:       total,
+			TotalIncome: totalIncome,
+			PaidAmount:  paidAmount,
+			PaidAt:      paidAtPtr,
+		}
+		if err := tx.Table("transactions").Create(&transaction).Error; err != nil {
+			return err
+		}
+
+		for _, ri := range resolvedItems {
+			item := TransactionItem{
+				TransactionId:  transaction.Id,
+				VariantId:      ri.variant.Id,
+				Amount:         ri.amount,
+				Price:          ri.variant.Price,
+				DiscountAmount: 0,
+				Subtotal:       ri.subtotal,
+				Note:           ri.note,
+			}
+			if err := tx.Table("transaction_items").Create(&item).Error; err != nil {
+				return err
+			}
+		}
+
+		for _, cd := range td.Coupons {
+			c, err := getCoupon(cd.Code)
+			if err != nil {
+				return err
+			}
+			tc := TransactionCoupon{
+				TransactionId: transaction.Id,
+				CouponId:      c.Id,
+				Type:          c.Type,
+				Amount:        c.Amount,
+			}
+			if err := tx.Table("transaction_coupons").Create(&tc).Error; err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}

--- a/apps/api/seeds/variant_seeder.go
+++ b/apps/api/seeds/variant_seeder.go
@@ -1,0 +1,246 @@
+package seeds
+
+import (
+	"fmt"
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// VariantSeeder seeds variants for each product together with their
+// material requirements and option-value links.
+type VariantSeeder struct{}
+
+func (VariantSeeder) Name() string { return "VariantSeeder" }
+
+func (VariantSeeder) Seed(tx *gorm.DB) error {
+	type Product struct {
+		Id   int64
+		Name string
+	}
+	type Material struct {
+		Id   int64
+		Name string
+	}
+	type OptionValue struct {
+		Id   int64
+		Name string
+	}
+	type Variant struct {
+		Id          int64
+		ProductId   int64
+		Name        string
+		Price       float32
+		Description *string
+		CreatedAt   time.Time
+		DeletedAt   *time.Time
+	}
+	type VariantMaterial struct {
+		Id         int64
+		VariantId  int64
+		MaterialId int64
+		Amount     float32
+		CreatedAt  time.Time
+		DeletedAt  *time.Time
+	}
+	type VariantValue struct {
+		Id            int64
+		VariantId     int64
+		OptionValueId int64
+	}
+
+	getProductId := func(name string) (int64, error) {
+		var p Product
+		if err := tx.Table("products").Where("name = ?", name).First(&p).Error; err != nil {
+			return 0, fmt.Errorf("product %q not found: %w", name, err)
+		}
+		return p.Id, nil
+	}
+
+	getMaterialId := func(name string) (int64, error) {
+		var m Material
+		if err := tx.Table("materials").Where("name = ?", name).First(&m).Error; err != nil {
+			return 0, fmt.Errorf("material %q not found: %w", name, err)
+		}
+		return m.Id, nil
+	}
+
+	// getOptionValueId finds the ID of an option value belonging to a given product.
+	getOptionValueId := func(productId int64, optionName, valueName string) (int64, error) {
+		var ov OptionValue
+		err := tx.Table("option_values").
+			Joins("JOIN options ON options.id = option_values.option_id").
+			Where("options.product_id = ? AND options.name = ? AND option_values.name = ?", productId, optionName, valueName).
+			First(&ov).Error
+		if err != nil {
+			return 0, fmt.Errorf("option value %q/%q for product %d not found: %w", optionName, valueName, productId, err)
+		}
+		return ov.Id, nil
+	}
+
+	desc := func(s string) *string { return &s }
+
+	// variantDef describes a single variant to seed.
+	type materialUsage struct {
+		Name   string
+		Amount float32
+	}
+	type variantDef struct {
+		ProductName string
+		Name        string
+		Price       float32
+		Description string
+		// option name -> option value name (can be empty for products with no options)
+		OptionValues map[string]string
+		Materials    []materialUsage
+	}
+
+	variants := []variantDef{
+		// ── Espresso ──────────────────────────────────────────────────────────
+		{
+			ProductName: "Espresso", Name: "Espresso Small", Price: 15000,
+			Description:  "Small espresso shot",
+			OptionValues: map[string]string{"Size": "Small"},
+			Materials:    []materialUsage{{"Coffee Beans", 0.005}, {"Cup (12oz)", 1}, {"Cup Lid", 1}},
+		},
+		{
+			ProductName: "Espresso", Name: "Espresso Medium", Price: 20000,
+			Description:  "Medium espresso shot",
+			OptionValues: map[string]string{"Size": "Medium"},
+			Materials:    []materialUsage{{"Coffee Beans", 0.007}, {"Cup (12oz)", 1}, {"Cup Lid", 1}},
+		},
+		{
+			ProductName: "Espresso", Name: "Espresso Large", Price: 25000,
+			Description:  "Large espresso shot",
+			OptionValues: map[string]string{"Size": "Large"},
+			Materials:    []materialUsage{{"Coffee Beans", 0.010}, {"Cup (12oz)", 1}, {"Cup Lid", 1}},
+		},
+		// ── Cappuccino ────────────────────────────────────────────────────────
+		{
+			ProductName: "Cappuccino", Name: "Cappuccino Small", Price: 22000,
+			Description:  "Small cappuccino",
+			OptionValues: map[string]string{"Size": "Small"},
+			Materials:    []materialUsage{{"Coffee Beans", 0.005}, {"Milk", 0.10}, {"Cup (12oz)", 1}, {"Cup Lid", 1}},
+		},
+		{
+			ProductName: "Cappuccino", Name: "Cappuccino Medium", Price: 28000,
+			Description:  "Medium cappuccino",
+			OptionValues: map[string]string{"Size": "Medium"},
+			Materials:    []materialUsage{{"Coffee Beans", 0.007}, {"Milk", 0.15}, {"Cup (12oz)", 1}, {"Cup Lid", 1}},
+		},
+		{
+			ProductName: "Cappuccino", Name: "Cappuccino Large", Price: 34000,
+			Description:  "Large cappuccino",
+			OptionValues: map[string]string{"Size": "Large"},
+			Materials:    []materialUsage{{"Coffee Beans", 0.010}, {"Milk", 0.20}, {"Cup (12oz)", 1}, {"Cup Lid", 1}},
+		},
+		// ── Matcha Latte ──────────────────────────────────────────────────────
+		{
+			ProductName: "Matcha Latte", Name: "Matcha Latte Small", Price: 25000,
+			Description:  "Small matcha latte",
+			OptionValues: map[string]string{"Size": "Small"},
+			Materials:    []materialUsage{{"Matcha Powder", 0.010}, {"Milk", 0.10}, {"Cup (12oz)", 1}, {"Cup Lid", 1}},
+		},
+		{
+			ProductName: "Matcha Latte", Name: "Matcha Latte Medium", Price: 32000,
+			Description:  "Medium matcha latte",
+			OptionValues: map[string]string{"Size": "Medium"},
+			Materials:    []materialUsage{{"Matcha Powder", 0.015}, {"Milk", 0.15}, {"Cup (12oz)", 1}, {"Cup Lid", 1}},
+		},
+		// ── Chocolate Cake ────────────────────────────────────────────────────
+		{
+			ProductName: "Chocolate Cake", Name: "Chocolate Cake Slice", Price: 18000,
+			Description:  "One slice of chocolate cake",
+			OptionValues: map[string]string{"Serving": "Slice"},
+			Materials:    []materialUsage{{"Chocolate Powder", 0.05}, {"Sugar", 0.05}},
+		},
+		{
+			ProductName: "Chocolate Cake", Name: "Chocolate Cake Whole", Price: 120000,
+			Description:  "Whole chocolate cake",
+			OptionValues: map[string]string{"Serving": "Whole"},
+			Materials:    []materialUsage{{"Chocolate Powder", 0.30}, {"Sugar", 0.30}},
+		},
+		// ── Chicken Sandwich ──────────────────────────────────────────────────
+		{
+			ProductName: "Chicken Sandwich", Name: "Chicken Sandwich Mild", Price: 28000,
+			Description:  "Mild grilled chicken sandwich",
+			OptionValues: map[string]string{"Spicy Level": "Mild"},
+			Materials:    nil,
+		},
+		{
+			ProductName: "Chicken Sandwich", Name: "Chicken Sandwich Spicy", Price: 28000,
+			Description:  "Spicy grilled chicken sandwich",
+			OptionValues: map[string]string{"Spicy Level": "Spicy"},
+			Materials:    nil,
+		},
+		// ── Mineral Water ─────────────────────────────────────────────────────
+		{
+			ProductName: "Mineral Water", Name: "Mineral Water 600ml", Price: 5000,
+			Description:  "600ml mineral water bottle",
+			OptionValues: nil,
+			Materials:    []materialUsage{{"Mineral Water", 1}},
+		},
+	}
+
+	for _, vd := range variants {
+		productId, err := getProductId(vd.ProductName)
+		if err != nil {
+			return err
+		}
+
+		var count int64
+		if err := tx.Table("variants").
+			Where("product_id = ? AND name = ?", productId, vd.Name).
+			Count(&count).Error; err != nil {
+			return err
+		}
+		if count > 0 {
+			continue
+		}
+
+		variant := Variant{
+			ProductId:   productId,
+			Name:        vd.Name,
+			Price:       vd.Price,
+			Description: desc(vd.Description),
+			CreatedAt:   time.Now(),
+		}
+		if err := tx.Table("variants").Create(&variant).Error; err != nil {
+			return err
+		}
+
+		// seed variant materials
+		for _, mu := range vd.Materials {
+			matId, err := getMaterialId(mu.Name)
+			if err != nil {
+				return err
+			}
+			vm := VariantMaterial{
+				VariantId:  variant.Id,
+				MaterialId: matId,
+				Amount:     mu.Amount,
+				CreatedAt:  time.Now(),
+			}
+			if err := tx.Table("variant_materials").Create(&vm).Error; err != nil {
+				return err
+			}
+		}
+
+		// seed variant values (option value links)
+		for optName, valName := range vd.OptionValues {
+			ovId, err := getOptionValueId(productId, optName, valName)
+			if err != nil {
+				return err
+			}
+			vv := VariantValue{
+				VariantId:     variant.Id,
+				OptionValueId: ovId,
+			}
+			if err := tx.Table("variant_values").Create(&vv).Error; err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive database seeders to populate sample data for the API, enabling development and testing with realistic data across multiple business domains.

## Key Changes
- **ProductSeeder**: Seeds 6 sample products (Espresso, Cappuccino, Matcha Latte, Chocolate Cake, Chicken Sandwich, Mineral Water) with their associated options and option values (e.g., Size, Serving, Spicy Level)
- **VariantSeeder**: Seeds 13 product variants with pricing, descriptions, material requirements, and option-value links
- **TransactionSeeder**: Seeds 4 sample transactions with:
  - Transaction items linked to variants with pricing and quantities
  - Applied coupons with discount calculations (percentage and fixed amount types)
  - Wallet associations and payment status tracking
- **ExpenseSeeder**: Seeds 3 sample expenses with line items, linked to wallets and budgets for financial tracking
- **RentalSeeder**: Seeds 2 sample rentals demonstrating active and checked-out states
- **Seeder orchestration**: Updated `seeder.go` to include all new seeders in the execution pipeline with proper dependency ordering

## Implementation Details
- All seeders implement idempotency checks to prevent duplicate data on repeated runs
- Seeders use helper functions to resolve foreign key relationships (e.g., looking up product IDs by name)
- Proper error handling with descriptive error messages for missing dependencies
- Timestamps are set to current time with relative offsets for realistic data (e.g., paid transactions 1 hour ago)
- Material usage amounts and pricing are realistic for a coffee shop/café business model

https://claude.ai/code/session_01WGYJxA89Y9RtaHYQBrg9bF