### PR TITLE
Add print invoice/order slip flow on transaction creation cancel

### DIFF
--- a/libs/ui/src/domain/usecases/transactionCreate.ts
+++ b/libs/ui/src/domain/usecases/transactionCreate.ts
@@ -95,6 +95,13 @@ export class TransactionCreateUsecase extends Usecase<
           type: 'loaded',
         })
       )
+      .with(
+        [{ type: 'submitSuccess' }, { type: 'SUBMIT_CANCEL' }],
+        ([state]) => ({
+          ...state,
+          type: 'loaded',
+        })
+      )
       .otherwise(() => state);
   }
 

--- a/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
@@ -298,8 +298,74 @@ export const TransactionCreateHandler = ({
         transactionPayController.state.type === 'paying' ||
         transactionPayController.state.type === 'payingSuccess' ||
         transactionPayController.state.type === 'payingError',
-      onCancel: () =>
-        transactionPayController.dispatch({ type: 'HIDE_CONFIRMATION' }),
+      onCancel: () => {
+        const transaction: TransactionPrintPayload['transaction'] = {
+          createdAt: dayjs(new Date().toISOString()).format('DD/MM/YYYY HH:mm'),
+          name: transactionCreateController.form.getValues('name'),
+          orderNumber: transactionCreateController.form.getValues('orderNumber'),
+          items: transactionCreateController.form
+            .getValues('transactionItems')
+            .sort((a, b) =>
+              a.variant.product.name.localeCompare(b.variant.product.name)
+            )
+            .map(({ variant, amount, discountAmount, note }) => ({
+              name: `${variant.product.name} - ${variant.values
+                .map(({ optionValue: { name } }) => name)
+                .join(' - ')}`,
+              price: variant.price,
+              amount,
+              discountAmount,
+              note,
+            })),
+          coupons: transactionCreateController.form
+            .getValues('transactionCoupons')
+            .map(({ coupon }) => ({
+              amount: coupon.amount,
+              type: coupon.type === 'fixed' ? 'FIXED' : 'PERCENTAGE',
+              code: coupon.code,
+            })),
+          isCashless: false,
+          paidAmount: 0,
+        };
+        transactionPayController.dispatch({ type: 'HIDE_CONFIRMATION' });
+        transactionCreateController.dispatch({ type: 'SUBMIT_CANCEL' });
+        show({
+          title: 'Print Invoice',
+          description: 'Do you want to print invoice ?',
+          onConfirm: () => {
+            print({ type: 'INVOICE', transaction })
+              .then(() => {
+                show({
+                  title: 'Print Order Slip',
+                  description: 'Do you want to print order slip ?',
+                  onConfirm: () => {
+                    print({ type: 'ORDER_SLIP', transaction }).then(() => {
+                      router.push('/transactions');
+                    });
+                  },
+                  onCancel: () => router.push('/transactions'),
+                });
+              })
+              .catch(() => {
+                router.push('/transactions');
+              });
+          },
+          onCancel: () => {
+            setTimeout(() => {
+              show({
+                title: 'Print Order Slip',
+                description: 'Do you want to print order slip ?',
+                onConfirm: () => {
+                  print({ type: 'ORDER_SLIP', transaction }).then(() => {
+                    router.push('/transactions');
+                  });
+                },
+                onCancel: () => router.push('/transactions'),
+              });
+            }, 200);
+          },
+        });
+      },
       onSubmit: (values) =>
         transactionPayController.dispatch({
           type: 'PAY',


### PR DESCRIPTION
## Summary
Enhanced the transaction creation cancellation flow to prompt users for printing invoices and order slips before returning to the transactions list.

## Key Changes
- **TransactionCreateHandler.tsx**: Expanded the `onCancel` handler to:
  - Build a `TransactionPrintPayload` object from the current form state
  - Display sequential confirmation dialogs for printing invoices and order slips
  - Handle print success/failure scenarios with appropriate navigation
  - Route back to `/transactions` after print operations complete or are cancelled

- **transactionCreate.ts**: Added state transition handler for `SUBMIT_CANCEL` action to reset the form state back to `'loaded'` type after cancellation

## Implementation Details
- Transaction data is constructed from form values with sorted items and mapped coupon data
- Print operations are chained sequentially: invoice first, then order slip
- A 200ms delay is added before showing the order slip dialog if invoice printing is skipped
- All paths (print success, print failure, or skip) ultimately navigate to the transactions list

https://claude.ai/code/session_016LoF7dTmajBdEbJ4so1QyZ