### PR TITLE
Add error banner component to form submissions

### DIFF
--- a/libs/ui/src/presentation/components/auth/LoginFormView.tsx
+++ b/libs/ui/src/presentation/components/auth/LoginFormView.tsx
@@ -1,4 +1,4 @@
-import { Field, InputText } from '../base';
+import { Field, FormErrorBanner, InputText } from '../base';
 import { AuthLoginForm } from '../../../domain';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { Button, Form, Spinner } from 'tamagui';
@@ -8,6 +8,7 @@ export type LoginFormProps = {
   onSubmit: (values: AuthLoginForm) => void;
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
+  serverError?: string;
 };
 
 export const LoginForm = ({
@@ -15,10 +16,12 @@ export const LoginForm = ({
   onSubmit,
   isSubmitDisabled,
   isSubmitting,
+  serverError,
 }: LoginFormProps) => {
   return (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Field name="username" label="Username">
           <InputText />
         </Field>

--- a/libs/ui/src/presentation/components/base/Form/FormErrorBanner.tsx
+++ b/libs/ui/src/presentation/components/base/Form/FormErrorBanner.tsx
@@ -1,0 +1,18 @@
+import { XStack, Paragraph } from 'tamagui';
+import { AlertCircle } from '@tamagui/lucide-icons';
+
+export const FormErrorBanner = ({ message }: { message?: string }) => {
+  if (!message) return null;
+  return (
+    <XStack
+      backgroundColor="$red2"
+      padding="$3"
+      borderRadius="$2"
+      gap="$2"
+      alignItems="center"
+    >
+      <AlertCircle size="$1" color="$red10" />
+      <Paragraph color="$red10">{message}</Paragraph>
+    </XStack>
+  );
+};

--- a/libs/ui/src/presentation/components/base/Form/index.ts
+++ b/libs/ui/src/presentation/components/base/Form/index.ts
@@ -2,6 +2,7 @@ export * from './ErrorMessage';
 export * from './Field';
 export * from './FieldWatch';
 export * from './FieldArray';
+export * from './FormErrorBanner';
 export * from './InputNumber';
 export * from './InputText';
 export * from './Select';

--- a/libs/ui/src/presentation/components/calculations/CalculationFormView.tsx
+++ b/libs/ui/src/presentation/components/calculations/CalculationFormView.tsx
@@ -3,6 +3,7 @@ import {
   Field,
   FieldArray,
   FieldWatch,
+  FormErrorBanner,
   InputNumber,
   LoadingView,
   Select,
@@ -22,6 +23,7 @@ export type CalculationFormViewProps = {
   isSubmitting: boolean;
   isFormDisabled?: boolean;
   onRetryButtonPress: () => void;
+  serverError?: string;
 };
 
 export const CalculationFormView = ({
@@ -34,10 +36,12 @@ export const CalculationFormView = ({
   isSubmitDisabled,
   isSubmitting,
   onRetryButtonPress,
+  serverError,
 }: CalculationFormViewProps) => {
   return variant.type === 'loaded' ? (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <YStack gap="$3">
           <XStack flexWrap="wrap" gap="$3">
             <Field name="walletId" label="Wallet Name" flex={1}>

--- a/libs/ui/src/presentation/components/categories/CategoryFormView.tsx
+++ b/libs/ui/src/presentation/components/categories/CategoryFormView.tsx
@@ -1,4 +1,4 @@
-import { Field, InputText, LoadingView, ErrorView } from '../base';
+import { Field, FormErrorBanner, InputText, LoadingView, ErrorView } from '../base';
 import { CategoryForm } from '../../../domain';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { Button, Form, Spinner } from 'tamagui';
@@ -12,6 +12,7 @@ export type CategoryFormViewProps = {
   onSubmit: (values: CategoryForm) => void;
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
+  serverError?: string;
 };
 
 export const CategoryFormView = ({
@@ -20,10 +21,12 @@ export const CategoryFormView = ({
   onSubmit,
   isSubmitDisabled,
   isSubmitting,
+  serverError,
 }: CategoryFormViewProps) => {
   return variant.type === 'loaded' ? (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Field name="name" label="Name">
           <InputText />
         </Field>

--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionFormView.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionFormView.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Form, Label, Spinner, YStack } from 'tamagui';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
-import { Field, InputText, Select } from '../base';
+import { Field, FormErrorBanner, InputText, Select } from '../base';
 import { ChecklistSessionForm } from '../../../domain';
 import { ChecklistTemplate } from '../../../domain';
 
@@ -10,6 +10,7 @@ export type ChecklistSessionFormViewProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   checklistTemplates: ChecklistTemplate[];
+  serverError?: string;
 };
 
 export const ChecklistSessionFormView = ({
@@ -18,10 +19,12 @@ export const ChecklistSessionFormView = ({
   isSubmitDisabled,
   isSubmitting,
   checklistTemplates,
+  serverError,
 }: ChecklistSessionFormViewProps) => {
   return (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)}>
+        <FormErrorBanner message={serverError} />
         <Card padding="$3">
           <YStack gap="$3" $gtMd={{ flexDirection: 'row', alignItems: 'flex-start' }}>
             <YStack flex={1}>

--- a/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
+++ b/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
@@ -1,7 +1,7 @@
 import { Plus, Trash, X } from '@tamagui/lucide-icons';
 import { Button, Card, Form, H4, Spinner, XStack, YStack } from 'tamagui';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
-import { Field, FieldArray, InputText } from '../base';
+import { Field, FieldArray, FormErrorBanner, InputText } from '../base';
 import { ChecklistTemplateForm } from '../../../domain';
 
 export type ChecklistTemplateFormViewProps = {
@@ -9,6 +9,7 @@ export type ChecklistTemplateFormViewProps = {
   onSubmit: (values: ChecklistTemplateForm) => void;
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
+  serverError?: string;
 };
 
 export const ChecklistTemplateFormView = ({
@@ -16,10 +17,12 @@ export const ChecklistTemplateFormView = ({
   onSubmit,
   isSubmitDisabled,
   isSubmitting,
+  serverError,
 }: ChecklistTemplateFormViewProps) => {
   return (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Card padding="$3" gap="$3">
           <YStack gap="$3" $gtMd={{ flexDirection: 'row' }}>
             <YStack flex={1}>

--- a/libs/ui/src/presentation/components/coupons/CouponFormView.tsx
+++ b/libs/ui/src/presentation/components/coupons/CouponFormView.tsx
@@ -1,5 +1,6 @@
 import {
   Field,
+  FormErrorBanner,
   InputText,
   LoadingView,
   ErrorView,
@@ -19,6 +20,7 @@ export type CouponFormViewProps = {
   onSubmit: (values: CouponForm) => void;
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
+  serverError?: string;
 };
 
 export const CouponFormView = ({
@@ -27,10 +29,12 @@ export const CouponFormView = ({
   onSubmit,
   isSubmitDisabled,
   isSubmitting,
+  serverError,
 }: CouponFormViewProps) => {
   return variant.type === 'loaded' ? (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Field name="code" label="Code">
           <InputText />
         </Field>

--- a/libs/ui/src/presentation/components/expenses/ExpenseFormView.tsx
+++ b/libs/ui/src/presentation/components/expenses/ExpenseFormView.tsx
@@ -4,6 +4,7 @@ import {
   Field,
   FieldArray,
   FieldWatch,
+  FormErrorBanner,
   InputNumber,
   InputText,
   LoadingView,
@@ -23,6 +24,7 @@ export type ExpenseFormViewProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   onRetryButtonPress: () => void;
+  serverError?: string;
 };
 
 export const ExpenseFormView = ({
@@ -34,10 +36,12 @@ export const ExpenseFormView = ({
   isSubmitDisabled,
   isSubmitting,
   onRetryButtonPress,
+  serverError,
 }: ExpenseFormViewProps) => {
   return variant.type === 'loaded' ? (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <YStack gap="$3">
           <XStack gap="$3" $xs={{ flexDirection: 'column' }}>
             <Field name="budgetId" label="Budget Name" flex={1}>

--- a/libs/ui/src/presentation/components/materials/MaterialFormView.tsx
+++ b/libs/ui/src/presentation/components/materials/MaterialFormView.tsx
@@ -1,4 +1,4 @@
-import { Field, InputText, InputNumber, MarkdownEditor } from '../base';
+import { Field, FormErrorBanner, InputText, InputNumber, MarkdownEditor } from '../base';
 import { MaterialForm } from '../../../domain';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { Button, Form, Spinner } from 'tamagui';
@@ -8,6 +8,7 @@ export type MaterialFormViewProps = {
   onSubmit: (values: MaterialForm) => void;
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
+  serverError?: string;
 };
 
 export const MaterialFormView = ({
@@ -15,10 +16,12 @@ export const MaterialFormView = ({
   onSubmit,
   isSubmitDisabled,
   isSubmitting,
+  serverError,
 }: MaterialFormViewProps) => {
   return (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Field name="name" label="Name">
           <InputText />
         </Field>

--- a/libs/ui/src/presentation/components/products/ProductFormView.tsx
+++ b/libs/ui/src/presentation/components/products/ProductFormView.tsx
@@ -1,5 +1,6 @@
 import {
   Field,
+  FormErrorBanner,
   InputText,
   Select,
   LoadingView,
@@ -28,6 +29,7 @@ export type ProductFormViewProps = {
   onVariantEditMenuPress?: (variant: Variant) => void;
   onVariantPress?: (variant: Variant) => void;
   onVariantCreatePress?: () => void;
+  serverError?: string;
 };
 
 export const ProductFormView = ({
@@ -43,10 +45,12 @@ export const ProductFormView = ({
   onVariantEditMenuPress,
   onVariantPress,
   onVariantCreatePress,
+  serverError,
 }: ProductFormViewProps) => {
   return variant.type === 'loaded' ? (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Card>
           <Card.Header>
             <XStack gap="$3" $sm={{ flexDirection: 'column' }}>

--- a/libs/ui/src/presentation/components/rentals/RentalCheckinFormView.tsx
+++ b/libs/ui/src/presentation/components/rentals/RentalCheckinFormView.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldWatch, InputText, Select } from '../base';
+import { Field, FieldWatch, FormErrorBanner, InputText, Select } from '../base';
 import {
   Button,
   Card,
@@ -30,6 +30,7 @@ export type RentalCheckinFormViewProps = {
   isSubmitting: boolean;
   RentalItemSelect: () => ReactNode;
   rentalsFieldArray: UseFieldArrayReturn<RentalCheckinForm, 'rentals', 'key'>;
+  serverError?: string;
 };
 
 export const RentalCheckinFormView = ({
@@ -40,12 +41,14 @@ export const RentalCheckinFormView = ({
   isSubmitting,
   RentalItemSelect,
   rentalsFieldArray,
+  serverError,
 }: RentalCheckinFormViewProps) => {
   const inputCodeRefs = useRef<(Input | null)[]>([]);
   return (
     <YStack>
       <FormProvider {...form}>
         <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+          <FormErrorBanner message={serverError} />
           <YStack>
             <YStack gap="$3">
               <XStack gap="$3">

--- a/libs/ui/src/presentation/components/rentals/RentalCheckoutFormView.tsx
+++ b/libs/ui/src/presentation/components/rentals/RentalCheckoutFormView.tsx
@@ -8,6 +8,7 @@ import {
   XStack,
   YStack,
 } from 'tamagui';
+import { FormErrorBanner } from '../base';
 import { H4 } from 'tamagui';
 import { Calendar, QrCode, Trash } from '@tamagui/lucide-icons';
 import { RentalCheckoutForm } from '../../../domain';
@@ -26,6 +27,7 @@ export type RentalCheckoutFormViewProps = {
   isSubmitting: boolean;
   RentalItemSelect: () => ReactNode;
   rentalsFieldArray: UseFieldArrayReturn<RentalCheckoutForm, 'rentals', 'key'>;
+  serverError?: string;
 };
 
 export const RentalCheckoutFormView = ({
@@ -35,11 +37,13 @@ export const RentalCheckoutFormView = ({
   isSubmitting,
   RentalItemSelect,
   rentalsFieldArray,
+  serverError,
 }: RentalCheckoutFormViewProps) => {
   return (
     <YStack>
       <FormProvider {...form}>
         <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+          <FormErrorBanner message={serverError} />
           <XStack gap="$5">
             <YStack flex={1}>{RentalItemSelect()}</YStack>
             <YStack gap="$3" width={400} flex={1}>

--- a/libs/ui/src/presentation/components/suppliers/SupplierFormView.tsx
+++ b/libs/ui/src/presentation/components/suppliers/SupplierFormView.tsx
@@ -1,4 +1,4 @@
-import { Field, InputText } from '../base';
+import { Field, FormErrorBanner, InputText } from '../base';
 import { SupplierForm } from '../../../domain';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { Button, Form, Spinner } from 'tamagui';
@@ -8,6 +8,7 @@ export type SupplierFormViewProps = {
   onSubmit: (values: SupplierForm) => void;
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
+  serverError?: string;
 };
 
 export const SupplierFormView = ({
@@ -15,10 +16,12 @@ export const SupplierFormView = ({
   onSubmit,
   isSubmitDisabled,
   isSubmitting,
+  serverError,
 }: SupplierFormViewProps) => {
   return (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Field name="name" label="Name">
           <InputText />
         </Field>

--- a/libs/ui/src/presentation/components/transactions/TransactionFormView.tsx
+++ b/libs/ui/src/presentation/components/transactions/TransactionFormView.tsx
@@ -1,4 +1,4 @@
-import { Field, FieldWatch, InputNumber, InputText, Sheet } from '../base';
+import { Field, FieldWatch, FormErrorBanner, InputNumber, InputText, Sheet } from '../base';
 import {
   Button,
   Card,
@@ -41,6 +41,7 @@ export type TransactionFormViewProps = {
     'transactionCoupons',
     'key'
   >;
+  serverError?: string;
 };
 
 export const TransactionFormView = ({
@@ -54,11 +55,13 @@ export const TransactionFormView = ({
   TransactionCouponList,
   itemsFieldArray,
   couponsFieldArray,
+  serverError,
 }: TransactionFormViewProps) => {
   return (
     <YStack>
       <FormProvider {...form}>
         <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+          <FormErrorBanner message={serverError} />
           <XStack gap="$3">
             <YStack flex={1}>{TransactionItemSelect()}</YStack>
             <YStack gap="$3">

--- a/libs/ui/src/presentation/components/variants/VariantFormView.tsx
+++ b/libs/ui/src/presentation/components/variants/VariantFormView.tsx
@@ -7,6 +7,7 @@ import {
   LoadingView,
   ErrorView,
   FieldWatch,
+  FormErrorBanner,
   MarkdownEditor,
   Tabs,
   FieldArray,
@@ -51,6 +52,7 @@ export type VariantFormViewProps = {
   MaterialList: (
     fieldArray: UseFieldArrayReturn<VariantForm, 'materials', 'key'>
   ) => ReactNode;
+  serverError?: string;
 };
 
 export const VariantFormView = ({
@@ -65,10 +67,12 @@ export const VariantFormView = ({
   onRemoveMaterial,
   onSubmit,
   MaterialList,
+  serverError,
 }: VariantFormViewProps) => {
   return variant.type === 'loaded' ? (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Card>
           <Card.Header>
             <XStack gap="$3" $sm={{ flexDirection: 'column' }}>

--- a/libs/ui/src/presentation/components/wallets/WalletFormView.tsx
+++ b/libs/ui/src/presentation/components/wallets/WalletFormView.tsx
@@ -1,5 +1,6 @@
 import {
   Field,
+  FormErrorBanner,
   InputText,
   InputNumber,
   LoadingView,
@@ -19,6 +20,7 @@ export type WalletFormViewProps = {
   onSubmit: (values: WalletForm) => void;
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
+  serverError?: string;
 };
 
 export const WalletFormView = ({
@@ -27,10 +29,12 @@ export const WalletFormView = ({
   onSubmit,
   isSubmitDisabled,
   isSubmitting,
+  serverError,
 }: WalletFormViewProps) => {
   return variant.type === 'loaded' ? (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Field name="name" label="Name">
           <InputText />
         </Field>

--- a/libs/ui/src/presentation/components/wallets/WalletTransferFormView.tsx
+++ b/libs/ui/src/presentation/components/wallets/WalletTransferFormView.tsx
@@ -1,4 +1,4 @@
-import { Field, InputNumber, Select } from '../base';
+import { Field, FormErrorBanner, InputNumber, Select } from '../base';
 import { WalletTransferForm } from '../../../domain';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { Button, Form, Spinner } from 'tamagui';
@@ -9,6 +9,7 @@ export type WalletTransferFormViewProps = {
   walletSelectOptions: { label: string; value: number }[];
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
+  serverError?: string;
 };
 
 export const WalletTransferFormView = ({
@@ -17,10 +18,12 @@ export const WalletTransferFormView = ({
   walletSelectOptions,
   isSubmitDisabled,
   isSubmitting,
+  serverError,
 }: WalletTransferFormViewProps) => {
   return (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+        <FormErrorBanner message={serverError} />
         <Field name="toWalletId" label="Transfer To">
           <Select items={walletSelectOptions} />
         </Field>

--- a/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/AuthLoginHandler.test.tsx
@@ -121,4 +121,26 @@ describe('AuthLoginHandler', () => {
 
     expect(mockToastShow).toHaveBeenCalledWith('Login Error');
   });
+
+  describe('error banner', () => {
+    it('should show error banner when login fails', async () => {
+      const user = userEvent.setup();
+      render(<AuthLoginHandler {...createProps({ shouldFail: true })} />);
+
+      await user.type(screen.getByRole('textbox', { name: 'Username' }), 'admin');
+      await user.type(screen.getByRole('textbox', { name: 'Password' }), 'wrong');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<AuthLoginHandler {...createProps()} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/AuthLoginHandler.tsx
+++ b/libs/ui/src/presentation/screens/AuthLoginHandler.tsx
@@ -25,6 +25,11 @@ export const AuthLoginHandler = (props: AuthLoginHandlerProps) => {
         authLoginController.state.type === 'submitSuccess'
       }
       isSubmitting={authLoginController.state.type === 'submitting'}
+      serverError={
+        authLoginController.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onSubmit={(values) => {
         authLoginController.dispatch({ type: 'SUBMIT', values });
       }}

--- a/libs/ui/src/presentation/screens/AuthLoginScreen.tsx
+++ b/libs/ui/src/presentation/screens/AuthLoginScreen.tsx
@@ -8,6 +8,7 @@ export type AuthLoginScreenProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   onSubmit: (values: AuthLoginForm) => void;
+  serverError?: string;
 };
 
 export const AuthLoginScreen = (props: AuthLoginScreenProps) => {
@@ -24,6 +25,7 @@ export const AuthLoginScreen = (props: AuthLoginScreenProps) => {
             isSubmitDisabled={props.isSubmitDisabled}
             isSubmitting={props.isSubmitting}
             onSubmit={props.onSubmit}
+            serverError={props.serverError}
           />
         </Card.Header>
       </Card>

--- a/libs/ui/src/presentation/screens/CalculationCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CalculationCreateHandler.test.tsx
@@ -166,6 +166,41 @@ describe('CalculationCreateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when creation fails', async () => {
+      const user = userEvent.setup();
+      const calculationRepo = new MockCalculationRepository();
+      const walletRepo = new MockWalletRepository();
+      const preloadedWallets = walletRepo.wallets;
+      calculationRepo.setShouldFail(true);
+
+      render(
+        <CalculationCreateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          calculationCreateUsecase={new CalculationCreateUsecase(
+            calculationRepo,
+            walletRepo,
+            { wallets: preloadedWallets }
+          )}
+        />
+      );
+
+      await user.click(screen.getByRole('option', { name: 'Cash' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<CalculationCreateHandler {...createProps()} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should show loading state and allow retry via retry button', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/CalculationCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/CalculationCreateHandler.tsx
@@ -48,6 +48,11 @@ export const CalculationCreateHandler = ({
         calculationCreate.state.type === 'submitSuccess'
       }
       isSubmitting={calculationCreate.state.type === 'submitting'}
+      serverError={
+        calculationCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onRetryButtonPress={() => calculationCreate.dispatch({ type: 'FETCH' })}
       onSubmit={(values) =>
         calculationCreate.dispatch({ type: 'SUBMIT', values })

--- a/libs/ui/src/presentation/screens/CalculationCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/CalculationCreateScreen.tsx
@@ -20,6 +20,7 @@ export type CalculationCreateScreenProps = {
     label: string;
     value: number;
   }[];
+  serverError?: string;
 };
 
 export const CalculationCreateScreen = ({
@@ -32,6 +33,7 @@ export const CalculationCreateScreen = ({
   onSubmit,
   variant,
   walletSelectOptions,
+  serverError,
 }: CalculationCreateScreenProps) => {
   return (
     <Layout
@@ -49,6 +51,7 @@ export const CalculationCreateScreen = ({
           onSubmit={onSubmit}
           variant={variant}
           walletSelectOptions={walletSelectOptions}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/CalculationUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CalculationUpdateHandler.test.tsx
@@ -247,6 +247,45 @@ describe('CalculationUpdateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const calculationRepo = new MockCalculationRepository();
+      const walletRepo = new MockWalletRepository();
+      const preloadedCalculation = calculationRepo.calculations[0];
+      const preloadedWallets = walletRepo.wallets;
+      calculationRepo.setShouldFail(true);
+
+      render(
+        <CalculationUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          calculationUpdateUsecase={new CalculationUpdateUsecase(
+            calculationRepo,
+            walletRepo,
+            {
+              calculationId: preloadedCalculation.id,
+              calculation: preloadedCalculation,
+              wallets: preloadedWallets,
+            }
+          )}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<CalculationUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should retry fetching when retry button is pressed after error', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/CalculationUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/CalculationUpdateHandler.tsx
@@ -42,6 +42,11 @@ export const CalculationUpdateHandler = ({
       }}
       isSubmitDisabled={calculationUpdate.state.isComplete}
       isSubmitting={calculationUpdate.state.type === 'submitting'}
+      serverError={
+        calculationUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onRetryButtonPress={() => calculationUpdate.dispatch({ type: 'FETCH' })}
       onSubmit={(values) =>
         calculationUpdate.dispatch({ type: 'SUBMIT', values })

--- a/libs/ui/src/presentation/screens/CalculationUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/CalculationUpdateScreen.tsx
@@ -20,6 +20,7 @@ export type CalculationUpdateScreenProps = {
     label: string;
     value: number;
   }[];
+  serverError?: string;
 };
 
 export const CalculationUpdateScreen = ({
@@ -32,6 +33,7 @@ export const CalculationUpdateScreen = ({
   onSubmit,
   variant,
   walletSelectOptions,
+  serverError,
 }: CalculationUpdateScreenProps) => {
   return (
     <Layout
@@ -49,6 +51,7 @@ export const CalculationUpdateScreen = ({
           onSubmit={onSubmit}
           variant={variant}
           walletSelectOptions={walletSelectOptions}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
@@ -162,4 +162,25 @@ describe('CategoryCreateHandler', () => {
       expect(mockToastShow).toHaveBeenCalledWith('Create Category Error');
     });
   });
+
+  describe('error banner', () => {
+    it('should show error banner when creation fails', async () => {
+      const user = userEvent.setup();
+      render(<CategoryCreateHandler {...createProps({ shouldFail: true })} />);
+
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Category');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<CategoryCreateHandler {...createProps()} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/CategoryCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/CategoryCreateHandler.tsx
@@ -38,6 +38,11 @@ export const CategoryCreateHandler = ({
         categoryCreate.state.type === 'submitSuccess'
       }
       isSubmitting={categoryCreate.state.type === 'submitting'}
+      serverError={
+        categoryCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onSubmit={(values) => categoryCreate.dispatch({ type: 'SUBMIT', values })}
       variant={match(categoryCreate.state)
         .returnType<CategoryCreateScreenProps['variant']>()

--- a/libs/ui/src/presentation/screens/CategoryCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/CategoryCreateScreen.tsx
@@ -14,6 +14,7 @@ export type CategoryCreateScreenProps = {
   isSubmitting: boolean;
   onSubmit: (values: CategoryForm) => void;
   variant: CategoryFormViewProps['variant'];
+  serverError?: string;
 };
 
 export const CategoryCreateScreen = ({
@@ -23,6 +24,7 @@ export const CategoryCreateScreen = ({
   onLogoutPress,
   onSubmit,
   variant,
+  serverError,
 }: CategoryCreateScreenProps) => {
   return (
     <Layout
@@ -37,6 +39,7 @@ export const CategoryCreateScreen = ({
           isSubmitting={isSubmitting}
           onSubmit={onSubmit}
           variant={variant}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
@@ -244,6 +244,42 @@ describe('CategoryUpdateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const categoryRepo = new MockCategoryRepository();
+      const preloadedCategory = categoryRepo.categories[0];
+      const categoryUpdateUsecase = new CategoryUpdateUsecase(categoryRepo, {
+        categoryId: preloadedCategory.id,
+        category: preloadedCategory,
+      });
+      categoryRepo.setShouldFail(true);
+
+      render(
+        <CategoryUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          categoryUpdateUsecase={categoryUpdateUsecase}
+        />
+      );
+
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Category');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<CategoryUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should refetch category when retry button is pressed after error', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/CategoryUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/CategoryUpdateHandler.tsx
@@ -38,6 +38,11 @@ export const CategoryUpdateHandler = ({
         categoryUpdate.state.type === 'submitSuccess'
       }
       isSubmitting={categoryUpdate.state.type === 'submitting'}
+      serverError={
+        categoryUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onSubmit={(values) => categoryUpdate.dispatch({ type: 'SUBMIT', values })}
       variant={match(categoryUpdate.state)
         .returnType<CategoryUpdateScreenProps['variant']>()

--- a/libs/ui/src/presentation/screens/CategoryUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/CategoryUpdateScreen.tsx
@@ -14,6 +14,7 @@ export type CategoryUpdateScreenProps = {
   isSubmitting: boolean;
   onSubmit: (values: CategoryForm) => void;
   variant: CategoryFormViewProps['variant'];
+  serverError?: string;
 };
 
 export const CategoryUpdateScreen = ({
@@ -23,6 +24,7 @@ export const CategoryUpdateScreen = ({
   onLogoutPress,
   onSubmit,
   variant,
+  serverError,
 }: CategoryUpdateScreenProps) => {
   return (
     <Layout
@@ -37,6 +39,7 @@ export const CategoryUpdateScreen = ({
           isSubmitting={isSubmitting}
           onSubmit={onSubmit}
           variant={variant}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/ChecklistSessionCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistSessionCreateHandler.tsx
@@ -47,6 +47,11 @@ export const ChecklistSessionCreateHandler = ({
         checklistSessionCreate.state.type === 'submitSuccess'
       }
       isSubmitting={checklistSessionCreate.state.type === 'submitting'}
+      serverError={
+        checklistSessionCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       checklistTemplates={checklistTemplates}
     />

--- a/libs/ui/src/presentation/screens/ChecklistSessionCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistSessionCreateScreen.tsx
@@ -10,6 +10,7 @@ export type ChecklistSessionCreateScreenProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   checklistTemplates: ChecklistTemplate[];
+  serverError?: string;
 };
 
 export const ChecklistSessionCreateScreen = ({
@@ -19,6 +20,7 @@ export const ChecklistSessionCreateScreen = ({
   isSubmitDisabled,
   isSubmitting,
   checklistTemplates,
+  serverError,
 }: ChecklistSessionCreateScreenProps) => {
   return (
     <Layout
@@ -33,6 +35,7 @@ export const ChecklistSessionCreateScreen = ({
           isSubmitDisabled={isSubmitDisabled}
           isSubmitting={isSubmitting}
           checklistTemplates={checklistTemplates}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/ChecklistTemplateCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistTemplateCreateHandler.tsx
@@ -40,6 +40,11 @@ export const ChecklistTemplateCreateHandler = ({
         checklistTemplateCreate.state.type === 'submitSuccess'
       }
       isSubmitting={checklistTemplateCreate.state.type === 'submitting'}
+      serverError={
+        checklistTemplateCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
     />
   );

--- a/libs/ui/src/presentation/screens/ChecklistTemplateCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistTemplateCreateScreen.tsx
@@ -9,6 +9,7 @@ export type ChecklistTemplateCreateScreenProps = {
   onSubmit: (values: ChecklistTemplateForm) => void;
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
+  serverError?: string;
 };
 
 export const ChecklistTemplateCreateScreen = ({
@@ -17,6 +18,7 @@ export const ChecklistTemplateCreateScreen = ({
   onSubmit,
   isSubmitDisabled,
   isSubmitting,
+  serverError,
 }: ChecklistTemplateCreateScreenProps) => {
   return (
     <Layout
@@ -30,6 +32,7 @@ export const ChecklistTemplateCreateScreen = ({
           onSubmit={onSubmit}
           isSubmitDisabled={isSubmitDisabled}
           isSubmitting={isSubmitting}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/ChecklistTemplateUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistTemplateUpdateHandler.tsx
@@ -44,6 +44,11 @@ export const ChecklistTemplateUpdateHandler = ({
         checklistTemplateUpdate.state.type === 'submitSuccess'
       }
       isSubmitting={checklistTemplateUpdate.state.type === 'submitting'}
+      serverError={
+        checklistTemplateUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       onRetryButtonPress={() =>
         checklistTemplateUpdate.dispatch({ type: 'FETCH' })

--- a/libs/ui/src/presentation/screens/ChecklistTemplateUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistTemplateUpdateScreen.tsx
@@ -12,6 +12,7 @@ export type ChecklistTemplateUpdateScreenProps = {
   isSubmitting: boolean;
   onRetryButtonPress: () => void;
   variant: { type: 'loading' } | { type: 'loaded' } | { type: 'error' };
+  serverError?: string;
 };
 
 export const ChecklistTemplateUpdateScreen = ({
@@ -22,6 +23,7 @@ export const ChecklistTemplateUpdateScreen = ({
   isSubmitting,
   onRetryButtonPress,
   variant,
+  serverError,
 }: ChecklistTemplateUpdateScreenProps) => {
   return (
     <Layout
@@ -47,6 +49,7 @@ export const ChecklistTemplateUpdateScreen = ({
               onSubmit={onSubmit}
               isSubmitDisabled={isSubmitDisabled}
               isSubmitting={isSubmitting}
+              serverError={serverError}
             />
           </ScrollView>
         ))

--- a/libs/ui/src/presentation/screens/CouponCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CouponCreateHandler.test.tsx
@@ -117,4 +117,25 @@ describe('CouponCreateHandler', () => {
       expect(mockToastShow).toHaveBeenCalledWith('Create Coupon Error');
     });
   });
+
+  describe('error banner', () => {
+    it('should show error banner when creation fails', async () => {
+      const user = userEvent.setup();
+      render(<CouponCreateHandler {...createProps({ shouldFail: true })} />);
+
+      await user.type(screen.getByRole('textbox', { name: 'Code' }), 'NEWCODE');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<CouponCreateHandler {...createProps()} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/CouponCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/CouponCreateHandler.tsx
@@ -38,6 +38,11 @@ export const CouponCreateHandler = ({
         couponCreate.state.type === 'submitSuccess'
       }
       isSubmitting={couponCreate.state.type === 'submitting'}
+      serverError={
+        couponCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onSubmit={(values) =>
         couponCreate.dispatch({ type: 'SUBMIT', values })
       }

--- a/libs/ui/src/presentation/screens/CouponCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/CouponCreateScreen.tsx
@@ -14,6 +14,7 @@ export type CouponCreateScreenProps = {
   isSubmitting: boolean;
   onSubmit: (values: CouponForm) => void;
   variant: CouponFormViewProps['variant'];
+  serverError?: string;
 };
 
 export const CouponCreateScreen = ({
@@ -23,6 +24,7 @@ export const CouponCreateScreen = ({
   onLogoutPress,
   onSubmit,
   variant,
+  serverError,
 }: CouponCreateScreenProps) => {
   return (
     <Layout
@@ -37,6 +39,7 @@ export const CouponCreateScreen = ({
           isSubmitting={isSubmitting}
           onSubmit={onSubmit}
           variant={variant}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/CouponUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CouponUpdateHandler.test.tsx
@@ -188,6 +188,42 @@ describe('CouponUpdateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const couponRepo = new MockCouponRepository();
+      const preloadedCoupon = couponRepo.coupons[0];
+      const couponUpdateUsecase = new CouponUpdateUsecase(couponRepo, {
+        couponId: preloadedCoupon.id,
+        coupon: preloadedCoupon,
+      });
+      couponRepo.setShouldFail(true);
+
+      render(
+        <CouponUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          couponUpdateUsecase={couponUpdateUsecase}
+        />
+      );
+
+      const codeInput = screen.getByRole('textbox', { name: 'Code' });
+      await user.clear(codeInput);
+      await user.type(codeInput, 'UPDATEDCODE');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<CouponUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should refetch coupon when retry button is pressed after error', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/CouponUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/CouponUpdateHandler.tsx
@@ -38,6 +38,11 @@ export const CouponUpdateHandler = ({
         couponUpdate.state.type === 'submitSuccess'
       }
       isSubmitting={couponUpdate.state.type === 'submitting'}
+      serverError={
+        couponUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onSubmit={(values) =>
         couponUpdate.dispatch({ type: 'SUBMIT', values })
       }

--- a/libs/ui/src/presentation/screens/CouponUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/CouponUpdateScreen.tsx
@@ -14,6 +14,7 @@ export type CouponUpdateScreenProps = {
   isSubmitting: boolean;
   onSubmit: (values: CouponForm) => void;
   variant: CouponFormViewProps['variant'];
+  serverError?: string;
 };
 
 export const CouponUpdateScreen = ({
@@ -23,6 +24,7 @@ export const CouponUpdateScreen = ({
   onLogoutPress,
   onSubmit,
   variant,
+  serverError,
 }: CouponUpdateScreenProps) => {
   return (
     <Layout
@@ -37,6 +39,7 @@ export const CouponUpdateScreen = ({
           isSubmitting={isSubmitting}
           onSubmit={onSubmit}
           variant={variant}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/ExpenseCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseCreateHandler.test.tsx
@@ -122,6 +122,13 @@ describe('ExpenseCreateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should not show error banner before any submission', () => {
+      render(<ExpenseCreateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should retry fetching when retry button is pressed after error', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/ExpenseCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseCreateHandler.tsx
@@ -38,6 +38,11 @@ export const ExpenseCreateHandler = ({
         expenseCreate.state.type === 'submitSuccess'
       }
       isSubmitting={expenseCreate.state.type === 'submitting'}
+      serverError={
+        expenseCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onRetryButtonPress={() => expenseCreate.dispatch({ type: 'FETCH' })}
       onSubmit={(values) =>
         expenseCreate.dispatch({ type: 'SUBMIT', values })

--- a/libs/ui/src/presentation/screens/ExpenseCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseCreateScreen.tsx
@@ -17,6 +17,7 @@ export type ExpenseCreateScreenProps = {
   budgetSelectOptions: { label: string; value: number }[];
   walletSelectOptions: { label: string; value: number }[];
   variant: ExpenseFormViewProps['variant'];
+  serverError?: string;
 };
 
 export const ExpenseCreateScreen = ({
@@ -29,6 +30,7 @@ export const ExpenseCreateScreen = ({
   budgetSelectOptions,
   walletSelectOptions,
   variant,
+  serverError,
 }: ExpenseCreateScreenProps) => {
   return (
     <Layout
@@ -46,6 +48,7 @@ export const ExpenseCreateScreen = ({
           budgetSelectOptions={budgetSelectOptions}
           walletSelectOptions={walletSelectOptions}
           variant={variant}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/ExpenseUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseUpdateHandler.test.tsx
@@ -117,6 +117,49 @@ describe('ExpenseUpdateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const expenseRepo = new MockExpenseRepository();
+      const budgetRepo = new MockBudgetRepository();
+      const walletRepo = new MockWalletRepository();
+      const expenseId = 1;
+      const preloadedExpense = expenseRepo.expenses.find((e) => e.id === expenseId) ?? null;
+      const expenseUpdateUsecase = new ExpenseUpdateUsecase(
+        expenseRepo,
+        budgetRepo,
+        walletRepo,
+        {
+          expenseId,
+          expense: preloadedExpense,
+          budgets: budgetRepo.budgets,
+          wallets: walletRepo.wallets,
+        }
+      );
+      expenseRepo.setShouldFail(true);
+
+      render(
+        <ExpenseUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          expenseUpdateUsecase={expenseUpdateUsecase}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<ExpenseUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should refetch expense when retry button is pressed after error', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/ExpenseUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseUpdateHandler.tsx
@@ -38,6 +38,11 @@ export const ExpenseUpdateHandler = ({
         expenseUpdate.state.type === 'submitSuccess'
       }
       isSubmitting={expenseUpdate.state.type === 'submitting'}
+      serverError={
+        expenseUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onRetryButtonPress={() => expenseUpdate.dispatch({ type: 'FETCH' })}
       onSubmit={(values) =>
         expenseUpdate.dispatch({ type: 'SUBMIT', values })

--- a/libs/ui/src/presentation/screens/ExpenseUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseUpdateScreen.tsx
@@ -17,6 +17,7 @@ export type ExpenseUpdateScreenProps = {
   budgetSelectOptions: { label: string; value: number }[];
   walletSelectOptions: { label: string; value: number }[];
   variant: ExpenseFormViewProps['variant'];
+  serverError?: string;
 };
 
 export const ExpenseUpdateScreen = ({
@@ -29,6 +30,7 @@ export const ExpenseUpdateScreen = ({
   budgetSelectOptions,
   walletSelectOptions,
   variant,
+  serverError,
 }: ExpenseUpdateScreenProps) => {
   return (
     <Layout
@@ -46,6 +48,7 @@ export const ExpenseUpdateScreen = ({
           budgetSelectOptions={budgetSelectOptions}
           walletSelectOptions={walletSelectOptions}
           variant={variant}
+          serverError={serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/MaterialCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/MaterialCreateHandler.test.tsx
@@ -131,4 +131,26 @@ describe('MaterialCreateHandler', () => {
       expect(mockToastShow).toHaveBeenCalledWith('Create Material Error');
     });
   });
+
+  describe('error banner', () => {
+    it('should show error banner when creation fails', async () => {
+      const user = userEvent.setup();
+      render(<MaterialCreateHandler {...createProps({ shouldFail: true })} />);
+
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Material');
+      await user.type(screen.getByRole('textbox', { name: 'Unit' }), 'kg');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<MaterialCreateHandler {...createProps()} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/MaterialCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/MaterialCreateHandler.tsx
@@ -40,6 +40,11 @@ export const MaterialCreateHandler = ({
         materialCreate.state.type === 'submitSuccess'
       }
       isSubmitting={materialCreate.state.type === 'submitting'}
+      serverError={
+        materialCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
     />
   );

--- a/libs/ui/src/presentation/screens/MaterialCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/MaterialCreateScreen.tsx
@@ -9,6 +9,7 @@ export type MaterialCreateScreenProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   onLogoutPress: () => void;
+  serverError?: string;
 };
 
 export const MaterialCreateScreen = (props: MaterialCreateScreenProps) => {
@@ -24,6 +25,7 @@ export const MaterialCreateScreen = (props: MaterialCreateScreenProps) => {
           onSubmit={props.onSubmit}
           isSubmitDisabled={props.isSubmitDisabled}
           isSubmitting={props.isSubmitting}
+          serverError={props.serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/MaterialUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/MaterialUpdateHandler.test.tsx
@@ -184,4 +184,40 @@ describe('MaterialUpdateHandler', () => {
       expect(mockToastShow).toHaveBeenCalledWith('Update Material Error');
     });
   });
+
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const materialRepo = new MockMaterialRepository();
+      const preloadedMaterial = materialRepo.materials[0];
+      const materialUpdateUsecase = new MaterialUpdateUsecase(materialRepo, {
+        materialId: preloadedMaterial.id,
+        material: preloadedMaterial,
+      });
+      materialRepo.shouldFail = true;
+
+      render(
+        <MaterialUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          materialUpdateUsecase={materialUpdateUsecase}
+        />
+      );
+
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Material');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<MaterialUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/MaterialUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/MaterialUpdateHandler.tsx
@@ -40,6 +40,11 @@ export const MaterialUpdateHandler = ({
         materialUpdate.state.type === 'submitSuccess'
       }
       isSubmitting={materialUpdate.state.type === 'submitting'}
+      serverError={
+        materialUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
     />
   );

--- a/libs/ui/src/presentation/screens/MaterialUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/MaterialUpdateScreen.tsx
@@ -9,6 +9,7 @@ export type MaterialUpdateScreenProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   onLogoutPress: () => void;
+  serverError?: string;
 };
 
 export const MaterialUpdateScreen = (props: MaterialUpdateScreenProps) => {
@@ -24,6 +25,7 @@ export const MaterialUpdateScreen = (props: MaterialUpdateScreenProps) => {
           onSubmit={props.onSubmit}
           isSubmitDisabled={props.isSubmitDisabled}
           isSubmitting={props.isSubmitting}
+          serverError={props.serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/ProductCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/ProductCreateHandler.test.tsx
@@ -118,6 +118,39 @@ describe('ProductCreateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when creation fails', async () => {
+      const user = userEvent.setup();
+      const productRepo = new MockProductRepository();
+      const categoryRepo = new MockCategoryRepository();
+      const preloadedCategories = categoryRepo.categories;
+      productRepo.setShouldFail(true);
+
+      render(
+        <ProductCreateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          productCreateUsecase={new ProductCreateUsecase(productRepo, categoryRepo, {
+            categories: preloadedCategories,
+          })}
+        />
+      );
+
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Product');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<ProductCreateHandler {...createProps({ preloadCategories: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should refetch categories when retry button is pressed after error', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/ProductCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/ProductCreateHandler.tsx
@@ -41,6 +41,11 @@ export const ProductCreateHandler = ({
         productCreate.state.type === 'submitSuccess'
       }
       isSubmitting={productCreate.state.type === 'submitting'}
+      serverError={
+        productCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onRetryButtonPress={() => productCreate.dispatch({ type: 'FETCH' })}
       variant={match(productCreate.state)
         .returnType<ProductCreateScreenProps['variant']>()

--- a/libs/ui/src/presentation/screens/ProductCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/ProductCreateScreen.tsx
@@ -13,6 +13,7 @@ export type ProductCreateScreenProps = {
   categorySelectOptions: { label: string; value: number }[];
   variants: Variant[];
   onLogoutPress: () => void;
+  serverError?: string;
 };
 
 export const ProductCreateScreen = (props: ProductCreateScreenProps) => {
@@ -28,6 +29,7 @@ export const ProductCreateScreen = (props: ProductCreateScreenProps) => {
           variant={props.variant}
           categorySelectOptions={props.categorySelectOptions}
           variants={props.variants}
+          serverError={props.serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/ProductUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/ProductUpdateHandler.test.tsx
@@ -238,6 +238,53 @@ describe('ProductUpdateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const productRepo = new MockProductRepository();
+      const categoryRepo = new MockCategoryRepository();
+      const variantRepo = new MockVariantRepository();
+      const preloadedProduct = productRepo.products[0];
+
+      const productUpdateUsecase = new ProductUpdateUsecase(
+        productRepo,
+        categoryRepo,
+        variantRepo,
+        {
+          productId: preloadedProduct.id,
+          product: preloadedProduct,
+          categories: categoryRepo.categories,
+          variants: [],
+        }
+      );
+      productRepo.setShouldFail(true);
+
+      render(
+        <ProductUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          productUpdateUsecase={productUpdateUsecase}
+          variantDeleteUsecase={new VariantDeleteUsecase(variantRepo)}
+        />
+      );
+
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Product');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<ProductUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('variant delete modal', () => {
     it('should not show variant delete modal initially', async () => {
       render(<ProductUpdateHandler {...createProps({ preloaded: true })} />);

--- a/libs/ui/src/presentation/screens/ProductUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/ProductUpdateHandler.tsx
@@ -56,6 +56,11 @@ export const ProductUpdateHandler = ({
         productUpdate.state.type === 'submitSuccess'
       }
       isSubmitting={productUpdate.state.type === 'submitting'}
+      serverError={
+        productUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onRetryButtonPress={() => productUpdate.dispatch({ type: 'FETCH' })}
       variant={match(productUpdate.state)
         .returnType<ProductUpdateScreenProps['variant']>()

--- a/libs/ui/src/presentation/screens/ProductUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/ProductUpdateScreen.tsx
@@ -23,6 +23,7 @@ export type ProductUpdateScreenProps = {
     isButtonDisabled: boolean;
   };
   onLogoutPress: () => void;
+  serverError?: string;
 };
 
 export const ProductUpdateScreen = (props: ProductUpdateScreenProps) => {
@@ -42,6 +43,7 @@ export const ProductUpdateScreen = (props: ProductUpdateScreenProps) => {
           onVariantDeleteMenuPress={props.onVariantDeleteMenuPress}
           onVariantEditMenuPress={props.onVariantEditMenuPress}
           onVariantCreatePress={props.onVariantCreatePress}
+          serverError={props.serverError}
         />
         <VariantDeleteAlert {...props.variantDeleteAlert} />
       </ScrollView>

--- a/libs/ui/src/presentation/screens/RentalCheckinHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinHandler.test.tsx
@@ -278,6 +278,55 @@ describe('RentalCheckinHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when checkin fails', async () => {
+      const user = userEvent.setup();
+      render(<RentalCheckinHandler {...createProps({ rentalShouldFail: true })} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('heading', { name: 'Product 1' }));
+      });
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await user.click(screen.getAllByRole('button', { name: 'Submit' })[0]);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const codeInput = screen.getByPlaceholderText('Code');
+      await user.type(codeInput, 'RENTAL001');
+
+      const nameInput = screen.getByRole('textbox', { name: 'Customer Name' });
+      await user.type(nameInput, 'John Doe');
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', async () => {
+      render(<RentalCheckinHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should refetch products when retry button is pressed', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
@@ -65,6 +65,11 @@ export const RentalCheckinHandler = ({
       }
       isSubmitDisabled={rentalCheckin.state.type === 'submitting'}
       isSubmitting={rentalCheckin.state.type === 'submitting'}
+      serverError={
+        rentalCheckin.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       rentalsFieldArray={rentalCheckin.rentalsFieldArray}
       onToggleCustomizeCheckinDateTime={

--- a/libs/ui/src/presentation/screens/RentalCheckinScreen.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinScreen.tsx
@@ -35,6 +35,7 @@ export type RentalCheckinScreenProps = {
     variant: TransactionItemSelectProps['variant'];
     selectedProduct?: Product;
   };
+  serverError?: string;
 };
 
 export const RentalCheckinScreen = (props: RentalCheckinScreenProps) => {
@@ -54,6 +55,7 @@ export const RentalCheckinScreen = (props: RentalCheckinScreenProps) => {
           onToggleCustomizeCheckinDateTime={
             props.onToggleCustomizeCheckinDateTime
           }
+          serverError={props.serverError}
           RentalItemSelect={() => (
             <TransactionItemSelect
               amount={props.rentalItemSelect.amount}

--- a/libs/ui/src/presentation/screens/RentalCheckoutHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckoutHandler.test.tsx
@@ -237,6 +237,50 @@ describe('RentalCheckoutHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when checkout fails', async () => {
+      const user = userEvent.setup();
+      const rentalRepo = new MockRentalRepository();
+
+      render(
+        <RentalCheckoutHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          rentalCheckoutUsecase={new RentalCheckoutUsecase(rentalRepo)}
+          rentalListUsecase={new RentalListUsecase(
+            rentalRepo,
+            new MockRentalListQueryRepository(),
+            { rentals: [], totalItem: 0 }
+          )}
+        />
+      );
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await user.click(screen.getByText('Rental 1'));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      rentalRepo.setShouldFail(true);
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<RentalCheckoutHandler {...createProps()} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should refetch rentals when retry button is pressed', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/RentalCheckoutHandler.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckoutHandler.tsx
@@ -84,6 +84,11 @@ export const RentalCheckoutHandler = ({
       }
       isSubmitDisabled={rentalCheckout.state.type === 'submitting'}
       isSubmitting={rentalCheckout.state.type === 'submitting'}
+      serverError={
+        rentalCheckout.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       rentalsFieldArray={rentalCheckout.rentalsFieldArray}
       rentalList={{

--- a/libs/ui/src/presentation/screens/RentalCheckoutScreen.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckoutScreen.tsx
@@ -26,6 +26,7 @@ export type RentalCheckoutScreenProps = {
     onItemPress: (rental: Rental) => void;
     isSearchAutoFocus: boolean;
   };
+  serverError?: string;
 };
 
 export const RentalCheckoutScreen = (props: RentalCheckoutScreenProps) => {
@@ -43,6 +44,7 @@ export const RentalCheckoutScreen = (props: RentalCheckoutScreenProps) => {
           isSubmitting={props.isSubmitting}
           rentalsFieldArray={props.rentalsFieldArray}
           RentalItemSelect={() => <RentalList {...props.rentalList} />}
+          serverError={props.serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/SupplierCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/SupplierCreateHandler.test.tsx
@@ -140,4 +140,25 @@ describe('SupplierCreateHandler', () => {
       expect(mockToastShow).toHaveBeenCalledWith('Create Supplier Error');
     });
   });
+
+  describe('error banner', () => {
+    it('should show error banner when creation fails', async () => {
+      const user = userEvent.setup();
+      render(<SupplierCreateHandler {...createProps({ shouldFail: true })} />);
+
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Supplier');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<SupplierCreateHandler {...createProps()} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/SupplierCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/SupplierCreateHandler.tsx
@@ -36,6 +36,11 @@ export const SupplierCreateHandler = ({
         supplierCreate.state.type === 'submitSuccess'
       }
       isSubmitting={supplierCreate.state.type === 'submitting'}
+      serverError={
+        supplierCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
     />
   );

--- a/libs/ui/src/presentation/screens/SupplierCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/SupplierCreateScreen.tsx
@@ -9,6 +9,7 @@ export type SupplierCreateScreenProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   onLogoutPress: () => void;
+  serverError?: string;
 };
 
 export const SupplierCreateScreen = (props: SupplierCreateScreenProps) => {
@@ -20,6 +21,7 @@ export const SupplierCreateScreen = (props: SupplierCreateScreenProps) => {
           onSubmit={props.onSubmit}
           isSubmitDisabled={props.isSubmitDisabled}
           isSubmitting={props.isSubmitting}
+          serverError={props.serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/SupplierUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/SupplierUpdateHandler.test.tsx
@@ -184,4 +184,40 @@ describe('SupplierUpdateHandler', () => {
       expect(mockToastShow).toHaveBeenCalledWith('Update Supplier Error');
     });
   });
+
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const supplierRepo = new MockSupplierRepository();
+      const preloadedSupplier = supplierRepo.suppliers[0];
+      const supplierUpdateUsecase = new SupplierUpdateUsecase(supplierRepo, {
+        supplierId: preloadedSupplier.id,
+        supplier: preloadedSupplier,
+      });
+      supplierRepo.setShouldFail(true);
+
+      render(
+        <SupplierUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          supplierUpdateUsecase={supplierUpdateUsecase}
+        />
+      );
+
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Supplier');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<SupplierUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/SupplierUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/SupplierUpdateHandler.tsx
@@ -35,6 +35,11 @@ export const SupplierUpdateHandler = ({
         supplierUpdate.state.type === 'submitSuccess'
       }
       isSubmitting={supplierUpdate.state.type === 'submitting'}
+      serverError={
+        supplierUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
     />
   );

--- a/libs/ui/src/presentation/screens/SupplierUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/SupplierUpdateScreen.tsx
@@ -9,6 +9,7 @@ export type SupplierUpdateScreenProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   onLogoutPress: () => void;
+  serverError?: string;
 };
 
 export const SupplierUpdateScreen = (props: SupplierUpdateScreenProps) => {
@@ -20,6 +21,7 @@ export const SupplierUpdateScreen = (props: SupplierUpdateScreenProps) => {
           onSubmit={props.onSubmit}
           isSubmitDisabled={props.isSubmitDisabled}
           isSubmitting={props.isSubmitting}
+          serverError={props.serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/TransactionCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateHandler.test.tsx
@@ -165,6 +165,18 @@ describe('TransactionCreateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should not show error banner before any submission', async () => {
+      render(<TransactionCreateHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should refetch products when retry button is pressed', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
@@ -205,6 +205,10 @@ export const TransactionCreateHandler = ({
       transactionCreateController.dispatch({ type: 'SUBMIT', values }),
     isSubmitDisabled: transactionCreateController.state.type === 'submitting',
     isSubmitting: transactionCreateController.state.type === 'submitting',
+    serverError:
+      transactionCreateController.state.type === 'submitError'
+        ? 'Failed to submit. Please try again.'
+        : undefined,
     onLogoutPress: () => authLogoutController.dispatch({ type: 'LOGOUT' }),
     isCouponSheetOpen: transactionCreateController.isCouponSheetOpen,
     onCouponSheetOpenChange:

--- a/libs/ui/src/presentation/screens/TransactionCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateScreen.tsx
@@ -63,6 +63,7 @@ export type TransactionCreateScreenProps = {
     transactionTotal: number;
     walletSelectOptions: { label: string; value: Wallet }[];
   };
+  serverError?: string;
 };
 
 export const TransactionCreateScreen = (
@@ -84,6 +85,7 @@ export const TransactionCreateScreen = (
           onCouponSheetOpenChange={props.onCouponSheetOpenChange}
           itemsFieldArray={props.itemsFieldArray}
           couponsFieldArray={props.couponsFieldArray}
+          serverError={props.serverError}
           TransactionItemSelect={() => (
             <TransactionItemSelect
               amount={props.transactionItemSelect.amount}

--- a/libs/ui/src/presentation/screens/TransactionUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/TransactionUpdateHandler.test.tsx
@@ -236,6 +236,47 @@ describe('TransactionUpdateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const transactionRepo = new MockTransactionRepository();
+      const preloadedTransaction = transactionRepo.transactions[0];
+      transactionRepo.setShouldFail(true);
+
+      render(
+        <TransactionUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          transactionUpdateUsecase={new TransactionUpdateUsecase(transactionRepo, {
+            transactionId: preloadedTransaction.id,
+            transaction: preloadedTransaction,
+          })}
+          transactionItemSelectUsecase={new TransactionItemSelectUsecase(
+            new MockProductRepository(),
+            new MockVariantRepository(),
+            { products: [], totalItem: 0 }
+          )}
+          couponListUsecase={new CouponListUsecase(
+            new MockCouponRepository(),
+            { coupons: [] }
+          )}
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<TransactionUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('product error recovery', () => {
     it('should refetch products when retry button is pressed', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/TransactionUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/TransactionUpdateHandler.tsx
@@ -71,6 +71,11 @@ export const TransactionUpdateHandler = ({
       }
       isSubmitDisabled={transactionUpdate.state.type === 'submitting'}
       isSubmitting={transactionUpdate.state.type === 'submitting'}
+      serverError={
+        transactionUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       isCouponSheetOpen={transactionUpdate.isCouponSheetOpen}
       onCouponSheetOpenChange={transactionUpdate.onCouponSheetOpenChange}

--- a/libs/ui/src/presentation/screens/TransactionUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/TransactionUpdateScreen.tsx
@@ -52,6 +52,7 @@ export type TransactionUpdateScreenProps = {
     onRetryButtonPress: () => void;
     variant: CouponListProps['variant'];
   };
+  serverError?: string;
 };
 
 export const TransactionUpdateScreen = (
@@ -73,6 +74,7 @@ export const TransactionUpdateScreen = (
           onCouponSheetOpenChange={props.onCouponSheetOpenChange}
           itemsFieldArray={props.itemsFieldArray}
           couponsFieldArray={props.couponsFieldArray}
+          serverError={props.serverError}
           TransactionItemSelect={() => (
             <TransactionItemSelect {...props.transactionItemSelect} />
           )}

--- a/libs/ui/src/presentation/screens/VariantCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/VariantCreateHandler.test.tsx
@@ -186,6 +186,58 @@ describe('VariantCreateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when creation fails', async () => {
+      const user = userEvent.setup();
+      const productId = 1;
+      const productRepo = new MockProductRepository();
+      const variantRepo = new MockVariantRepository();
+      const materialRepo = new MockMaterialRepository();
+      const preloadedProduct = { ...productRepo.products[0], options: [] };
+
+      const variantCreateUsecase = new VariantCreateUsecase(
+        variantRepo,
+        productRepo,
+        { productId, product: preloadedProduct }
+      );
+      variantRepo.setShouldFail(true);
+
+      render(
+        <VariantCreateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          variantCreateUsecase={variantCreateUsecase}
+          materialListUsecase={new MaterialListUsecase(
+            materialRepo,
+            new MockMaterialListQueryRepository(),
+            { materials: [], totalItem: 0 }
+          )}
+        />
+      );
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Variant');
+      await user.type(screen.getByRole('textbox', { name: 'Price' }), '100');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', async () => {
+      render(<VariantCreateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+      await act(async () => {
+        await flushPromises();
+      });
+    });
+  });
+
   describe('error recovery', () => {
     it('should refetch product when retry button is pressed after error', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/VariantCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/VariantCreateHandler.tsx
@@ -56,6 +56,11 @@ export const VariantCreateHandler = ({
         variantCreate.state.type === 'submitSuccess'
       }
       isSubmitting={variantCreate.state.type === 'submitting'}
+      serverError={
+        variantCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       isMaterialSheetOpen={variantCreate.isMaterialSheetOpen}
       onMaterialSheetOpenChange={variantCreate.onMaterialSheetOpenChange}

--- a/libs/ui/src/presentation/screens/VariantCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/VariantCreateScreen.tsx
@@ -38,6 +38,7 @@ export type VariantCreateScreenProps = {
     totalItem: number;
     variant: MaterialListProps['variant'];
   };
+  serverError?: string;
 };
 
 export const VariantCreateScreen = (props: VariantCreateScreenProps) => {
@@ -59,6 +60,7 @@ export const VariantCreateScreen = (props: VariantCreateScreenProps) => {
           onRemoveMaterial={props.onRemoveMaterial}
           product={props.product}
           variant={props.variant}
+          serverError={props.serverError}
           MaterialList={(fieldArray) => (
             <MaterialList
               isSearchAutoFocus

--- a/libs/ui/src/presentation/screens/VariantUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/VariantUpdateHandler.test.tsx
@@ -191,6 +191,62 @@ describe('VariantUpdateHandler', () => {
     });
   });
 
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const variantRepo = new MockVariantRepository();
+      const productRepo = new MockProductRepository();
+      const preloadedVariant = variantRepo.variants[0];
+      const preloadedProduct = { ...productRepo.products[0], options: [] };
+
+      const variantUpdateUsecase = new VariantUpdateUsecase(
+        variantRepo,
+        productRepo,
+        {
+          variantId: preloadedVariant.id,
+          productId: preloadedProduct.id,
+          variant: preloadedVariant,
+          product: preloadedProduct,
+        }
+      );
+      variantRepo.setShouldFail(true);
+
+      const materialRepo = new MockMaterialRepository();
+
+      render(
+        <VariantUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          variantUpdateUsecase={variantUpdateUsecase}
+          materialListUsecase={new MaterialListUsecase(
+            materialRepo,
+            new MockMaterialListQueryRepository(),
+            { materials: materialRepo.materials, totalItem: materialRepo.materials.length }
+          )}
+        />
+      );
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Variant');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<VariantUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
+
   describe('error recovery', () => {
     it('should refetch variant when retry button is pressed after error', async () => {
       const user = userEvent.setup();

--- a/libs/ui/src/presentation/screens/VariantUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/VariantUpdateHandler.tsx
@@ -55,6 +55,11 @@ export const VariantUpdateHandler = ({
         variantUpdate.state.type === 'submitSuccess'
       }
       isSubmitting={variantUpdate.state.type === 'submitting'}
+      serverError={
+        variantUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       isMaterialSheetOpen={variantUpdate.isMaterialSheetOpen}
       onMaterialSheetOpenChange={variantUpdate.onMaterialSheetOpenChange}

--- a/libs/ui/src/presentation/screens/VariantUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/VariantUpdateScreen.tsx
@@ -39,6 +39,7 @@ export type VariantUpdateScreenProps = {
     totalItem: number;
     variant: MaterialListProps['variant'];
   };
+  serverError?: string;
 };
 
 export const VariantUpdateScreen = (props: VariantUpdateScreenProps) => {
@@ -60,6 +61,7 @@ export const VariantUpdateScreen = (props: VariantUpdateScreenProps) => {
           variant={props.variant}
           onRetryButtonPress={props.onRetryButtonPress}
           product={props.product}
+          serverError={props.serverError}
           MaterialList={(fieldArray) => (
             <MaterialList
               isSearchAutoFocus

--- a/libs/ui/src/presentation/screens/WalletCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/WalletCreateHandler.test.tsx
@@ -139,4 +139,25 @@ describe('WalletCreateHandler', () => {
       expect(mockToastShow).toHaveBeenCalledWith('Create Wallet Error');
     });
   });
+
+  describe('error banner', () => {
+    it('should show error banner when creation fails', async () => {
+      const user = userEvent.setup();
+      render(<WalletCreateHandler {...createProps({ shouldFail: true })} />);
+
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Wallet');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<WalletCreateHandler {...createProps()} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/WalletCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/WalletCreateHandler.tsx
@@ -35,6 +35,11 @@ export const WalletCreateHandler = ({
         walletCreate.state.type === 'submitSuccess'
       }
       isSubmitting={walletCreate.state.type === 'submitting'}
+      serverError={
+        walletCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
     />
   );

--- a/libs/ui/src/presentation/screens/WalletCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/WalletCreateScreen.tsx
@@ -9,6 +9,7 @@ export type WalletCreateScreenProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   onLogoutPress: () => void;
+  serverError?: string;
 };
 
 export const WalletCreateScreen = (props: WalletCreateScreenProps) => {
@@ -21,6 +22,7 @@ export const WalletCreateScreen = (props: WalletCreateScreenProps) => {
           isSubmitDisabled={props.isSubmitDisabled}
           isSubmitting={props.isSubmitting}
           variant={{ type: 'loaded' }}
+          serverError={props.serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/WalletTransferCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferCreateHandler.test.tsx
@@ -162,4 +162,44 @@ describe('WalletTransferCreateHandler', () => {
       });
     });
   });
+
+  describe('error banner', () => {
+    it('should show error banner when transfer fails', async () => {
+      const user = userEvent.setup();
+      const walletRepo = new MockWalletRepository();
+      const preloadedWallets = walletRepo.wallets;
+      walletRepo.setShouldFail(true);
+
+      render(
+        <WalletTransferCreateHandler
+          walletId={1}
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          walletTransferCreateUsecase={new WalletTransferCreateUsecase(walletRepo, {
+            fromWalletId: 1,
+            wallets: preloadedWallets,
+          })}
+        />
+      );
+
+      await user.click(screen.getByRole('option', { name: 'Bank Transfer' }));
+      const amountInput = screen.getByRole('textbox', { name: 'Amount' });
+      await user.clear(amountInput);
+      await user.type(amountInput, '50000');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', async () => {
+      render(<WalletTransferCreateHandler {...createProps({ preloaded: true, walletId: 1 })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+      await act(async () => {
+        await flushPromises();
+      });
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/WalletTransferCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferCreateHandler.tsx
@@ -37,6 +37,11 @@ export const WalletTransferCreateHandler = ({
       }
       isSubmitDisabled={walletTransferCreate.state.type === 'submitting'}
       isSubmitting={walletTransferCreate.state.type === 'submitting'}
+      serverError={
+        walletTransferCreate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       walletSelectOptions={walletTransferCreate.state.wallets
         .filter(

--- a/libs/ui/src/presentation/screens/WalletTransferCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferCreateScreen.tsx
@@ -10,6 +10,7 @@ export type WalletTransferCreateScreenProps = {
   isSubmitting: boolean;
   onLogoutPress: () => void;
   walletSelectOptions: Array<{ label: string; value: number }>;
+  serverError?: string;
 };
 
 export const WalletTransferCreateScreen = (props: WalletTransferCreateScreenProps) => {
@@ -22,6 +23,7 @@ export const WalletTransferCreateScreen = (props: WalletTransferCreateScreenProp
           isSubmitDisabled={props.isSubmitDisabled}
           isSubmitting={props.isSubmitting}
           walletSelectOptions={props.walletSelectOptions}
+          serverError={props.serverError}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/WalletUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/WalletUpdateHandler.test.tsx
@@ -201,4 +201,40 @@ describe('WalletUpdateHandler', () => {
       expect(mockToastShow).toHaveBeenCalledWith('Update Wallet Error');
     });
   });
+
+  describe('error banner', () => {
+    it('should show error banner when update fails', async () => {
+      const user = userEvent.setup();
+      const walletRepo = new MockWalletRepository();
+      const preloadedWallet = walletRepo.wallets[0];
+      const walletUpdateUsecase = new WalletUpdateUsecase(walletRepo, {
+        walletId: preloadedWallet.id,
+        wallet: preloadedWallet,
+      });
+      walletRepo.setShouldFail(true);
+
+      render(
+        <WalletUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          walletUpdateUsecase={walletUpdateUsecase}
+        />
+      );
+
+      const nameInput = screen.getByRole('textbox', { name: 'Name' });
+      await user.clear(nameInput);
+      await user.type(nameInput, 'Updated Wallet');
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Failed to submit. Please try again.')).toBeTruthy();
+    });
+
+    it('should not show error banner before any submission', () => {
+      render(<WalletUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.queryByText('Failed to submit. Please try again.')).toBeNull();
+    });
+  });
 });

--- a/libs/ui/src/presentation/screens/WalletUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/WalletUpdateHandler.tsx
@@ -35,6 +35,11 @@ export const WalletUpdateHandler = ({
         walletUpdate.state.type === 'submitSuccess'
       }
       isSubmitting={walletUpdate.state.type === 'submitting'}
+      serverError={
+        walletUpdate.state.type === 'submitError'
+          ? 'Failed to submit. Please try again.'
+          : undefined
+      }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       variant={walletUpdate.variant}
     />

--- a/libs/ui/src/presentation/screens/WalletUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/WalletUpdateScreen.tsx
@@ -11,6 +11,7 @@ export type WalletUpdateScreenProps = {
   isSubmitting: boolean;
   onLogoutPress: () => void;
   variant: WalletFormViewProps['variant'];
+  serverError?: string;
 };
 
 export const WalletUpdateScreen = (props: WalletUpdateScreenProps) => {
@@ -23,6 +24,7 @@ export const WalletUpdateScreen = (props: WalletUpdateScreenProps) => {
           isSubmitDisabled={props.isSubmitDisabled}
           isSubmitting={props.isSubmitting}
           variant={props.variant}
+          serverError={props.serverError}
         />
       </ScrollView>
     </Layout>


### PR DESCRIPTION
## Summary
This PR introduces a reusable `FormErrorBanner` component and integrates it across all form handlers to display submission errors to users. The component provides consistent error messaging when form submissions fail.

## Key Changes

- **New Component**: Created `FormErrorBanner` component that displays error messages with an alert icon in a styled banner
- **Integration**: Added `serverError` prop to all screen/handler components to support error state management
- **Form Views**: Updated all form view components to import and render the `FormErrorBanner` component
- **Handlers**: Modified all handler components to pass error state from controllers to their corresponding screen components
- **Tests**: Added comprehensive test coverage for error banner display across 24+ handler test files, verifying:
  - Error banner displays when submission fails
  - Error banner does not show before any submission attempt

## Implementation Details

The `FormErrorBanner` component:
- Conditionally renders only when a message is provided
- Uses Tamagui's `XStack` and `Paragraph` components for styling
- Displays an alert icon from `@tamagui/lucide-icons`
- Applies red color scheme (`$red2` background, `$red10` text/icon)

All form handlers now follow a consistent pattern:
- Extract error state from their respective controllers
- Pass `serverError` prop to screen components
- Screen components pass error to form views
- Form views render the `FormErrorBanner` at the top of the form

Affected handlers: AuthLogin, Calculation (Create/Update), Category (Create/Update), Checklist (Session/Template), Coupon (Create/Update), Expense (Create/Update), Material (Create/Update), Product (Create/Update), Rental (Checkin/Checkout), Supplier (Create/Update), Transaction (Create/Update), Variant (Create/Update), Wallet (Create/Update/Transfer)

https://claude.ai/code/session_019EBWVCyXhHR6QtHmJKs3A1