### PR TITLE
Refactor Sidebar to responsive drawer pattern with mobile support

### DIFF
--- a/libs/ui/src/presentation/components/base/ContentContainer.tsx
+++ b/libs/ui/src/presentation/components/base/ContentContainer.tsx
@@ -1,0 +1,12 @@
+import { YStack } from 'tamagui';
+import { ReactNode } from 'react';
+
+type ContentContainerProps = {
+  children: ReactNode;
+};
+
+export const ContentContainer = ({ children }: ContentContainerProps) => (
+  <YStack flex={1} width="100%" maxWidth={1440} alignSelf="center">
+    {children}
+  </YStack>
+);

--- a/libs/ui/src/presentation/components/base/Layout.tsx
+++ b/libs/ui/src/presentation/components/base/Layout.tsx
@@ -1,7 +1,9 @@
-import { PortalProvider, XStack, YStack } from 'tamagui';
+import { Menu } from '@tamagui/lucide-icons';
+import { Button, PortalProvider, XStack, YStack, useMedia } from 'tamagui';
 import { Sidebar } from './Sidebar';
 import { Navbar } from './Navbar/Navbar';
-import { ReactNode } from 'react';
+import { ContentContainer } from './ContentContainer';
+import { ReactNode, useEffect, useState } from 'react';
 
 export type LayoutProps = {
   children: React.ReactNode;
@@ -18,18 +20,53 @@ export const Layout = ({
   rightActionItem,
   onLogoutPress,
 }: LayoutProps) => {
+  const media = useMedia();
+  const [isSidebarShown, setIsSidebarShown] = useState(false);
+
+  // Default: open on desktop, closed on mobile/tablet
+  useEffect(() => {
+    setIsSidebarShown(!!media.gtMd);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Intentionally runs once on mount with initial media value
+
+  const onToggleSidebar = () => setIsSidebarShown((prev) => !prev);
+
+  const hamburgerButton = (
+    <Button
+      icon={Menu}
+      size="$3"
+      variant="outlined"
+      circular
+      onPress={onToggleSidebar}
+      aria-label="Toggle navigation menu"
+      data-testid="sidebar-toggle"
+    />
+  );
+
   return (
     <PortalProvider shouldAddRootHost>
       <XStack flex={1}>
-        <Sidebar onLogoutPress={onLogoutPress} />
+        <Sidebar
+          onLogoutPress={onLogoutPress}
+          isShown={isSidebarShown}
+          onToggle={onToggleSidebar}
+          onOpenChange={setIsSidebarShown}
+        />
         <YStack flex={1}>
           <Navbar
             title={title}
             showBackButton={showBackButton}
             rightActionItem={rightActionItem}
+            leftActionItem={!media.gtMd ? hamburgerButton : undefined}
           />
-          <YStack padding="$5" gap="$3" flex={1}>
-            {children}
+          <YStack
+            flex={1}
+            padding="$5"
+            $xs={{ padding: '$3' }}
+            $sm={{ padding: '$4' }}
+            gap="$3"
+          >
+            <ContentContainer>{children}</ContentContainer>
           </YStack>
         </YStack>
       </XStack>

--- a/libs/ui/src/presentation/components/base/Navbar/Navbar.tsx
+++ b/libs/ui/src/presentation/components/base/Navbar/Navbar.tsx
@@ -7,21 +7,26 @@ export type NavbarProps = {
   title: string;
   showBackButton?: boolean;
   rightActionItem?: ReactNode;
+  leftActionItem?: ReactNode;
 };
 
 export const Navbar = ({
   title,
   showBackButton,
   rightActionItem,
+  leftActionItem,
 }: NavbarProps) => {
   const { onBackButtonPress } = useNavbarState();
   return (
     <XStack
       padding="$3"
       justifyContent="space-between"
+      alignItems="center"
       backgroundColor="$gray1"
+      $xs={{ flexDirection: 'column', alignItems: 'flex-start', gap: '$2' }}
     >
-      <XStack alignItems="center" gap="$3">
+      <XStack alignItems="center" gap="$3" flex={1}>
+        {leftActionItem}
         {showBackButton && (
           <Button
             icon={ArrowLeft}
@@ -31,7 +36,9 @@ export const Navbar = ({
             size="$3"
           />
         )}
-        <H4>{title}</H4>
+        <H4 numberOfLines={1} ellipsizeMode="tail" flex={1}>
+          {title}
+        </H4>
       </XStack>
       {rightActionItem}
     </XStack>

--- a/libs/ui/src/presentation/components/base/ResponsiveStack.tsx
+++ b/libs/ui/src/presentation/components/base/ResponsiveStack.tsx
@@ -1,0 +1,8 @@
+import { XStack } from 'tamagui';
+import type { XStackProps } from 'tamagui';
+
+export type ResponsiveStackProps = XStackProps;
+
+export const ResponsiveStack = (props: ResponsiveStackProps) => (
+  <XStack flexDirection="row" $md={{ flexDirection: 'column' }} {...props} />
+);

--- a/libs/ui/src/presentation/components/base/Sidebar/Sidebar.state.tsx
+++ b/libs/ui/src/presentation/components/base/Sidebar/Sidebar.state.tsx
@@ -7,7 +7,6 @@ import {
 } from '@tamagui/lucide-icons';
 import { NamedExoticComponent, useEffect, useState } from 'react';
 import { useRouter } from 'solito/router';
-import {} from 'solito';
 
 type MenuItem = {
   title: string;
@@ -61,17 +60,14 @@ const items: MenuItem[] = [
 ];
 
 export const useSidebarState = () => {
-  const [isShown, setIsShown] = useState(true);
-
-  const onToggleButtonPress = () => setIsShown((prev) => !prev);
-
   const router = useRouter();
-
   const [accordionValue, setAccordionValue] = useState<string>();
   const [currentPath, setCurrentPath] = useState<string>();
 
   useEffect(() => {
-    setCurrentPath(window.location.pathname);
+    if (typeof window !== 'undefined') {
+      setCurrentPath(window.location.pathname);
+    }
   }, []);
 
   useEffect(() => {
@@ -89,8 +85,6 @@ export const useSidebarState = () => {
   }, [currentPath]);
 
   return {
-    isShown,
-    onToggleButtonPress,
     router,
     items,
     accordionValue,

--- a/libs/ui/src/presentation/components/base/Sidebar/Sidebar.tsx
+++ b/libs/ui/src/presentation/components/base/Sidebar/Sidebar.tsx
@@ -1,6 +1,5 @@
 import {
   ChevronDown,
-  ChevronsLeft,
   ChevronsRight,
   LogOut,
 } from '@tamagui/lucide-icons';
@@ -14,130 +13,146 @@ import {
   XStack,
   YGroup,
   YStack,
+  useMedia,
 } from 'tamagui';
 import { useSidebarState } from './Sidebar.state';
 import { Link } from 'solito/link';
+import { Sheet } from '../Sheet';
 
 export type SidebarProps = {
   onLogoutPress: () => void;
+  isShown: boolean;
+  onToggle: () => void;
+  onOpenChange: (isOpen: boolean) => void;
 };
 
 export const Sidebar = (props: SidebarProps) => {
-  const {
-    isShown,
-    onToggleButtonPress,
-    router,
-    items,
-    accordionValue,
-    setAccordionValue,
-    currentPath,
-  } = useSidebarState();
+  const { isShown, onToggle, onOpenChange } = props;
+  const media = useMedia();
+  const { router, items, accordionValue, setAccordionValue, currentPath } =
+    useSidebarState();
 
+  const sidebarContent = (
+    <YStack flex={1} backgroundColor="$gray3" justifyContent="space-between">
+      <YStack gap="$3">
+        <XStack padding="$3" paddingBottom="$0">
+          <H5>Gatherloop POS</H5>
+        </XStack>
+
+        <Accordion
+          overflow="hidden"
+          type="single"
+          value={accordionValue}
+          onValueChange={setAccordionValue}
+        >
+          {items.map((item) => (
+            <Accordion.Item value={item.title} key={item.title}>
+              <Accordion.Trigger
+                flexDirection="row"
+                justifyContent="space-between"
+                backgroundColor="$gray3"
+                onPress={(event) => {
+                  if (item.path) {
+                    event.preventDefault();
+                    router.push(item.path);
+                  }
+                }}
+              >
+                {({ open }: { open: boolean }) => (
+                  <>
+                    <XStack gap="$3">
+                      <item.icon size="$1" />
+                      <Paragraph>{item.title}</Paragraph>
+                    </XStack>
+                    {item.subItems && (
+                      <Square
+                        animation="quick"
+                        rotate={open ? '180deg' : '0deg'}
+                      >
+                        <ChevronDown size="$1" />
+                      </Square>
+                    )}
+                  </>
+                )}
+              </Accordion.Trigger>
+
+              {item.subItems && (
+                <Accordion.HeightAnimator animation="medium">
+                  <Accordion.Content
+                    animation="medium"
+                    exitStyle={{ opacity: 0 }}
+                    backgroundColor="$gray3"
+                  >
+                    {item.subItems.map((subItem, index) => (
+                      <YGroup.Item key={index}>
+                        <Link href={subItem.path}>
+                          <ListItem
+                            backgroundColor={
+                              subItem.path === currentPath
+                                ? undefined
+                                : '$colorTransparent'
+                            }
+                            hoverTheme
+                            size="$4"
+                            cursor="pointer"
+                            borderRadius="$3"
+                          >
+                            {subItem.title}
+                          </ListItem>
+                        </Link>
+                      </YGroup.Item>
+                    ))}
+                  </Accordion.Content>
+                </Accordion.HeightAnimator>
+              )}
+            </Accordion.Item>
+          ))}
+        </Accordion>
+      </YStack>
+
+      <YStack padding="$3" paddingTop="$0">
+        <Button
+          onPress={props.onLogoutPress}
+          icon={LogOut}
+          variant="outlined"
+        >
+          Logout
+        </Button>
+      </YStack>
+    </YStack>
+  );
+
+  // Mobile/tablet (md and below): off-canvas Sheet drawer
+  if (!media.gtMd) {
+    return (
+      <Sheet isOpen={isShown} onOpenChange={onOpenChange}>
+        {sidebarContent}
+      </Sheet>
+    );
+  }
+
+  // Desktop (gtMd): classic inline sidebar
   return (
     <>
       <YGroup
+        data-testid="sidebar"
+        flex={1}
         width={200}
-        $xs={{ position: 'absolute', top: 0, bottom: 0, zIndex: '$5' }}
         elevation="$1"
         backgroundColor="$gray3"
         borderRadius="$0"
+        animation="medium"
         marginLeft={isShown ? 0 : -200}
       >
-        <YStack flex={1} justifyContent="space-between">
-          <YStack gap="$3">
-            <XStack padding="$3" paddingBottom="$0">
-              <H5>Gatherloop POS</H5>
-            </XStack>
-
-            <Accordion
-              overflow="hidden"
-              type="single"
-              value={accordionValue}
-              onValueChange={setAccordionValue}
-            >
-              {items.map((item) => (
-                <Accordion.Item value={item.title} key={item.title}>
-                  <Accordion.Trigger
-                    flexDirection="row"
-                    justifyContent="space-between"
-                    backgroundColor={'$gray3'}
-                    onPress={(event) => {
-                      if (item.path) {
-                        event.preventDefault();
-                        router.push(item.path);
-                      }
-                    }}
-                  >
-                    {({ open }: { open: boolean }) => (
-                      <>
-                        <XStack gap="$3">
-                          <item.icon size="$1" />
-                          <Paragraph>{item.title}</Paragraph>
-                        </XStack>
-                        {item.subItems && (
-                          <Square
-                            animation="quick"
-                            rotate={open ? '180deg' : '0deg'}
-                          >
-                            <ChevronDown size="$1" />
-                          </Square>
-                        )}
-                      </>
-                    )}
-                  </Accordion.Trigger>
-
-                  {item.subItems && (
-                    <Accordion.HeightAnimator animation="medium">
-                      <Accordion.Content
-                        animation="medium"
-                        exitStyle={{ opacity: 0 }}
-                        backgroundColor="$gray3"
-                      >
-                        {item.subItems.map((subItem, index) => (
-                          <YGroup.Item key={index}>
-                            <Link href={subItem.path}>
-                              <ListItem
-                                backgroundColor={
-                                  subItem.path === currentPath
-                                    ? undefined
-                                    : '$colorTransparent'
-                                }
-                                hoverTheme
-                                size="$4"
-                                cursor="pointer"
-                                borderRadius="$3"
-                              >
-                                {subItem.title}
-                              </ListItem>
-                            </Link>
-                          </YGroup.Item>
-                        ))}
-                      </Accordion.Content>
-                    </Accordion.HeightAnimator>
-                  )}
-                </Accordion.Item>
-              ))}
-            </Accordion>
-          </YStack>
-
-          <YStack padding="$3" paddingTop="$0">
-            <Button
-              onPress={props.onLogoutPress}
-              icon={LogOut}
-              variant="outlined"
-            >
-              Logout
-            </Button>
-          </YStack>
-        </YStack>
+        {sidebarContent}
       </YGroup>
 
       {!isShown && (
         <Button
-          icon={isShown ? ChevronsLeft : ChevronsRight}
-          onPress={onToggleButtonPress}
+          icon={ChevronsRight}
+          onPress={onToggle}
           position="absolute"
-          left={isShown ? 200 : 0}
+          left={0}
           zIndex={999}
           animation="fast"
           size="$3"
@@ -146,7 +161,7 @@ export const Sidebar = (props: SidebarProps) => {
           bottom="$20"
           borderWidth="$0"
           theme="blue"
-        ></Button>
+        />
       )}
     </>
   );

--- a/libs/ui/src/presentation/components/base/index.tsx
+++ b/libs/ui/src/presentation/components/base/index.tsx
@@ -14,3 +14,5 @@ export * from './Markdown';
 export * from './Tabs';
 export * from './ConfirmationAlert';
 export * from './SkeletonView';
+export * from './ContentContainer';
+export * from './ResponsiveStack';


### PR DESCRIPTION
## Summary
Refactored the Sidebar component to support responsive layouts with a mobile-first approach. On mobile/tablet devices, the sidebar now renders as an off-canvas Sheet drawer, while desktop maintains the classic inline sidebar. Updated the Layout component to manage sidebar state and added responsive utilities.

## Key Changes

- **Sidebar Component Refactoring**
  - Moved sidebar state management (`isShown`, `onToggle`) from internal hook to parent Layout component via props
  - Extracted sidebar content into reusable `sidebarContent` variable to avoid duplication
  - Added responsive rendering: Sheet drawer for mobile/tablet (≤md), inline sidebar for desktop (>md)
  - Removed `ChevronsLeft` icon import and simplified toggle button logic
  - Added `useMedia()` hook for responsive breakpoint detection
  - Improved accessibility with `data-testid` attributes

- **Layout Component Enhancement**
  - Added sidebar state management with `useState` and `useEffect`
  - Sidebar defaults to open on desktop, closed on mobile/tablet
  - Added hamburger menu button (Menu icon) that appears only on mobile/tablet
  - Passed hamburger button as `leftActionItem` to Navbar
  - Wrapped children in new `ContentContainer` component for max-width constraint
  - Added responsive padding adjustments ($xs, $sm breakpoints)

- **Navbar Component Updates**
  - Added `leftActionItem` prop to support hamburger menu button
  - Improved responsive layout with flex direction change on mobile
  - Added text truncation to title with `numberOfLines` and `ellipsizeMode`
  - Better alignment and spacing for mobile views

- **New Components**
  - `ContentContainer`: Centers content with max-width (1440px) constraint
  - `ResponsiveStack`: Responsive XStack that switches to column layout on medium screens

- **Sidebar State Hook Cleanup**
  - Removed `isShown` and `onToggleButtonPress` from `useSidebarState`
  - Added SSR safety check for `window` object access
  - Removed unused import

## Implementation Details

The responsive behavior uses Tamagui's `useMedia()` hook to detect breakpoints:
- **Mobile/Tablet (≤md)**: Sidebar renders as a Sheet drawer overlay, toggled by hamburger menu
- **Desktop (>md)**: Sidebar renders as a fixed inline component with slide animation

State is managed at the Layout level to coordinate sidebar visibility across the entire layout, ensuring consistent behavior across all child components.

https://claude.ai/code/session_01R25cNRQMhafRu4VQ7njNFL