### PR TITLE
Add pricing tier support to variants and rentals

### DIFF
--- a/libs/api-contract/src/api.yaml
+++ b/libs/api-contract/src/api.yaml
@@ -2655,6 +2655,16 @@ components:
           format: int64
         name:
           type: string
+    PricingTier:
+      type: object
+      required:
+        - upToMinutes
+        - price
+      properties:
+        upToMinutes:
+          type: integer
+        price:
+          type: number
     Variant:
       type: object
       required:
@@ -2666,6 +2676,7 @@ components:
         - materials
         - values
         - createdAt
+        - pricingTiers
       properties:
         id:
           type: integer
@@ -2695,6 +2706,10 @@ components:
         createdAt:
           type: string
           format: date-time
+        pricingTiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/PricingTier'
     VariantRequest:
       type: object
       required:
@@ -2721,6 +2736,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/VariantValueRequest'
+        pricingTiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/PricingTier'
     VariantMaterial:
       type: object
       required:
@@ -3029,6 +3048,7 @@ components:
         - variant
         - checkinAt
         - createdAt
+        - pricingTiers
       properties:
         id:
           type: integer
@@ -3051,6 +3071,13 @@ components:
         createdAt:
           type: string
           format: date-time
+        pricingTiers:
+          type: array
+          items:
+            $ref: '#/components/schemas/PricingTier'
+        runningTotal:
+          type: number
+          readOnly: true
     RentalRequest:
       type: object
       required:


### PR DESCRIPTION
## Summary
This change introduces pricing tier functionality to the API contract by adding a new `PricingTier` schema and integrating it into both the `Variant` and `Rental` response models.

## Key Changes
- **New `PricingTier` schema**: Added a reusable object with `upToMinutes` (integer) and `price` (number) properties to represent tiered pricing based on rental duration
- **Variant model updates**: 
  - Added `pricingTiers` as a required array field to the `Variant` response schema
  - Added `pricingTiers` as an optional array field to the `VariantRequest` schema
- **Rental model updates**:
  - Added `pricingTiers` as a required array field to the `Rental` response schema
  - Added `runningTotal` as a read-only number field to the `Rental` response schema

## Implementation Details
- The `PricingTier` schema is defined as a reusable component and referenced via `$ref` in both variant and rental schemas
- Both `upToMinutes` and `price` are required fields in the `PricingTier` object
- The `pricingTiers` field is marked as required in response schemas (`Variant` and `Rental`) but optional in request schemas (`VariantRequest`)
- The `runningTotal` field in `Rental` is marked as read-only, indicating it's computed server-side

https://claude.ai/code/session_01LZ5ZNb833QY2qCsFUEMosE