### PR TITLE
Refactor: Extract migrations and seeding into separate CLI commands

### DIFF
--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -7,13 +7,13 @@ export
 DB_URL ?= mysql://$(DB_USERNAME):$(DB_PASSWORD)@tcp($(DB_HOST):$(DB_PORT))/$(DB_NAME)
 MIGRATIONS_DIR ?= migrations
 
-.PHONY: migrate-up migrate-down migrate-create migrate-version dev build test
+.PHONY: migrate-up migrate-down migrate-create migrate-version dev build build-migrate build-seed migrate seed test
 
-## migrate-up: Run all pending migrations
+## migrate-up: Run all pending migrations (via migrate CLI)
 migrate-up:
 	migrate -path $(MIGRATIONS_DIR) -database "$(DB_URL)" up
 
-## migrate-down: Rollback the last migration
+## migrate-down: Rollback the last migration (via migrate CLI)
 migrate-down:
 	migrate -path $(MIGRATIONS_DIR) -database "$(DB_URL)" down 1
 
@@ -26,13 +26,29 @@ migrate-create:
 migrate-version:
 	migrate -path $(MIGRATIONS_DIR) -database "$(DB_URL)" version
 
-## dev: Run the API in development mode (with hot reload via `go run`)
+## dev: Run the API in development mode
 dev:
 	go run main.go
 
-## build: Build the API binary
+## build: Build the API server binary
 build:
 	go build -o dist/api main.go
+
+## build-migrate: Build the migration binary
+build-migrate:
+	go build -o dist/migrate cmd/migrate/main.go
+
+## build-seed: Build the seeder binary
+build-seed:
+	go build -o dist/seed cmd/seed/main.go
+
+## migrate: Run database migrations using the Go binary
+migrate:
+	go run cmd/migrate/main.go
+
+## seed: Run database seeders using the Go binary
+seed:
+	go run cmd/seed/main.go
 
 ## test: Run all tests
 test:

--- a/apps/api/cmd/migrate/main.go
+++ b/apps/api/cmd/migrate/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"apps/api/migrations"
+	"apps/api/pkg/logger"
+	"apps/api/pkg/migrator"
+	"apps/api/utils"
+	"fmt"
+	"log/slog"
+)
+
+func main() {
+	err := utils.LoadEnv()
+
+	env := utils.GetEnv()
+
+	rootLogger := logger.New(env.ServiceName, env.AppEnv, env.LogLevel)
+	slog.SetDefault(rootLogger)
+
+	if err == nil {
+		rootLogger.Info("loaded .env file")
+	}
+
+	rootLogger.Info("running database migrations")
+	if err := migrator.Run(migrator.Params{
+		DbUsername:   env.DbUsername,
+		DbPassword:   env.DbPassword,
+		DbHost:       env.DbHost,
+		DbPort:       env.DbPort,
+		DbName:       env.DbName,
+		MigrationsFS: migrations.FS,
+	}); err != nil {
+		panic(fmt.Sprintf("failed to run migrations: %v", err))
+	}
+
+	rootLogger.Info("migrations completed successfully")
+}

--- a/apps/api/cmd/seed/main.go
+++ b/apps/api/cmd/seed/main.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"apps/api/data/mysql"
+	"apps/api/pkg/logger"
+	"apps/api/seeds"
+	"apps/api/utils"
+	"fmt"
+	"log/slog"
+)
+
+func main() {
+	err := utils.LoadEnv()
+
+	env := utils.GetEnv()
+
+	rootLogger := logger.New(env.ServiceName, env.AppEnv, env.LogLevel)
+	slog.SetDefault(rootLogger)
+
+	if err == nil {
+		rootLogger.Info("loaded .env file")
+	}
+
+	db, err := mysql.ConnectDB(mysql.ConnectDBParams{
+		DbUsername: env.DbUsername,
+		DbPassword: env.DbPassword,
+		DbHost:     env.DbHost,
+		DbPort:     env.DbPort,
+		DbName:     env.DbName,
+	})
+	if err != nil {
+		panic("failed to connect database")
+	}
+
+	rootLogger.Info("running seeders")
+	if err := seeds.RunAll(db, seeds.All()); err != nil {
+		panic(fmt.Sprintf("failed to run seeders: %v", err))
+	}
+
+	rootLogger.Info("seeders completed successfully")
+}

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -3,13 +3,9 @@ package main
 import (
 	"apps/api/data/mysql"
 	"apps/api/domain"
-	"apps/api/migrations"
 	"apps/api/pkg/logger"
-	"apps/api/pkg/migrator"
 	"apps/api/presentation/restapi"
-	"apps/api/seeds"
 	"apps/api/utils"
-	"flag"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -18,10 +14,6 @@ import (
 )
 
 func main() {
-	migrateOnly := flag.Bool("migrate-only", false, "run database migrations and exit")
-	seedFlag := flag.Bool("seed", false, "run database migrations then seeders and exit")
-	flag.Parse()
-
 	err := utils.LoadEnv()
 
 	env := utils.GetEnv()
@@ -38,24 +30,6 @@ func main() {
 		slog.String("env", env.AppEnv),
 	)
 
-	// Run database migrations before connecting the application.
-	rootLogger.Info("running database migrations")
-	if err := migrator.Run(migrator.Params{
-		DbUsername:   env.DbUsername,
-		DbPassword:   env.DbPassword,
-		DbHost:       env.DbHost,
-		DbPort:       env.DbPort,
-		DbName:       env.DbName,
-		MigrationsFS: migrations.FS,
-	}); err != nil {
-		panic(fmt.Sprintf("failed to run migrations: %v", err))
-	}
-
-	if *migrateOnly {
-		rootLogger.Info("--migrate-only flag set, exiting after migrations")
-		return
-	}
-
 	db, err := mysql.ConnectDB(mysql.ConnectDBParams{
 		DbUsername: env.DbUsername,
 		DbPassword: env.DbPassword,
@@ -65,15 +39,6 @@ func main() {
 	})
 	if err != nil {
 		panic("failed to connect database")
-	}
-
-	if *seedFlag {
-		rootLogger.Info("--seed flag set, running seeders")
-		if err := seeds.RunAll(db, seeds.All()); err != nil {
-			panic(fmt.Sprintf("failed to run seeders: %v", err))
-		}
-		rootLogger.Info("seeders completed successfully")
-		return
 	}
 
 	router := mux.NewRouter().StrictSlash(true)


### PR DESCRIPTION
## Summary
Extracted database migrations and seeding logic from the main API server into separate standalone CLI commands. This decouples these operational tasks from the server startup process, allowing them to be run independently.

## Key Changes
- **New `cmd/migrate/main.go`**: Standalone CLI command to run database migrations
- **New `cmd/seed/main.go`**: Standalone CLI command to run database seeders
- **Simplified `main.go`**: Removed migration and seeding logic, command-line flags (`--migrate-only`, `--seed`), and related imports
- **Updated `Makefile`**: 
  - Added `build-migrate` and `build-seed` targets to compile the new binaries
  - Added `migrate` and `seed` targets to run the commands via `go run`
  - Updated comments to clarify which targets use the migrate CLI vs Go binaries

## Implementation Details
- Both new commands follow the same initialization pattern: load environment variables, configure logging, and execute their respective operations
- The migration command uses the existing `migrator.Run()` function with the migrations filesystem
- The seed command uses the existing `seeds.RunAll()` function
- All three commands (API server, migrate, seed) share the same environment configuration and logging setup
- This enables cleaner separation of concerns and allows these operations to be triggered independently in deployment pipelines

https://claude.ai/code/session_01HkT9xerXKGVnBoLLMpJHAb