### PR TITLE
Refactor ChecklistTemplateForm layout to side-by-side fields

### DIFF
--- a/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
+++ b/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
@@ -1,7 +1,7 @@
 import { Plus, Trash, X } from '@tamagui/lucide-icons';
 import { Button, Card, Form, H4, Separator, XStack, YStack } from 'tamagui';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
-import { Field, FieldArray, InputText, Textarea } from '../base';
+import { Field, FieldArray, InputText } from '../base';
 import { ChecklistTemplateForm } from '../../../domain';
 
 export type ChecklistTemplateFormViewProps = {
@@ -19,12 +19,18 @@ export const ChecklistTemplateFormView = ({
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
         <Card padding="$3" gap="$3">
-          <Field name="name" label="Template Name">
-            <InputText placeholder="e.g. Opening Checklist" />
-          </Field>
-          <Field name="description" label="Description (optional)">
-            <Textarea placeholder="When/how to use this checklist" />
-          </Field>
+          <XStack gap="$3">
+            <YStack flex={1}>
+              <Field name="name" label="Template Name">
+                <InputText placeholder="e.g. Opening Checklist" />
+              </Field>
+            </YStack>
+            <YStack flex={1}>
+              <Field name="description" label="Description (optional)">
+                <InputText placeholder="When/how to use this checklist" />
+              </Field>
+            </YStack>
+          </XStack>
         </Card>
 
         <FieldArray


### PR DESCRIPTION
## Summary
Updated the ChecklistTemplateFormView component to display the template name and description fields in a side-by-side layout instead of stacked vertically.

## Key Changes
- Removed unused `Textarea` import from the base components
- Wrapped name and description fields in an `XStack` container with `gap="$3"` for horizontal layout
- Each field is now contained in its own `YStack` with `flex={1}` to distribute space equally
- Changed description field input from `Textarea` to `InputText` component for consistency with the new layout

## Implementation Details
- The layout change uses Tamagui's `XStack` (horizontal stack) and `YStack` (vertical stack) components
- Both fields now have equal width due to `flex={1}` property
- The gap between fields is maintained at `$3` spacing unit
- Input placeholder text remains unchanged for user guidance

https://claude.ai/code/session_01E4TGm5hGieY4SmR4Tqkaq9