### PR TITLE
Replace loading text with skeleton loaders across list screens

### DIFF
--- a/libs/ui/src/presentation/components/base/SkeletonView.tsx
+++ b/libs/ui/src/presentation/components/base/SkeletonView.tsx
@@ -1,0 +1,28 @@
+import { Card, XStack, YStack } from 'tamagui';
+
+export const SkeletonCard = () => (
+  <Card animation="slow" opacity={0.5} enterStyle={{ opacity: 0.3 }}>
+    <YStack gap="$2" padding="$3">
+      <XStack
+        height={16}
+        backgroundColor="$gray5"
+        borderRadius="$2"
+        width="60%"
+      />
+      <XStack
+        height={12}
+        backgroundColor="$gray4"
+        borderRadius="$2"
+        width="40%"
+      />
+    </YStack>
+  </Card>
+);
+
+export const SkeletonList = ({ count = 5 }: { count?: number }) => (
+  <YStack gap="$3" testID="skeleton-list">
+    {Array.from({ length: count }).map((_, i) => (
+      <SkeletonCard key={i} />
+    ))}
+  </YStack>
+);

--- a/libs/ui/src/presentation/components/base/index.tsx
+++ b/libs/ui/src/presentation/components/base/index.tsx
@@ -13,3 +13,4 @@ export * from './Chart';
 export * from './Markdown';
 export * from './Tabs';
 export * from './ConfirmationAlert';
+export * from './SkeletonView';

--- a/libs/ui/src/presentation/components/budgets/BudgetList.tsx
+++ b/libs/ui/src/presentation/components/budgets/BudgetList.tsx
@@ -1,11 +1,12 @@
-import { YStack } from 'tamagui';
+import { Spinner, YStack } from 'tamagui';
 import { BudgetListItem, BudgetListItemProps } from './BudgetListItem';
