### PR TITLE
Add reordering functionality to checklist template items

### DIFF
--- a/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
+++ b/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
@@ -19,23 +19,9 @@ export const ChecklistTemplateFormView = ({
   isSubmitting,
   serverError,
 }: ChecklistTemplateFormViewProps) => {
-  const handleSubmit = (values: ChecklistTemplateForm) => {
-    onSubmit({
-      ...values,
-      items: values.items.map((item, itemIndex) => ({
-        ...item,
-        displayOrder: itemIndex + 1,
-        subItems: item.subItems.map((subItem, subItemIndex) => ({
-          ...subItem,
-          displayOrder: subItemIndex + 1,
-        })),
-      })),
-    });
-  };
-
   return (
     <FormProvider {...form}>
-      <Form onSubmit={form.handleSubmit(handleSubmit)} gap="$3">
+      <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
         <FormErrorBanner message={serverError} />
         <Card padding="$3" gap="$3">
           <YStack gap="$3" $gtMd={{ flexDirection: 'row' }}>
@@ -212,7 +198,7 @@ export const ChecklistTemplateFormView = ({
 
         <Button
           disabled={isSubmitDisabled}
-          onPress={form.handleSubmit(handleSubmit)}
+          onPress={form.handleSubmit(onSubmit)}
           theme="blue"
           icon={isSubmitting ? <Spinner /> : undefined}
         >

--- a/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
+++ b/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
@@ -1,4 +1,4 @@
-import { Plus, Trash, X } from '@tamagui/lucide-icons';
+import { ArrowDown, ArrowUp, Plus, Trash, X } from '@tamagui/lucide-icons';
 import { Button, Card, Form, H4, Spinner, XStack, YStack } from 'tamagui';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { Field, FieldArray, FormErrorBanner, InputText } from '../base';
@@ -19,9 +19,23 @@ export const ChecklistTemplateFormView = ({
   isSubmitting,
   serverError,
 }: ChecklistTemplateFormViewProps) => {
+  const handleSubmit = (values: ChecklistTemplateForm) => {
+    onSubmit({
+      ...values,
+      items: values.items.map((item, itemIndex) => ({
+        ...item,
+        displayOrder: itemIndex + 1,
+        subItems: item.subItems.map((subItem, subItemIndex) => ({
+          ...subItem,
+          displayOrder: subItemIndex + 1,
+        })),
+      })),
+    });
+  };
+
   return (
     <FormProvider {...form}>
-      <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
+      <Form onSubmit={form.handleSubmit(handleSubmit)} gap="$3">
         <FormErrorBanner message={serverError} />
         <Card padding="$3" gap="$3">
           <YStack gap="$3" $gtMd={{ flexDirection: 'row' }}>
@@ -64,14 +78,34 @@ export const ChecklistTemplateFormView = ({
                 <Card key={field.key} padding="$3" gap="$3">
                   <XStack justifyContent="space-between" alignItems="center">
                     <H4 size="$4">Item {index + 1}</H4>
-                    <Button
-                      size="$3"
-                      icon={Trash}
-                      theme="red"
-                      color="$red8"
-                      circular
-                      onPress={() => itemsArray.remove(index)}
-                    />
+                    <XStack gap="$2" alignItems="center">
+                      <Button
+                        size="$3"
+                        icon={ArrowUp}
+                        circular
+                        disabled={index === 0}
+                        opacity={index === 0 ? 0.4 : 1}
+                        onPress={() => itemsArray.move(index, index - 1)}
+                      />
+                      <Button
+                        size="$3"
+                        icon={ArrowDown}
+                        circular
+                        disabled={index === itemsArray.fields.length - 1}
+                        opacity={
+                          index === itemsArray.fields.length - 1 ? 0.4 : 1
+                        }
+                        onPress={() => itemsArray.move(index, index + 1)}
+                      />
+                      <Button
+                        size="$3"
+                        icon={Trash}
+                        theme="red"
+                        color="$red8"
+                        circular
+                        onPress={() => itemsArray.remove(index)}
+                      />
+                    </XStack>
                   </XStack>
 
                   <YStack gap="$3" $gtMd={{ flexDirection: 'row' }}>
@@ -133,6 +167,32 @@ export const ChecklistTemplateFormView = ({
                             </YStack>
                             <Button
                               size="$2"
+                              icon={ArrowUp}
+                              circular
+                              disabled={subIndex === 0}
+                              opacity={subIndex === 0 ? 0.4 : 1}
+                              onPress={() =>
+                                subItemsArray.move(subIndex, subIndex - 1)
+                              }
+                            />
+                            <Button
+                              size="$2"
+                              icon={ArrowDown}
+                              circular
+                              disabled={
+                                subIndex === subItemsArray.fields.length - 1
+                              }
+                              opacity={
+                                subIndex === subItemsArray.fields.length - 1
+                                  ? 0.4
+                                  : 1
+                              }
+                              onPress={() =>
+                                subItemsArray.move(subIndex, subIndex + 1)
+                              }
+                            />
+                            <Button
+                              size="$2"
                               icon={X}
                               theme="red"
                               color="$red8"
@@ -152,7 +212,7 @@ export const ChecklistTemplateFormView = ({
 
         <Button
           disabled={isSubmitDisabled}
-          onPress={form.handleSubmit(onSubmit)}
+          onPress={form.handleSubmit(handleSubmit)}
           theme="blue"
           icon={isSubmitting ? <Spinner /> : undefined}
         >

--- a/libs/ui/src/presentation/screens/ChecklistTemplateCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistTemplateCreateHandler.tsx
@@ -32,7 +32,20 @@ export const ChecklistTemplateCreateHandler = ({
     <ChecklistTemplateCreateScreen
       form={checklistTemplateCreate.form}
       onSubmit={(values) =>
-        checklistTemplateCreate.dispatch({ type: 'SUBMIT', values })
+        checklistTemplateCreate.dispatch({
+          type: 'SUBMIT',
+          values: {
+            ...values,
+            items: values.items.map((item, itemIndex) => ({
+              ...item,
+              displayOrder: itemIndex + 1,
+              subItems: item.subItems.map((subItem, subItemIndex) => ({
+                ...subItem,
+                displayOrder: subItemIndex + 1,
+              })),
+            })),
+          },
+        })
       }
       isSubmitDisabled={
         checklistTemplateCreate.state.type === 'submitting' ||

--- a/libs/ui/src/presentation/screens/ChecklistTemplateUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/ChecklistTemplateUpdateHandler.tsx
@@ -36,7 +36,20 @@ export const ChecklistTemplateUpdateHandler = ({
     <ChecklistTemplateUpdateScreen
       form={checklistTemplateUpdate.form}
       onSubmit={(values) =>
-        checklistTemplateUpdate.dispatch({ type: 'SUBMIT', values })
+        checklistTemplateUpdate.dispatch({
+          type: 'SUBMIT',
+          values: {
+            ...values,
+            items: values.items.map((item, itemIndex) => ({
+              ...item,
+              displayOrder: itemIndex + 1,
+              subItems: item.subItems.map((subItem, subItemIndex) => ({
+                ...subItem,
+                displayOrder: subItemIndex + 1,
+              })),
+            })),
+          },
+        })
       }
       isSubmitDisabled={
         checklistTemplateUpdate.state.type === 'submitting' ||


### PR DESCRIPTION
## Summary
Added the ability to reorder checklist items and sub-items using arrow buttons in the ChecklistTemplateFormView component. The display order is now automatically calculated and persisted based on the item positions in the form.

## Key Changes
- Imported `ArrowUp` and `ArrowDown` icons from tamagui/lucide-icons
- Created a new `handleSubmit` function that automatically assigns `displayOrder` values to items and sub-items based on their array indices before submission
- Added up/down arrow buttons next to each checklist item to allow reordering via the `move()` method from react-hook-form's FieldArray
- Added up/down arrow buttons next to each sub-item for independent reordering
- Arrow buttons are disabled when at the first or last position with reduced opacity for visual feedback
- Reorganized the delete button layout to accommodate the new reordering controls

## Implementation Details
- The `displayOrder` is calculated as `index + 1` for both items and sub-items, ensuring 1-based ordering
- Arrow buttons use the FieldArray's `move()` method to reorder elements in the form state
- Disabled state is managed with both the `disabled` prop and opacity styling for better UX
- The submit handler now wraps the original `onSubmit` to inject the calculated display order values

https://claude.ai/code/session_01HWmb8qpyQHRmYGsxQEkTyU