### PR TITLE
Add pricing tier support to variants and rental snapshots

### DIFF
--- a/apps/api/data/mysql/rental_entity.go
+++ b/apps/api/data/mysql/rental_entity.go
@@ -1,15 +1,60 @@
 package mysql
 
-import "time"
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"time"
+)
+
+// PricingTiersJSON is a []byte-backed type that reads and writes the MySQL JSON
+// column storing the pricing-tier snapshot on a rental row.
+type PricingTiersJSON []byte
+
+func (p PricingTiersJSON) Value() (driver.Value, error) {
+	if len(p) == 0 {
+		return "[]", nil
+	}
+	return string(p), nil
+}
+
+func (p *PricingTiersJSON) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case []byte:
+		*p = make([]byte, len(v))
+		copy(*p, v)
+	case string:
+		*p = []byte(v)
+	case nil:
+		*p = []byte("[]")
+	default:
+		return fmt.Errorf("unsupported type for PricingTiersJSON: %T", value)
+	}
+	return nil
+}
 
 type Rental struct {
-	Id         int64
-	Code       string
-	Name       string
-	VariantId  int64
-	Variant    Variant
-	CheckinAt  time.Time
-	CheckoutAt *time.Time
-	CreatedAt  time.Time
-	DeletedAt  *time.Time
+	Id           int64
+	Code         string
+	Name         string
+	VariantId    int64
+	Variant      Variant
+	CheckinAt    time.Time
+	CheckoutAt   *time.Time
+	PricingTiers PricingTiersJSON
+	CreatedAt    time.Time
+	DeletedAt    *time.Time
+}
+
+// toPricingTierList unmarshals the JSON snapshot into a slice of PricingTier.
+func (p PricingTiersJSON) toPricingTierList() []PricingTier {
+	var tiers []PricingTier
+	_ = json.Unmarshal(p, &tiers)
+	return tiers
+}
+
+// pricingTierListToJSON marshals a slice of PricingTier to PricingTiersJSON.
+func pricingTierListToJSON(tiers []PricingTier) PricingTiersJSON {
+	b, _ := json.Marshal(tiers)
+	return PricingTiersJSON(b)
 }

--- a/apps/api/data/mysql/rental_transformer.go
+++ b/apps/api/data/mysql/rental_transformer.go
@@ -4,29 +4,31 @@ import "apps/api/domain"
 
 func ToRentalDB(domainRental domain.Rental) Rental {
 	return Rental{
-		Id:         domainRental.Id,
-		Code:       domainRental.Code,
-		Name:       domainRental.Name,
-		CheckinAt:  domainRental.CheckinAt,
-		CheckoutAt: domainRental.CheckoutAt,
-		VariantId:  domainRental.VariantId,
-		Variant:    ToVariantDB(domainRental.Variant),
-		CreatedAt:  domainRental.CreatedAt,
-		DeletedAt:  domainRental.DeletedAt,
+		Id:           domainRental.Id,
+		Code:         domainRental.Code,
+		Name:         domainRental.Name,
+		CheckinAt:    domainRental.CheckinAt,
+		CheckoutAt:   domainRental.CheckoutAt,
+		VariantId:    domainRental.VariantId,
+		Variant:      ToVariantDB(domainRental.Variant),
+		PricingTiers: pricingTierListToJSON(ToPricingTierListDB(domainRental.PricingTiers)),
+		CreatedAt:    domainRental.CreatedAt,
+		DeletedAt:    domainRental.DeletedAt,
 	}
 }
 
 func ToRentalDomain(dbRental Rental) domain.Rental {
 	return domain.Rental{
-		Id:         dbRental.Id,
-		Code:       dbRental.Code,
-		Name:       dbRental.Name,
-		VariantId:  dbRental.VariantId,
-		Variant:    ToVariantDomain(dbRental.Variant),
-		CheckinAt:  dbRental.CheckinAt,
-		CheckoutAt: dbRental.CheckoutAt,
-		CreatedAt:  dbRental.CreatedAt,
-		DeletedAt:  dbRental.DeletedAt,
+		Id:           dbRental.Id,
+		Code:         dbRental.Code,
+		Name:         dbRental.Name,
+		VariantId:    dbRental.VariantId,
+		Variant:      ToVariantDomain(dbRental.Variant),
+		CheckinAt:    dbRental.CheckinAt,
+		CheckoutAt:   dbRental.CheckoutAt,
+		PricingTiers: ToPricingTierListDomain(dbRental.PricingTiers.toPricingTierList()),
+		CreatedAt:    dbRental.CreatedAt,
+		DeletedAt:    dbRental.DeletedAt,
 	}
 }
 

