### PR TITLE
Display completion timestamps inline with checklist items

### DIFF
--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionFormView.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionFormView.tsx
@@ -1,4 +1,4 @@
-import { Button, Card, Form, XStack, YStack } from 'tamagui';
+import { Button, Card, Form, Label, YStack } from 'tamagui';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { Field, InputText, Select } from '../base';
 import { ChecklistSessionForm } from '../../../domain';
@@ -21,7 +21,7 @@ export const ChecklistSessionFormView = ({
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)}>
         <Card padding="$3">
-          <YStack gap="$3" $gtMd={{ flexDirection: 'row', alignItems: 'flex-end' }}>
+          <YStack gap="$3" $gtMd={{ flexDirection: 'row', alignItems: 'flex-start' }}>
             <YStack flex={1}>
               <Field name="checklistTemplateId" label="Checklist Template">
                 <Select<number>
@@ -39,14 +39,18 @@ export const ChecklistSessionFormView = ({
               </Field>
             </YStack>
 
-            <Button
-              disabled={isSubmitDisabled}
-              onPress={form.handleSubmit(onSubmit)}
-              theme="blue"
-              $gtMd={{ marginBottom: '$1' }}
-            >
-              Start Session
-            </Button>
+            <YStack gap="$3">
+              <Label opacity={0} pointerEvents="none" $gtMd={{ display: 'flex' }} display="none">
+                {' '}
+              </Label>
+              <Button
+                disabled={isSubmitDisabled}
+                onPress={form.handleSubmit(onSubmit)}
+                theme="blue"
+              >
+                Start Session
+              </Button>
+            </YStack>
           </YStack>
         </Card>
       </Form>

--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.tsx
@@ -95,29 +95,31 @@ export function ChecklistSessionItemRow({
         )}
 
         <YStack flex={1} gap="$1">
-          <Text
-            fontSize="$5"
-            fontWeight="bold"
-            textDecorationLine={
-              isCompleted && !hasSubItems ? 'line-through' : 'none'
-            }
-            color={isCompleted && !hasSubItems ? '$gray9' : '$color'}
-          >
-            {item.name}
-          </Text>
+          <XStack alignItems="center" justifyContent="space-between" gap="$2">
+            <Text
+              flex={1}
+              fontSize="$5"
+              fontWeight="bold"
+              textDecorationLine={
+                isCompleted && !hasSubItems ? 'line-through' : 'none'
+              }
+              color={isCompleted && !hasSubItems ? '$gray9' : '$color'}
+            >
+              {item.name}
+            </Text>
+            {isCompleted && !hasSubItems && item.completedAt && (
+              <Paragraph fontSize="$2" color="$gray9" flexShrink={0}>
+                {new Date(item.completedAt).toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  hour12: false,
+                })}
+              </Paragraph>
+            )}
+          </XStack>
           {item.description && (
             <Paragraph fontSize="$3" color="$gray10">
               {item.description}
-            </Paragraph>
-          )}
-          {isCompleted && !hasSubItems && item.completedAt && (
-            <Paragraph fontSize="$2" color="$gray9">
-              Completed at{' '}
-              {new Date(item.completedAt).toLocaleTimeString([], {
-                hour: '2-digit',
-                minute: '2-digit',
-                hour12: false,
-              })}
             </Paragraph>
           )}
         </YStack>

--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionSubItemRow.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionSubItemRow.tsx
@@ -45,8 +45,9 @@ export function ChecklistSessionSubItemRow({
         </YStack>
       )}
 
-      <YStack flex={1} gap="$1">
+      <XStack flex={1} alignItems="center" justifyContent="space-between" gap="$2">
         <Text
+          flex={1}
           fontSize="$4"
           textDecorationLine={isCompleted ? 'line-through' : 'none'}
           color={isCompleted ? '$gray9' : '$color'}
@@ -54,7 +55,7 @@ export function ChecklistSessionSubItemRow({
           {subItem.name}
         </Text>
         {isCompleted && subItem.completedAt && (
-          <Paragraph fontSize="$2" color="$gray9">
+          <Paragraph fontSize="$2" color="$gray9" flexShrink={0}>
             {new Date(subItem.completedAt).toLocaleTimeString([], {
               hour: '2-digit',
               minute: '2-digit',
@@ -62,7 +63,7 @@ export function ChecklistSessionSubItemRow({
             })}
           </Paragraph>
         )}
-      </YStack>
+      </XStack>
     </XStack>
   );
 }


### PR DESCRIPTION
## Summary
Refactored the layout of checklist session items to display completion timestamps inline with item names rather than on separate lines, improving visual hierarchy and space efficiency.

## Key Changes
- **ChecklistSessionItemRow.tsx**: Wrapped item name and completion timestamp in an `XStack` with `space-between` alignment to display them horizontally on the same line
- **ChecklistSessionSubItemRow.tsx**: Applied the same layout pattern to sub-items, converting from `YStack` to `XStack` for inline timestamp display
- **ChecklistSessionFormView.tsx**: 
  - Fixed form field alignment by changing `alignItems` from `flex-end` to `flex-start` on medium+ screens
  - Wrapped the "Start Session" button in a `YStack` with a hidden `Label` placeholder to ensure proper vertical alignment with form fields across responsive breakpoints
  - Removed inline margin adjustment on the button

## Implementation Details
- Completion timestamps now appear on the right side of item names using `justifyContent="space-between"`
- Text elements use `flex={1}` to allow proper space distribution
- Timestamp paragraphs use `flexShrink={0}` to prevent text truncation
- The hidden label in the form ensures consistent spacing between the button and input fields on larger screens

https://claude.ai/code/session_01UDT9onNguodzPuHmUz2K1C