-import { EmptyView, ErrorView, LoadingView } from '../base';
+import { EmptyView, ErrorView, SkeletonList } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
 
 export type BudgetListProps = {
   onRetryButtonPress: () => void;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -15,14 +16,14 @@ export type BudgetListProps = {
 
 export const BudgetList = ({
   onRetryButtonPress,
+  isRevalidating,
   variant,
 }: BudgetListProps) => {
   return (
     <YStack gap="$3" flex={1}>
+      {isRevalidating && <Spinner size="small" alignSelf="flex-end" />}
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Budgets..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Budget is Empty"

--- a/libs/ui/src/presentation/components/calculations/CalculationList.tsx
+++ b/libs/ui/src/presentation/components/calculations/CalculationList.tsx
@@ -1,5 +1,5 @@
-import { EmptyView, ErrorView, LoadingView } from '../base';
-import { YStack } from 'tamagui';
+import { EmptyView, ErrorView, SkeletonList } from '../base';
+import { Spinner, YStack } from 'tamagui';
 import { FlatList } from 'react-native';
 import { CalculationListItem } from './CalculationListItem';
 import { Calculation } from '../../../domain';
@@ -10,6 +10,7 @@ export type CalculationListProps = {
   onDeleteMenuPress: (calculation: Calculation) => void;
   onCompleteMenuPress: (calculation: Calculation) => void;
   onItemPress: (calculation: Calculation) => void;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -22,12 +23,14 @@ export const CalculationList = ({
   onEditMenuPress,
   onCompleteMenuPress,
   onItemPress,
+  isRevalidating,
   variant,
 }: CalculationListProps) => {
   return (
     <YStack gap="$3" flex={1}>
+      {isRevalidating && <Spinner size="small" alignSelf="flex-end" />}
       {variant.type === 'loading' ? (
-        <LoadingView title="Fetching Calculations..." />
+        <SkeletonList />
       ) : variant.type === 'loaded' ? (
         variant.items.length > 0 ? (
           <FlatList

--- a/libs/ui/src/presentation/components/categories/CategoryList.tsx
+++ b/libs/ui/src/presentation/components/categories/CategoryList.tsx
@@ -1,6 +1,6 @@
-import { YStack } from 'tamagui';
+import { Spinner, YStack } from 'tamagui';
 import { CategoryListItem } from './CategoryListItem';
-import { EmptyView, ErrorView, LoadingView } from '../base';
+import { EmptyView, ErrorView, SkeletonList } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
 import { Category } from '../../../domain';
@@ -10,6 +10,7 @@ export type CategoryListProps = {
   onDeleteMenuPress: (category: Category) => void;
   onEditMenuPress: (category: Category) => void;
   onItemPress: (category: Category) => void;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -22,14 +23,14 @@ export const CategoryList = ({
   onDeleteMenuPress,
   onEditMenuPress,
   onItemPress,
+  isRevalidating,
   variant,
 }: CategoryListProps) => {
   return (
     <YStack gap="$3" flex={1}>
+      {isRevalidating && <Spinner size="small" alignSelf="flex-end" />}
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Categories..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Category is Empty"

--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionList.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionList.tsx
@@ -1,5 +1,5 @@
-import { Select, XStack, YStack } from 'tamagui';
-import { EmptyView, ErrorView, ListItem, LoadingView, Pagination } from '../base';
+import { Select, Spinner, XStack, YStack } from 'tamagui';
+import { EmptyView, ErrorView, ListItem, Pagination, SkeletonList } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
 import { CheckCircle, Clock, Filter } from '@tamagui/lucide-icons';
@@ -14,6 +14,7 @@ export type ChecklistSessionListProps = {
   currentPage: number;
   totalItem: number;
   itemPerPage: number;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -43,11 +44,11 @@ export const ChecklistSessionList = ({
   totalItem,
   currentPage,
   itemPerPage,
+  isRevalidating,
   variant,
 }: ChecklistSessionListProps) => {
   return (
     <YStack gap="$3" flex={1}>
-      {/* Filter Controls */}
       <XStack gap="$2" alignItems="center" flexWrap="wrap">
         <Filter size="$1" color="$gray10" />
         <Select
@@ -81,12 +82,11 @@ export const ChecklistSessionList = ({
             <Select.ScrollDownButton />
           </Select.Content>
         </Select>
+        {isRevalidating && <Spinner size="small" color="$gray10" marginLeft="auto" />}
       </XStack>
 
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Checklist Sessions..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Checklist Sessions is Empty"

--- a/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateList.tsx
+++ b/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateList.tsx
@@ -1,6 +1,6 @@
-import { Input, YStack } from 'tamagui';
+import { Input, Spinner, XStack, YStack } from 'tamagui';
 import { ChecklistTemplateListItem } from './ChecklistTemplateListItem';
-import { EmptyView, ErrorView, LoadingView, Pagination } from '../base';
+import { EmptyView, ErrorView, Pagination, SkeletonList } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
 import { ChecklistTemplate } from '../../../domain';
@@ -17,6 +17,7 @@ export type ChecklistTemplateListProps = {
   currentPage: number;
   totalItem: number;
   itemPerPage: number;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -36,23 +37,24 @@ export const ChecklistTemplateList = ({
   totalItem,
   currentPage,
   itemPerPage,
+  isRevalidating,
   variant,
 }: ChecklistTemplateListProps) => {
   return (
     <YStack gap="$3" flex={1}>
-      <YStack>
+      <XStack alignItems="center" gap="$2">
         <Input
           placeholder="Search Checklist Templates by Name"
           value={searchValue}
           onChangeText={onSearchValueChange}
           autoFocus={isSearchAutoFocus}
+          flex={1}
         />
-      </YStack>
+        {isRevalidating && <Spinner size="small" color="$gray10" />}
+      </XStack>
 
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Checklist Templates..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Checklist Template is Empty"

--- a/libs/ui/src/presentation/components/coupons/CouponList.tsx
+++ b/libs/ui/src/presentation/components/coupons/CouponList.tsx
@@ -1,6 +1,6 @@
-import { YStack } from 'tamagui';
+import { Spinner, YStack } from 'tamagui';
 import { CouponListItem } from './CouponListItem';
-import { EmptyView, ErrorView, LoadingView } from '../base';
+import { EmptyView, ErrorView, SkeletonList } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
 import { Coupon } from '../../../domain';
@@ -10,6 +10,7 @@ export type CouponListProps = {
   onDeleteMenuPress?: (coupon: Coupon) => void;
   onEditMenuPress?: (coupon: Coupon) => void;
   onItemPress: (coupon: Coupon) => void;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -22,14 +23,14 @@ export const CouponList = ({
   onDeleteMenuPress,
   onEditMenuPress,
   onItemPress,
+  isRevalidating,
   variant,
 }: CouponListProps) => {
   return (
     <YStack gap="$3" flex={1}>
+      {isRevalidating && <Spinner size="small" alignSelf="flex-end" />}
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Coupons..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Coupon is Empty"

--- a/libs/ui/src/presentation/components/expenses/ExpenseList.tsx
+++ b/libs/ui/src/presentation/components/expenses/ExpenseList.tsx
@@ -1,4 +1,4 @@
-import { EmptyView, ErrorView, LoadingView, Pagination } from '../base';
+import { EmptyView, ErrorView, Pagination, SkeletonList } from '../base';
 import {
   Button,
   Input,
@@ -7,6 +7,7 @@ import {
   Popover,
   RadioGroup,
   Separator,
+  Spinner,
   XStack,
   YStack,
 } from 'tamagui';
@@ -34,6 +35,7 @@ export type ExpenseListProps = {
   budgets: Budget[];
   budgetId: number | null;
   onBudgetIdChange: (budgetId: number | null) => void;
+  isRevalidating?: boolean;
 };
 
 export const ExpenseList = ({
@@ -55,6 +57,7 @@ export const ExpenseList = ({
   onEditMenuPress,
   onItemPress,
   variant,
+  isRevalidating,
 }: ExpenseListProps) => {
   return (
     <YStack gap="$3" flex={1}>
@@ -168,9 +171,11 @@ export const ExpenseList = ({
             </YStack>
           </Popover.Content>
         </Popover>
+
+        {isRevalidating && <Spinner size="small" color="$gray10" />}
       </XStack>
       {variant.type === 'loading' ? (
-        <LoadingView title="Fetching Expenses..." />
+        <SkeletonList />
       ) : variant.type === 'loaded' ? (
         expenses.length > 0 ? (
           <>

--- a/libs/ui/src/presentation/components/materials/MaterialList.tsx
+++ b/libs/ui/src/presentation/components/materials/MaterialList.tsx
@@ -1,6 +1,6 @@
-import { Input, YStack } from 'tamagui';
+import { Input, Spinner, XStack, YStack } from 'tamagui';
 import { MaterialListItem } from './MaterialListItem';
-import { EmptyView, ErrorView, LoadingView, Pagination } from '../base';
+import { EmptyView, ErrorView, Pagination, SkeletonList } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
 import { Material } from '../../../domain';
@@ -17,6 +17,7 @@ export type MaterialListProps = {
   currentPage: number;
   totalItem: number;
   itemPerPage: number;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -36,23 +37,24 @@ export const MaterialList = ({
   totalItem,
   currentPage,
   itemPerPage,
+  isRevalidating,
   variant,
 }: MaterialListProps) => {
   return (
     <YStack gap="$3" flex={1}>
-      <YStack>
+      <XStack alignItems="center" gap="$2">
         <Input
           placeholder="Search Materials by Name"
           value={searchValue}
           onChangeText={onSearchValueChange}
           autoFocus={isSearchAutoFocus}
+          flex={1}
         />
-      </YStack>
+        {isRevalidating && <Spinner size="small" color="$gray10" />}
+      </XStack>
 
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Materials..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Material is Empty"

--- a/libs/ui/src/presentation/components/products/ProductList.tsx
+++ b/libs/ui/src/presentation/components/products/ProductList.tsx
@@ -5,6 +5,7 @@ import {
   Paragraph,
   Popover,
   RadioGroup,
+  Spinner,
   XStack,
   YStack,
 } from 'tamagui';
@@ -13,8 +14,8 @@ import {
   EmptyView,
   ErrorView,
   Focusable,
-  LoadingView,
   Pagination,
+  SkeletonList,
 } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
@@ -35,6 +36,7 @@ export type ProductListProps = {
   currentPage: number;
   totalItem: number;
   itemPerPage: number;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -57,6 +59,7 @@ export const ProductList = ({
   totalItem,
   currentPage,
   itemPerPage,
+  isRevalidating,
   variant,
   numColumns = 1,
 }: ProductListProps) => {
@@ -130,12 +133,12 @@ export const ProductList = ({
             </YStack>
           </Popover.Content>
         </Popover>
+
+        {isRevalidating && <Spinner size="small" color="$gray10" />}
       </XStack>
 
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Products..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Product is Empty"

--- a/libs/ui/src/presentation/components/rentals/RentalList.tsx
+++ b/libs/ui/src/presentation/components/rentals/RentalList.tsx
@@ -1,17 +1,18 @@
-import { EmptyView, ErrorView, LoadingView, Pagination } from '../base';
+import { EmptyView, ErrorView, Pagination, SkeletonList } from '../base';
 import {
   Button,
   Input,
+  Label,
   Paragraph,
   Popover,
   RadioGroup,
+  Spinner,
   XStack,
   YStack,
 } from 'tamagui';
 import { FlatList, TextInput } from 'react-native';
 import { RentalListItem } from './RentalListItem';
 import { CheckoutStatus, Rental } from '../../../domain';
-import { Label } from 'tamagui';
 import { Filter, X } from '@tamagui/lucide-icons';
 import { useRef } from 'react';
 
@@ -30,6 +31,7 @@ export type RentalListProps = {
   onDeleteMenuPress?: (rental: Rental) => void;
   onItemPress?: (rental: Rental) => void;
   isSearchAutoFocus?: boolean;
+  isRevalidating?: boolean;
 };
 
 export const RentalList = ({
@@ -47,6 +49,7 @@ export const RentalList = ({
   onDeleteMenuPress,
   onItemPress,
   isSearchAutoFocus,
+  isRevalidating,
 }: RentalListProps) => {
   const textInputRef = useRef<TextInput>(null);
   return (
@@ -138,9 +141,11 @@ export const RentalList = ({
             </YStack>
           </Popover.Content>
         </Popover>
+
+        {isRevalidating && <Spinner size="small" color="$gray10" />}
       </XStack>
       {variant.type === 'loading' ? (
-        <LoadingView title="Fetching Rentals..." />
+        <SkeletonList />
       ) : variant.type === 'loaded' ? (
         rentals.length > 0 ? (
           <>

--- a/libs/ui/src/presentation/components/suppliers/SupplierList.tsx
+++ b/libs/ui/src/presentation/components/suppliers/SupplierList.tsx
@@ -1,6 +1,6 @@
-import { Input, YStack } from 'tamagui';
+import { Input, Spinner, XStack, YStack } from 'tamagui';
 import { SupplierListItem } from './SupplierListItem';
-import { EmptyView, ErrorView, LoadingView, Pagination } from '../base';
+import { EmptyView, ErrorView, Pagination, SkeletonList } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
 import { Supplier } from '../../../domain';
@@ -18,6 +18,7 @@ export type SupplierListProps = {
   currentPage: number;
   totalItem: number;
   itemPerPage: number;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -38,23 +39,24 @@ export const SupplierList = ({
   totalItem,
   currentPage,
   itemPerPage,
+  isRevalidating,
   variant,
 }: SupplierListProps) => {
   return (
     <YStack gap="$3" flex={1}>
-      <YStack>
+      <XStack alignItems="center" gap="$2">
         <Input
           placeholder="Search Suppliers by Name"
           value={searchValue}
           onChangeText={onSearchValueChange}
           autoFocus={isSearchAutoFocus}
+          flex={1}
         />
-      </YStack>
+        {isRevalidating && <Spinner size="small" color="$gray10" />}
+      </XStack>
 
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Suppliers..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Supplier is Empty"

--- a/libs/ui/src/presentation/components/transactions/TransactionList.tsx
+++ b/libs/ui/src/presentation/components/transactions/TransactionList.tsx
@@ -1,18 +1,19 @@
-import { EmptyView, ErrorView, LoadingView, Pagination } from '../base';
+import { EmptyView, ErrorView, Pagination, SkeletonList } from '../base';
 import {
   Button,
   Input,
+  Label,
   Paragraph,
   Popover,
   RadioGroup,
   Separator,
+  Spinner,
   XStack,
   YStack,
 } from 'tamagui';
 import { FlatList } from 'react-native';
 import { TransactionListItem } from './TransactionListItem';
 import { PaymentStatus, Transaction, Wallet } from '../../../domain';
-import { Label } from 'tamagui';
 import { Filter } from '@tamagui/lucide-icons';
 
 export type TransactionListProps = {
@@ -37,6 +38,7 @@ export type TransactionListProps = {
   wallets: Wallet[];
   walletId: number | null;
   onWalletIdChange: (walletId: number | null) => void;
+  isRevalidating?: boolean;
 };
 
 export const TransactionList = ({
@@ -61,6 +63,7 @@ export const TransactionList = ({
   wallets,
   walletId,
   onWalletIdChange,
+  isRevalidating,
 }: TransactionListProps) => {
   return (
     <YStack gap="$3" flex={1}>
@@ -172,9 +175,11 @@ export const TransactionList = ({
             </YStack>
           </Popover.Content>
         </Popover>
+
+        {isRevalidating && <Spinner size="small" color="$gray10" />}
       </XStack>
       {variant.type === 'loading' ? (
-        <LoadingView title="Fetching Transactions..." />
+        <SkeletonList />
       ) : variant.type === 'loaded' ? (
         transactions.length > 0 ? (
           <>

--- a/libs/ui/src/presentation/components/variants/VariantList.tsx
+++ b/libs/ui/src/presentation/components/variants/VariantList.tsx
@@ -1,11 +1,11 @@
-import { Input, YStack } from 'tamagui';
+import { Input, Spinner, XStack, YStack } from 'tamagui';
 import { VariantListItem } from './VariantListItem';
 import {
   EmptyView,
   ErrorView,
   Focusable,
-  LoadingView,
   Pagination,
+  SkeletonList,
 } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
@@ -23,6 +23,7 @@ export type VariantListProps = {
   currentPage: number;
   totalItem: number;
   itemPerPage: number;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -43,24 +44,25 @@ export const VariantList = ({
   totalItem,
   currentPage,
   itemPerPage,
+  isRevalidating,
   variant,
   numColumns = 1,
 }: VariantListProps) => {
   return (
     <YStack gap="$3" flex={1}>
-      <YStack>
+      <XStack alignItems="center" gap="$2">
         <Input
           placeholder="Search Variants by Name"
           value={searchValue}
           onChangeText={onSearchValueChange}
           autoFocus={isSearchAutoFocus}
+          flex={1}
         />
-      </YStack>
+        {isRevalidating && <Spinner size="small" color="$gray10" />}
+      </XStack>
 
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Variants..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Variant is Empty"

--- a/libs/ui/src/presentation/components/wallets/WalletList.tsx
+++ b/libs/ui/src/presentation/components/wallets/WalletList.tsx
@@ -1,12 +1,13 @@
-import { YStack } from 'tamagui';
+import { Spinner, YStack } from 'tamagui';
 import { WalletListItem } from './WalletListItem';
-import { EmptyView, ErrorView, LoadingView } from '../base';
+import { EmptyView, ErrorView, SkeletonList } from '../base';
 import { FlatList } from 'react-native';
 import { match } from 'ts-pattern';
 import { Wallet } from '../../../domain';
 
 export type WalletListProps = {
   onRetryButtonPress: () => void;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -19,6 +20,7 @@ export type WalletListProps = {
 
 export const WalletList = ({
   onRetryButtonPress,
+  isRevalidating,
   onEditMenuPress,
   onTransferMenuPress,
   onItemPress,
@@ -26,10 +28,9 @@ export const WalletList = ({
 }: WalletListProps) => {
   return (
     <YStack gap="$3" flex={1}>
+      {isRevalidating && <Spinner size="small" alignSelf="flex-end" />}
       {match(variant)
-        .with({ type: 'loading' }, () => (
-          <LoadingView title="Fetching Wallets..." />
-        ))
+        .with({ type: 'loading' }, () => <SkeletonList />)
         .with({ type: 'empty' }, () => (
           <EmptyView
             title="Oops, Wallet is Empty"

--- a/libs/ui/src/presentation/components/wallets/WalletTransferList.tsx
+++ b/libs/ui/src/presentation/components/wallets/WalletTransferList.tsx
@@ -1,10 +1,11 @@
-import { YStack } from 'tamagui';
-import { EmptyView, ErrorView, LoadingView } from '../base';
+import { Spinner, YStack } from 'tamagui';
+import { EmptyView, ErrorView, SkeletonList } from '../base';
 import { FlatList } from 'react-native';
 import { WalletTransferListItem, WalletTransferListItemProps } from '..';
 
 export type WalletTransferListProps = {
   onRetryButtonPress: () => void;
+  isRevalidating?: boolean;
   variant:
     | { type: 'loading' }
     | { type: 'loaded'; items: WalletTransferListItemProps[] }
@@ -14,11 +15,13 @@ export type WalletTransferListProps = {
 export const WalletTransferList = ({
   variant,
   onRetryButtonPress,
+  isRevalidating,
 }: WalletTransferListProps) => {
   return (
     <YStack gap="$3" flex={1}>
+      {isRevalidating && <Spinner size="small" alignSelf="flex-end" />}
       {variant.type === 'loading' ? (
-        <LoadingView title="Fetching Transfer Histories..." />
+        <SkeletonList />
       ) : variant.type === 'loaded' ? (
         variant.items.length > 0 ? (
           <FlatList

--- a/libs/ui/src/presentation/screens/BudgetListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/BudgetListHandler.test.tsx
@@ -32,12 +32,22 @@ describe('BudgetListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<BudgetListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Budgets...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<BudgetListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show budget list after successful fetch', async () => {

--- a/libs/ui/src/presentation/screens/BudgetListHandler.tsx
+++ b/libs/ui/src/presentation/screens/BudgetListHandler.tsx
@@ -21,6 +21,7 @@ export const BudgetListHandler = ({
     <BudgetListScreen
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       onRetryButtonPress={() => budgetList.dispatch({ type: 'FETCH' })}
+      isRevalidating={budgetList.state.type === 'revalidating'}
       variant={match(budgetList.state)
         .returnType<BudgetListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/BudgetListScreen.tsx
+++ b/libs/ui/src/presentation/screens/BudgetListScreen.tsx
@@ -5,16 +5,18 @@ export type BudgetListScreenProps = {
   onLogoutPress: () => void;
   onRetryButtonPress: () => void;
   variant: BudgetListProps['variant'];
+  isRevalidating?: boolean;
 };
 
 export const BudgetListScreen = ({
   onLogoutPress,
   onRetryButtonPress,
   variant,
+  isRevalidating,
 }: BudgetListScreenProps) => {
   return (
     <Layout title="Budgets" onLogoutPress={onLogoutPress}>
-      <BudgetList onRetryButtonPress={onRetryButtonPress} variant={variant} />
+      <BudgetList onRetryButtonPress={onRetryButtonPress} variant={variant} isRevalidating={isRevalidating} />
     </Layout>
   );
 };

--- a/libs/ui/src/presentation/screens/CalculationListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CalculationListHandler.test.tsx
@@ -43,9 +43,9 @@ describe('CalculationListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<CalculationListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Calculations...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -74,6 +74,37 @@ describe('CalculationListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Failed to Fetch Calculations' })).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<CalculationListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+    });
+
+    it('should preserve list content during revalidation after delete', async () => {
+      const user = userEvent.setup();
+      render(<CalculationListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no calculations exist', async () => {

--- a/libs/ui/src/presentation/screens/CalculationListHandler.tsx
+++ b/libs/ui/src/presentation/screens/CalculationListHandler.tsx
@@ -81,6 +81,7 @@ export const CalculationListHandler = ({
         })
       }
       onRetryButtonPress={() => calculationList.dispatch({ type: 'FETCH' })}
+      isRevalidating={calculationList.state.type === 'revalidating'}
       variant={match(calculationList.state)
         .returnType<CalculationListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/CalculationListScreen.tsx
+++ b/libs/ui/src/presentation/screens/CalculationListScreen.tsx
@@ -18,6 +18,7 @@ export type CalculationListScreenProps = {
   onItemPress: (calculation: Calculation) => void;
   onRetryButtonPress: () => void;
   variant: CalculationListProps['variant'];
+  isRevalidating?: boolean;
 
   isDeleteModalOpen: boolean;
   isDeleteButtonDisabled: boolean;
@@ -38,6 +39,7 @@ export const CalculationListScreen = ({
   onItemPress,
   onRetryButtonPress,
   variant,
+  isRevalidating,
   isDeleteModalOpen,
   isDeleteButtonDisabled,
   onDeleteCancel,
@@ -60,6 +62,7 @@ export const CalculationListScreen = ({
       <CalculationList
         onRetryButtonPress={onRetryButtonPress}
         variant={variant}
+        isRevalidating={isRevalidating}
         onDeleteMenuPress={onDeleteMenuPress}
         onEditMenuPress={onEditMenuPress}
         onCompleteMenuPress={onCompleteMenuPress}

--- a/libs/ui/src/presentation/screens/CategoryListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryListHandler.test.tsx
@@ -40,9 +40,9 @@ describe('CategoryListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<CategoryListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Categories...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -70,6 +70,37 @@ describe('CategoryListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Failed to Fetch Categories' })).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<CategoryListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+    });
+
+    it('should preserve list content during revalidation after delete', async () => {
+      const user = userEvent.setup();
+      render(<CategoryListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no categories exist', async () => {

--- a/libs/ui/src/presentation/screens/CategoryListHandler.tsx
+++ b/libs/ui/src/presentation/screens/CategoryListHandler.tsx
@@ -56,6 +56,7 @@ export const CategoryListHandler = ({
         })
       }
       onRetryButtonPress={() => categoryList.dispatch({ type: 'FETCH' })}
+      isRevalidating={categoryList.state.type === 'revalidating'}
       variant={match(categoryList.state)
         .returnType<CategoryListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/CategoryListScreen.tsx
+++ b/libs/ui/src/presentation/screens/CategoryListScreen.tsx
@@ -16,6 +16,7 @@ export type CategoryListScreenProps = {
   onItemPress: (category: Category) => void;
   onRetryButtonPress: () => void;
   variant: CategoryListProps['variant'];
+  isRevalidating?: boolean;
   isDeleteButtonDisabled: boolean;
   isDeleteModalOpen: boolean;
   onDeleteCancel: () => void;
@@ -29,6 +30,7 @@ export const CategoryListScreen = ({
   onItemPress,
   onRetryButtonPress,
   variant,
+  isRevalidating,
   isDeleteButtonDisabled,
   isDeleteModalOpen,
   onDeleteCancel,
@@ -47,6 +49,7 @@ export const CategoryListScreen = ({
       <CategoryList
         onRetryButtonPress={onRetryButtonPress}
         variant={variant}
+        isRevalidating={isRevalidating}
         onEditMenuPress={onEditMenuPress}
         onDeleteMenuPress={onDeleteMenuPress}
         onItemPress={onItemPress}

--- a/libs/ui/src/presentation/screens/ChecklistSessionListHandler.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistSessionListHandler.tsx
@@ -57,6 +57,7 @@ export const ChecklistSessionListHandler = ({
       onRetryButtonPress={() =>
         checklistSessionList.dispatch({ type: 'FETCH' })
       }
+      isRevalidating={checklistSessionList.state.type === 'revalidating'}
       onFilterChange={(filter: ChecklistSessionListFilter) =>
         checklistSessionList.dispatch({ type: 'CHANGE_PARAMS', filter })
       }

--- a/libs/ui/src/presentation/screens/ChecklistSessionListScreen.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistSessionListScreen.tsx
@@ -23,6 +23,7 @@ export type ChecklistSessionListScreenProps = {
   onSubmit: (values: ChecklistSessionForm) => void;
   isSubmitDisabled: boolean;
   checklistTemplates: ChecklistTemplate[];
+  isRevalidating?: boolean;
 };
 
 export const ChecklistSessionListScreen = ({
@@ -40,6 +41,7 @@ export const ChecklistSessionListScreen = ({
   onSubmit,
   isSubmitDisabled,
   checklistTemplates,
+  isRevalidating,
 }: ChecklistSessionListScreenProps) => {
   return (
     <Layout
@@ -68,6 +70,7 @@ export const ChecklistSessionListScreen = ({
             currentPage={currentPage}
             totalItem={totalItem}
             itemPerPage={itemPerPage}
+            isRevalidating={isRevalidating}
           />
         </YStack>
       </ScrollView>

--- a/libs/ui/src/presentation/screens/ChecklistTemplateListHandler.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistTemplateListHandler.tsx
@@ -65,6 +65,7 @@ export const ChecklistTemplateListHandler = ({
       onRetryButtonPress={() =>
         checklistTemplateList.dispatch({ type: 'FETCH' })
       }
+      isRevalidating={checklistTemplateList.state.type === 'revalidating'}
       variant={match(checklistTemplateList.state)
         .returnType<ChecklistTemplateListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({

--- a/libs/ui/src/presentation/screens/ChecklistTemplateListScreen.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistTemplateListScreen.tsx
@@ -30,6 +30,7 @@ export type ChecklistTemplateListScreenProps = {
   isDeleteButtonDisabled: boolean;
   onDeleteCancel: () => void;
   onDeleteConfirm: () => void;
+  isRevalidating?: boolean;
 };
 
 export const ChecklistTemplateListScreen = ({
@@ -50,6 +51,7 @@ export const ChecklistTemplateListScreen = ({
   isDeleteButtonDisabled,
   onDeleteCancel,
   onDeleteConfirm,
+  isRevalidating,
 }: ChecklistTemplateListScreenProps) => {
   return (
     <Layout
@@ -73,6 +75,7 @@ export const ChecklistTemplateListScreen = ({
         currentPage={currentPage}
         totalItem={totalItem}
         itemPerPage={itemPerPage}
+        isRevalidating={isRevalidating}
       />
       <ChecklistTemplateDeleteAlert
         isOpen={isDeleteModalOpen}

--- a/libs/ui/src/presentation/screens/CouponListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CouponListHandler.test.tsx
@@ -40,9 +40,9 @@ describe('CouponListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<CouponListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Coupons...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -70,6 +70,37 @@ describe('CouponListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Failed to Fetch Coupons' })).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<CouponListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+    });
+
+    it('should preserve list content during revalidation after delete', async () => {
+      const user = userEvent.setup();
+      render(<CouponListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no coupons exist', async () => {

--- a/libs/ui/src/presentation/screens/CouponListHandler.tsx
+++ b/libs/ui/src/presentation/screens/CouponListHandler.tsx
@@ -52,6 +52,7 @@ export const CouponListHandler = ({
         })
       }
       onRetryButtonPress={() => couponList.dispatch({ type: 'FETCH' })}
+      isRevalidating={couponList.state.type === 'revalidating'}
       variant={match(couponList.state)
         .returnType<CouponListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/CouponListScreen.tsx
+++ b/libs/ui/src/presentation/screens/CouponListScreen.tsx
@@ -12,6 +12,7 @@ export type CouponListScreenProps = {
   onItemPress: (coupon: Coupon) => void;
   onRetryButtonPress: () => void;
   variant: CouponListProps['variant'];
+  isRevalidating?: boolean;
   isDeleteModalOpen: boolean;
   isDeleteButtonDisabled: boolean;
   onDeleteCancel: () => void;
@@ -25,6 +26,7 @@ export const CouponListScreen = ({
   onItemPress,
   onRetryButtonPress,
   variant,
+  isRevalidating,
   isDeleteModalOpen,
   isDeleteButtonDisabled,
   onDeleteCancel,
@@ -46,6 +48,7 @@ export const CouponListScreen = ({
         onEditMenuPress={onEditMenuPress}
         onItemPress={onItemPress}
         variant={variant}
+        isRevalidating={isRevalidating}
       />
       <CouponDeleteAlert
         isOpen={isDeleteModalOpen}

--- a/libs/ui/src/presentation/screens/ExpenseListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseListHandler.test.tsx
@@ -52,9 +52,9 @@ describe('ExpenseListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<ExpenseListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Expenses...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -83,6 +83,37 @@ describe('ExpenseListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Failed to Fetch Expenses' })).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<ExpenseListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+    });
+
+    it('should preserve list content during revalidation after delete', async () => {
+      const user = userEvent.setup();
+      render(<ExpenseListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no expenses exist', async () => {

--- a/libs/ui/src/presentation/screens/ExpenseListHandler.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseListHandler.tsx
@@ -56,6 +56,7 @@ export const ExpenseListHandler = ({
         })
       }
       onRetryButtonPress={() => expenseList.dispatch({ type: 'FETCH' })}
+      isRevalidating={expenseList.state.type === 'revalidating'}
       variant={match(expenseList.state)
         .returnType<ExpenseListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/ExpenseListScreen.tsx
+++ b/libs/ui/src/presentation/screens/ExpenseListScreen.tsx
@@ -33,6 +33,7 @@ export type ExpenseListScreenProps = {
   isDeleteButtonDisabled: boolean;
   onDeleteCancel: () => void;
   onDeleteButtonConfirmPress: () => void;
+  isRevalidating?: boolean;
 };
 
 export const ExpenseListScreen = ({
@@ -59,6 +60,7 @@ export const ExpenseListScreen = ({
   isDeleteButtonDisabled,
   onDeleteCancel,
   onDeleteButtonConfirmPress,
+  isRevalidating,
 }: ExpenseListScreenProps) => {
   return (
     <Layout
@@ -89,6 +91,7 @@ export const ExpenseListScreen = ({
         onDeleteMenuPress={onDeleteMenuPress}
         onEditMenuPress={onEditMenuPress}
         onItemPress={onItemPress}
+        isRevalidating={isRevalidating}
       />
       <ExpenseDeleteAlert
         isOpen={isDeleteModalOpen}

--- a/libs/ui/src/presentation/screens/MaterialListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/MaterialListHandler.test.tsx
@@ -48,9 +48,9 @@ describe('MaterialListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<MaterialListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Materials...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -78,6 +78,37 @@ describe('MaterialListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Failed to Fetch Materials' })).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<MaterialListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+    });
+
+    it('should preserve list content during revalidation after delete', async () => {
+      const user = userEvent.setup();
+      render(<MaterialListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no materials exist', async () => {

--- a/libs/ui/src/presentation/screens/MaterialListHandler.tsx
+++ b/libs/ui/src/presentation/screens/MaterialListHandler.tsx
@@ -56,6 +56,7 @@ export const MaterialListHandler = ({
         })
       }
       onRetryButtonPress={() => materialList.dispatch({ type: 'FETCH' })}
+      isRevalidating={materialList.state.type === 'revalidating'}
       variant={match(materialList.state)
         .returnType<MaterialListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/MaterialListScreen.tsx
+++ b/libs/ui/src/presentation/screens/MaterialListScreen.tsx
@@ -27,6 +27,7 @@ export type MaterialListScreenProps = {
   isDeleteButtonDisabled: boolean;
   onDeleteCancel: () => void;
   onDeleteConfirm: () => void;
+  isRevalidating?: boolean;
 };
 
 export const MaterialListScreen = ({
@@ -46,6 +47,7 @@ export const MaterialListScreen = ({
   isDeleteButtonDisabled,
   onDeleteCancel,
   onDeleteConfirm,
+  isRevalidating,
 }: MaterialListScreenProps) => {
   return (
     <Layout
@@ -69,6 +71,7 @@ export const MaterialListScreen = ({
         onEditMenuPress={onEditMenuPress}
         onDeleteMenuPress={onDeleteMenuPress}
         onItemPress={onItemPress}
+        isRevalidating={isRevalidating}
       />
       <MaterialDeleteAlert
         isOpen={isDeleteModalOpen}

--- a/libs/ui/src/presentation/screens/ProductListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/ProductListHandler.test.tsx
@@ -48,12 +48,22 @@ describe('ProductListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<ProductListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Products...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<ProductListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show product list after successful fetch', async () => {
@@ -91,6 +101,29 @@ describe('ProductListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Oops, Product is Empty' })).toBeTruthy();
+    });
+
+    it('should preserve list content during revalidation after delete', async () => {
+      const user = userEvent.setup();
+      const productRepo = new MockProductRepository();
+      render(<ProductListHandler {...createProps({ productRepo })} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+      expect(screen.getByRole('heading', { name: 'Product 2' })).toBeTruthy();
     });
   });
 

--- a/libs/ui/src/presentation/screens/ProductListHandler.tsx
+++ b/libs/ui/src/presentation/screens/ProductListHandler.tsx
@@ -63,6 +63,7 @@ export const ProductListHandler = ({
         productList.dispatch({ type: 'CHANGE_PARAMS', page })
       }
       onRetryButtonPress={() => productList.dispatch({ type: 'FETCH' })}
+      isRevalidating={productList.state.type === 'revalidating'}
       onSaleTypeChange={(saleType?: SaleType) =>
         productList.dispatch({ type: 'CHANGE_PARAMS', saleType })
       }

--- a/libs/ui/src/presentation/screens/ProductListScreen.tsx
+++ b/libs/ui/src/presentation/screens/ProductListScreen.tsx
@@ -28,6 +28,7 @@ export type ProductListScreenProps = {
   isDeleteModalOpen: boolean;
   onDeleteCancel: () => void;
   onDeleteConfirm: () => void;
+  isRevalidating?: boolean;
 };
 
 export const ProductListScreen = ({
@@ -49,6 +50,7 @@ export const ProductListScreen = ({
   searchValue,
   totalItem,
   variant,
+  isRevalidating,
 }: ProductListScreenProps) => {
   return (
     <Layout
@@ -71,6 +73,7 @@ export const ProductListScreen = ({
         searchValue={searchValue}
         totalItem={totalItem}
         variant={variant}
+        isRevalidating={isRevalidating}
         onEditMenuPress={onEditMenuPress}
         onDeleteMenuPress={onDeleteMenuPress}
         onItemPress={onItemPress}

--- a/libs/ui/src/presentation/screens/RentalListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/RentalListHandler.test.tsx
@@ -59,9 +59,9 @@ describe('RentalListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<RentalListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Rentals...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -88,6 +88,37 @@ describe('RentalListHandler', () => {
       expect(
         screen.getByRole('heading', { name: 'Failed to Fetch Rentals' })
       ).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<RentalListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+    });
+
+    it('should preserve list content during revalidation after delete', async () => {
+      const user = userEvent.setup();
+      render(<RentalListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no rentals exist', async () => {

--- a/libs/ui/src/presentation/screens/RentalListHandler.tsx
+++ b/libs/ui/src/presentation/screens/RentalListHandler.tsx
@@ -65,6 +65,7 @@ export const RentalListHandler = ({
         })
       }
       onRetryButtonPress={() => rentalList.dispatch({ type: 'FETCH' })}
+      isRevalidating={rentalList.state.type === 'revalidating'}
       variant={match(rentalList.state)
         .returnType<RentalListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({

--- a/libs/ui/src/presentation/screens/RentalListScreen.tsx
+++ b/libs/ui/src/presentation/screens/RentalListScreen.tsx
@@ -22,6 +22,7 @@ export type RentalListScreenProps = {
   isDeleteButtonDisabled: boolean;
   onDeleteCancel: () => void;
   onDeleteConfirm: () => void;
+  isRevalidating?: boolean;
 };
 
 export const RentalListScreen = ({
@@ -42,6 +43,7 @@ export const RentalListScreen = ({
   isDeleteButtonDisabled,
   onDeleteCancel,
   onDeleteConfirm,
+  isRevalidating,
 }: RentalListScreenProps) => {
   return (
     <Layout
@@ -75,6 +77,7 @@ export const RentalListScreen = ({
         itemPerPage={itemPerPage}
         onRetryButtonPress={onRetryButtonPress}
         onDeleteMenuPress={onDeleteMenuPress}
+        isRevalidating={isRevalidating}
       />
       <RentalDeleteAlert
         isOpen={isDeleteModalOpen}

--- a/libs/ui/src/presentation/screens/SupplierListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/SupplierListHandler.test.tsx
@@ -48,9 +48,9 @@ describe('SupplierListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<SupplierListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Suppliers...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -78,6 +78,37 @@ describe('SupplierListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Failed to Fetch Suppliers' })).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<SupplierListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+    });
+
+    it('should preserve list content during revalidation after delete', async () => {
+      const user = userEvent.setup();
+      render(<SupplierListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no suppliers exist', async () => {

--- a/libs/ui/src/presentation/screens/SupplierListHandler.tsx
+++ b/libs/ui/src/presentation/screens/SupplierListHandler.tsx
@@ -59,6 +59,7 @@ export const SupplierListHandler = ({
         router.push(`/suppliers/${supplier.id}`)
       }
       onRetryButtonPress={() => supplierList.dispatch({ type: 'FETCH' })}
+      isRevalidating={supplierList.state.type === 'revalidating'}
       variant={match(supplierList.state)
         .returnType<SupplierListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({

--- a/libs/ui/src/presentation/screens/SupplierListScreen.tsx
+++ b/libs/ui/src/presentation/screens/SupplierListScreen.tsx
@@ -23,6 +23,7 @@ export type SupplierListScreenProps = {
   isDeleteButtonDisabled: boolean;
   onDeleteCancel: () => void;
   onDeleteConfirm: () => void;
+  isRevalidating?: boolean;
 };
 
 export const SupplierListScreen = ({
@@ -44,6 +45,7 @@ export const SupplierListScreen = ({
   isDeleteButtonDisabled,
   onDeleteCancel,
   onDeleteConfirm,
+  isRevalidating,
 }: SupplierListScreenProps) => {
   return (
     <Layout
@@ -68,6 +70,7 @@ export const SupplierListScreen = ({
         currentPage={currentPage}
         totalItem={totalItem}
         itemPerPage={itemPerPage}
+        isRevalidating={isRevalidating}
       />
       <SupplierDeleteAlert
         isOpen={isDeleteModalOpen}

--- a/libs/ui/src/presentation/screens/TransactionListHandler.tsx
+++ b/libs/ui/src/presentation/screens/TransactionListHandler.tsx
@@ -159,6 +159,7 @@ export const TransactionListHandler = ({
         });
       }}
       onRetryButtonPress={() => transactionList.dispatch({ type: 'FETCH' })}
+      isRevalidating={transactionList.state.type === 'revalidating'}
       variant={match(transactionList.state)
         .returnType<TransactionListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/TransactionListScreen.tsx
+++ b/libs/ui/src/presentation/screens/TransactionListScreen.tsx
@@ -52,6 +52,7 @@ export type TransactionListScreenProps = {
   isUnpayButtonDisabled: boolean;
   onUnpayCancel: () => void;
   onUnpayConfirm: () => void;
+  isRevalidating?: boolean;
 };
 
 export const TransactionListScreen = ({
@@ -92,6 +93,7 @@ export const TransactionListScreen = ({
   isUnpayButtonDisabled,
   onUnpayCancel,
   onUnpayConfirm,
+  isRevalidating,
 }: TransactionListScreenProps) => {
   return (
     <Layout
@@ -125,6 +127,7 @@ export const TransactionListScreen = ({
         wallets={wallets}
         walletId={walletId}
         onWalletIdChange={onWalletIdChange}
+        isRevalidating={isRevalidating}
       />
       <TransactionDeleteAlert
         isOpen={isDeleteModalOpen}

--- a/libs/ui/src/presentation/screens/VariantListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/VariantListHandler.test.tsx
@@ -48,9 +48,9 @@ describe('VariantListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<VariantListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Variants...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -79,6 +79,37 @@ describe('VariantListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Failed to Fetch Variants' })).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<VariantListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+    });
+
+    it('should preserve list content during revalidation after delete', async () => {
+      const user = userEvent.setup();
+      render(<VariantListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const deleteMenuItems = screen.getAllByRole('button', { name: 'Delete' });
+      await user.click(deleteMenuItems[0]);
+      await user.click(screen.getByRole('button', { name: 'Yes' }));
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no variants exist', async () => {

--- a/libs/ui/src/presentation/screens/VariantListHandler.tsx
+++ b/libs/ui/src/presentation/screens/VariantListHandler.tsx
@@ -56,6 +56,7 @@ export const VariantListHandler = ({
         router.push(`/variants/${variant.id}`)
       }
       onRetryButtonPress={() => variantList.dispatch({ type: 'FETCH' })}
+      isRevalidating={variantList.state.type === 'revalidating'}
       variant={match(variantList.state)
         .returnType<VariantListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({

--- a/libs/ui/src/presentation/screens/VariantListScreen.tsx
+++ b/libs/ui/src/presentation/screens/VariantListScreen.tsx
@@ -22,6 +22,7 @@ export type VariantListScreenProps = {
   isDeleteButtonDisabled: boolean;
   onDeleteCancel: () => void;
   onDeleteConfirm: () => void;
+  isRevalidating?: boolean;
 };
 
 export const VariantListScreen = ({
@@ -42,6 +43,7 @@ export const VariantListScreen = ({
   isDeleteButtonDisabled,
   onDeleteCancel,
   onDeleteConfirm,
+  isRevalidating,
 }: VariantListScreenProps) => {
   return (
     <Layout
@@ -65,6 +67,7 @@ export const VariantListScreen = ({
         currentPage={currentPage}
         totalItem={totalItem}
         itemPerPage={itemPerPage}
+        isRevalidating={isRevalidating}
       />
       <VariantDeleteAlert
         isOpen={isDeleteModalOpen}

--- a/libs/ui/src/presentation/screens/WalletListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/WalletListHandler.test.tsx
@@ -35,9 +35,9 @@ describe('WalletListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<WalletListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Wallets...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -65,6 +65,16 @@ describe('WalletListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Failed to Fetch Wallets' })).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<WalletListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no wallets exist', async () => {

--- a/libs/ui/src/presentation/screens/WalletListHandler.tsx
+++ b/libs/ui/src/presentation/screens/WalletListHandler.tsx
@@ -34,6 +34,7 @@ export const WalletListHandler = ({
         router.push(`/wallets/${wallet.id}/transfers`)
       }
       onRetryButtonPress={() => walletList.dispatch({ type: 'FETCH' })}
+      isRevalidating={walletList.state.type === 'revalidating'}
       variant={match(walletList.state)
         .returnType<WalletListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/WalletListScreen.tsx
+++ b/libs/ui/src/presentation/screens/WalletListScreen.tsx
@@ -11,6 +11,7 @@ export type WalletListScreenProps = {
   onTransferMenuPress: (wallet: Wallet) => void;
   onRetryButtonPress: () => void;
   variant: { type: 'loading' } | { type: 'error' } | { type: 'empty' } | { type: 'loaded'; items: Wallet[] };
+  isRevalidating?: boolean;
 };
 
 export const WalletListScreen = ({
@@ -20,6 +21,7 @@ export const WalletListScreen = ({
   onTransferMenuPress,
   onRetryButtonPress,
   variant,
+  isRevalidating,
 }: WalletListScreenProps) => {
   return (
     <Layout
@@ -37,6 +39,7 @@ export const WalletListScreen = ({
         onEditMenuPress={onEditMenuPress}
         onItemPress={onItemPress}
         onTransferMenuPress={onTransferMenuPress}
+        isRevalidating={isRevalidating}
       />
     </Layout>
   );

--- a/libs/ui/src/presentation/screens/WalletTransferListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferListHandler.test.tsx
@@ -49,9 +49,9 @@ describe('WalletTransferListHandler', () => {
   });
 
   describe('loading and data states', () => {
-    it('should show loading state initially', async () => {
+    it('should show skeleton list during initial loading', async () => {
       render(<WalletTransferListHandler {...createProps()} />);
-      expect(screen.getByText('Fetching Transfer Histories...')).toBeTruthy();
+      expect(screen.getByTestId('skeleton-list')).toBeTruthy();
       await act(async () => {
         await flushPromises();
       });
@@ -86,6 +86,16 @@ describe('WalletTransferListHandler', () => {
       });
 
       expect(screen.getByRole('heading', { name: 'Failed to Fetch Transfer Histories' })).toBeTruthy();
+    });
+
+    it('should not show skeleton after data is loaded', async () => {
+      render(<WalletTransferListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.queryByTestId('skeleton-list')).toBeNull();
     });
 
     it('should show empty state when no transfers exist', async () => {

--- a/libs/ui/src/presentation/screens/WalletTransferListHandler.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferListHandler.tsx
@@ -56,6 +56,7 @@ export const WalletTransferListHandler = ({
         .with({ type: 'error' }, () => ({ type: 'error' }))
         .exhaustive()}
       onRetryButtonPress={() => walletTransfers.dispatch({ type: 'FETCH' })}
+      isRevalidating={walletTransfers.state.type === 'revalidating'}
     />
   );
 };

--- a/libs/ui/src/presentation/screens/WalletTransferListScreen.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferListScreen.tsx
@@ -16,6 +16,7 @@ export type WalletTransferListScreenProps = {
   paymentCostPercentage: number;
   variant: WalletTransferListProps['variant'];
   onRetryButtonPress: () => void;
+  isRevalidating?: boolean;
 };
 
 export const WalletTransferListScreen = ({
@@ -26,6 +27,7 @@ export const WalletTransferListScreen = ({
   paymentCostPercentage,
   variant,
   onRetryButtonPress,
+  isRevalidating,
 }: WalletTransferListScreenProps) => {
   return (
     <Layout
@@ -49,6 +51,7 @@ export const WalletTransferListScreen = ({
           <WalletTransferList
             variant={variant}
             onRetryButtonPress={onRetryButtonPress}
+            isRevalidating={isRevalidating}
           />
         </YStack>
       </YStack>


### PR DESCRIPTION
## Summary
Replaced generic loading text indicators with skeleton loaders across all list screens to provide a better visual representation of content being loaded. This improves the user experience by showing a preview of the actual list structure during initial load and revalidation.

## Key Changes

- **New SkeletonView component**: Created `SkeletonView.tsx` with `SkeletonCard` and `SkeletonList` components that display animated placeholder cards matching the list item structure
- **Updated all list components**: Modified 15+ list components (Product, Category, Coupon, Material, Supplier, Variant, Rental, Expense, Calculation, Budget, Wallet, etc.) to:
  - Replace `LoadingView` with `SkeletonList` during initial loading
  - Add `isRevalidating` prop to handle background data refresh states
  - Show skeleton loaders only during initial load, not during revalidation after delete operations
- **Updated all list handlers**: Modified corresponding handler components to pass `isRevalidating` state based on whether the list is in a revalidating state
- **Updated all list screens**: Added `isRevalidating` prop to screen component type definitions
- **Comprehensive test coverage**: Updated 12+ test files to verify:
  - Skeleton list displays during initial loading
  - Skeleton list is hidden after data loads
  - Skeleton list is not shown during revalidation after delete operations

## Implementation Details

- Skeleton loaders use Tamagui's `Card`, `XStack`, and `YStack` components with fade animations
- The `isRevalidating` state is derived from checking if the list state type is `'revalidating'`
- Skeleton loaders are only shown when variant type is `'loading'`, not during background revalidation
- All list components maintain backward compatibility with existing props and behavior

https://claude.ai/code/session_01LvvrS4sVgjeUycbhBXcuSc