--- a/apps/api/data/mysql/variant_entity.go
+++ b/apps/api/data/mysql/variant_entity.go
@@ -2,6 +2,14 @@ package mysql
 
 import "time"
 
+type PricingTier struct {
+	Id          int64     `json:"-"`
+	VariantId   int64     `json:"-"`
+	UpToMinutes int       `json:"up_to_minutes"`
+	Price       float32   `json:"price"`
+	CreatedAt   time.Time `json:"-"`
+}
+
 type VariantMaterial struct {
 	Id         int64
 	VariantId  int64
@@ -30,4 +38,5 @@ type Variant struct {
 	DeletedAt     *time.Time
 	CreatedAt     time.Time
 	VariantValues []VariantValue
+	PricingTiers  []PricingTier
 }

--- a/apps/api/data/mysql/variant_repo.go
+++ b/apps/api/data/mysql/variant_repo.go
@@ -13,11 +13,24 @@ func NewVariantRepository(db *gorm.DB) domain.VariantRepository {
 	return Repository{db: db}
 }
 
+func preloadVariantPricingTiers(db *gorm.DB) *gorm.DB {
+	return db.Order("pricing_tiers.up_to_minutes ASC")
+}
+
 func (repo Repository) GetVariantList(ctx context.Context, query string, sortBy domain.SortBy, order domain.Order, skip int, limit int, productId *int, optionValueIds []int) ([]domain.Variant, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 
 	var variants []Variant
-	result := db.Table("variants").Preload("Product").Preload("Product.Category").Preload("Materials").Preload("Materials.Material").Preload("VariantValues").Preload("VariantValues.OptionValue").Where("variants.deleted_at", nil).Order(fmt.Sprintf("%s %s", ToSortByColumn(sortBy), ToOrderColumn(order)))
+	result := db.Table("variants").
+		Preload("Product").
+		Preload("Product.Category").
+		Preload("Materials").
+		Preload("Materials.Material").
+		Preload("VariantValues").
+		Preload("VariantValues.OptionValue").
+		Preload("PricingTiers", preloadVariantPricingTiers).
+		Where("variants.deleted_at", nil).
+		Order(fmt.Sprintf("%s %s", ToSortByColumn(sortBy), ToOrderColumn(order)))
 
 	if len(optionValueIds) > 0 {
 		result = result.Joins("JOIN variant_values ON variant_values.variant_id = variants.id").Where("variant_values.option_value_id IN ?", optionValueIds).Group("variants.id").Having("COUNT(*) = ?", len(optionValueIds))
@@ -61,20 +74,52 @@ func (repo Repository) GetVariantListTotal(ctx context.Context, query string) (i
 func (repo Repository) GetVariantById(ctx context.Context, id int64) (domain.Variant, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var variant Variant
-	result := db.Table("variants").Preload("Product").Preload("Product.Category").Preload("Materials").Preload("Materials.Material").Preload("VariantValues").Preload("VariantValues.OptionValue").Where("id = ?", id).First(&variant)
+	result := db.Table("variants").
+		Preload("Product").
+		Preload("Product.Category").
+		Preload("Materials").
+		Preload("Materials.Material").
+		Preload("VariantValues").
+		Preload("VariantValues.OptionValue").
+		Preload("PricingTiers", preloadVariantPricingTiers).
+		Where("id = ?", id).
+		First(&variant)
 	return ToVariantDomain(variant), ToErrorCtx(ctx, result.Error, "GetVariantById")
 }
 
 func (repo Repository) CreateVariant(ctx context.Context, variant domain.Variant) (domain.Variant, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	payload := ToVariantDB(variant)
+
+	// Separate tiers so GORM doesn't auto-manage them; we insert manually after.
+	tiers := payload.PricingTiers
+	payload.PricingTiers = nil
+
 	if result := db.Table("variants").Create(&payload); result.Error != nil {
 		return domain.Variant{}, ToErrorCtx(ctx, result.Error, "CreateVariant")
 	}
 
-	// Fetch the created variant with all relations
+	if len(tiers) > 0 {
+		for i := range tiers {
+			tiers[i].Id = 0
+			tiers[i].VariantId = payload.Id
+		}
+		if result := db.Table("pricing_tiers").Create(&tiers); result.Error != nil {
+			return domain.Variant{}, ToErrorCtx(ctx, result.Error, "CreateVariant")
+		}
+	}
+
 	var createdVariant Variant
-	fetchResult := db.Table("variants").Preload("Product").Preload("Product.Category").Preload("Materials").Preload("Materials.Material").Preload("VariantValues").Preload("VariantValues.OptionValue").Where("id = ?", payload.Id).First(&createdVariant)
+	fetchResult := db.Table("variants").
+		Preload("Product").
+		Preload("Product.Category").
+		Preload("Materials").
+		Preload("Materials.Material").
+		Preload("VariantValues").
+		Preload("VariantValues.OptionValue").
+		Preload("PricingTiers", preloadVariantPricingTiers).
+		Where("id = ?", payload.Id).
+		First(&createdVariant)
 	return ToVariantDomain(createdVariant), ToErrorCtx(ctx, fetchResult.Error, "CreateVariant")
 }
 
@@ -82,8 +127,12 @@ func (repo Repository) UpdateVariantById(ctx context.Context, variant domain.Var
 	db := GetDbFromCtx(ctx, repo.db)
 	variant.Id = id
 
-	// Update the variant and its associations using FullSaveAssociations to ensure all related records are updated
 	variantPayload := ToVariantDB(variant)
+
+	// Separate tiers so GORM doesn't auto-manage them; we replace them manually.
+	tiers := variantPayload.PricingTiers
+	variantPayload.PricingTiers = nil
+
 	if result := db.Session(&gorm.Session{FullSaveAssociations: true}).Table("variants").Where("id = ?", id).Updates(&variantPayload); result.Error != nil {
 		return domain.Variant{}, ToErrorCtx(ctx, result.Error, "UpdateVariantById")
 	}
@@ -118,9 +167,31 @@ func (repo Repository) UpdateVariantById(ctx context.Context, variant domain.Var
 		}
 	}
 
-	// Fetch the updated variant with all relations
+	// Replace pricing tiers atomically: delete all existing, then insert the new set.
+	if result := db.Table("pricing_tiers").Where("variant_id = ?", id).Delete(&PricingTier{}); result.Error != nil {
+		return domain.Variant{}, ToErrorCtx(ctx, result.Error, "UpdateVariantById")
+	}
+	if len(tiers) > 0 {
+		for i := range tiers {
+			tiers[i].Id = 0
+			tiers[i].VariantId = id
+		}
+		if result := db.Table("pricing_tiers").Create(&tiers); result.Error != nil {
+			return domain.Variant{}, ToErrorCtx(ctx, result.Error, "UpdateVariantById")
+		}
+	}
+
 	var updatedVariant Variant
-	fetchResult := db.Table("variants").Preload("Product").Preload("Product.Category").Preload("Materials").Preload("Materials.Material").Preload("VariantValues").Preload("VariantValues.OptionValue").Where("id = ?", id).First(&updatedVariant)
+	fetchResult := db.Table("variants").
+		Preload("Product").
+		Preload("Product.Category").
+		Preload("Materials").
+		Preload("Materials.Material").
+		Preload("VariantValues").
+		Preload("VariantValues.OptionValue").
+		Preload("PricingTiers", preloadVariantPricingTiers).
+		Where("id = ?", id).
+		First(&updatedVariant)
 	return ToVariantDomain(updatedVariant), ToErrorCtx(ctx, fetchResult.Error, "UpdateVariantById")
 }
 

--- a/apps/api/data/mysql/variant_transformer.go
+++ b/apps/api/data/mysql/variant_transformer.go
@@ -2,6 +2,42 @@ package mysql
 
 import "apps/api/domain"
 
+func ToPricingTierDomain(dbTier PricingTier) domain.PricingTier {
+	return domain.PricingTier{
+		Id:          dbTier.Id,
+		VariantId:   dbTier.VariantId,
+		UpToMinutes: dbTier.UpToMinutes,
+		Price:       dbTier.Price,
+		CreatedAt:   dbTier.CreatedAt,
+	}
+}
+
+func ToPricingTierDB(domainTier domain.PricingTier) PricingTier {
+	return PricingTier{
+		Id:          domainTier.Id,
+		VariantId:   domainTier.VariantId,
+		UpToMinutes: domainTier.UpToMinutes,
+		Price:       domainTier.Price,
+		CreatedAt:   domainTier.CreatedAt,
+	}
+}
+
+func ToPricingTierListDomain(dbTiers []PricingTier) []domain.PricingTier {
+	var result []domain.PricingTier
+	for _, t := range dbTiers {
+		result = append(result, ToPricingTierDomain(t))
+	}
+	return result
+}
+
+func ToPricingTierListDB(domainTiers []domain.PricingTier) []PricingTier {
+	var result []PricingTier
+	for _, t := range domainTiers {
+		result = append(result, ToPricingTierDB(t))
+	}
+	return result
+}
+
 func ToVariantDB(domainVariant domain.Variant) Variant {
 	return Variant{
 		Id:            domainVariant.Id,
@@ -14,6 +50,7 @@ func ToVariantDB(domainVariant domain.Variant) Variant {
 		Product:       ToProductDB(domainVariant.Product),
 		Materials:     ToVariantMaterialListDB(domainVariant.Materials),
 		VariantValues: ToVariantValueListDB(domainVariant.VariantValues),
+		PricingTiers:  ToPricingTierListDB(domainVariant.PricingTiers),
 	}
 }
 
@@ -29,6 +66,7 @@ func ToVariantDomain(dbVariant Variant) domain.Variant {
 		Product:       ToProductDomain(dbVariant.Product),
 		Materials:     ToVariantMaterialListDomain(dbVariant.Materials),
 		VariantValues: ToVariantValueListDomain(dbVariant.VariantValues),
+		PricingTiers:  ToPricingTierListDomain(dbVariant.PricingTiers),
 	}
 }
 


### PR DESCRIPTION
## Summary
This PR adds support for pricing tiers on product variants and captures pricing tier snapshots on rental records. Pricing tiers allow variants to have tiered pricing based on rental duration (up to X minutes), and rentals now store a JSON snapshot of the pricing tiers at the time of booking.

## Key Changes

- **Variant Pricing Tiers**: Added `PricingTier` entity to represent tiered pricing for variants, with fields for duration threshold (`UpToMinutes`) and price
  - Pricing tiers are preloaded in all variant queries, sorted by duration
  - Manual tier management in create/update operations to prevent GORM auto-association issues
  - Tiers are replaced atomically on variant updates (delete all, then insert new set)

- **Rental Pricing Snapshots**: Added `PricingTiersJSON` field to `Rental` to store a JSON snapshot of pricing tiers at booking time
  - Implemented custom `Value()` and `Scan()` methods for MySQL JSON column handling
  - Helper methods to marshal/unmarshal between JSON and `PricingTier` slices

- **Data Transformers**: Added conversion functions for pricing tiers between domain and database layers
  - `ToPricingTierDomain()`, `ToPricingTierDB()` for single tier conversion
  - `ToPricingTierListDomain()`, `ToPricingTierListDB()` for batch conversion

- **Code Formatting**: Improved readability of variant repository queries by breaking long GORM chains into multiple lines

## Implementation Details

- Pricing tiers are manually managed (not auto-associated by GORM) to maintain control over insertion/deletion order
- Rental pricing snapshots use JSON serialization to preserve the exact pricing structure at booking time, independent of future variant changes
- All variant queries now include pricing tier preloading with ascending order by duration

https://claude.ai/code/session_01Tka69vvgUnhpQRvhj74beo