### PR TITLE
Denormalize price field in transaction items

### DIFF
--- a/libs/ui/src/domain/entities/Transaction.ts
+++ b/libs/ui/src/domain/entities/Transaction.ts
@@ -37,6 +37,7 @@ type TransactionItemForm = {
   id?: number;
   variant: Variant;
   amount: number;
+  price: number;
   discountAmount: number;
   note: string;
 };

--- a/libs/ui/src/domain/usecases/transactionUpdate.ts
+++ b/libs/ui/src/domain/usecases/transactionUpdate.ts
@@ -57,7 +57,14 @@ export class TransactionUpdateUsecase extends Usecase<
       values: {
         name: this.params.transaction?.name ?? '',
         orderNumber: this.params.transaction?.orderNumber ?? 0,
-        transactionItems: this.params.transaction?.transactionItems ?? [],
+        transactionItems: this.params.transaction?.transactionItems.map((item) => ({
+          id: item.id,
+          amount: item.amount,
+          variant: item.variant,
+          price: item.price,
+          discountAmount: item.discountAmount,
+          note: item.note,
+        })) ?? [],
         transactionCoupons: this.params.transaction?.transactionCoupons ?? [],
       },
     };
@@ -157,6 +164,7 @@ export class TransactionUpdateUsecase extends Usecase<
                   amount: item.amount,
                   variantId: item.variant.id,
                   variant: item.variant,
+                  price: item.price,
                   discountAmount: item.discountAmount,
                   note: item.note,
                 })),

--- a/libs/ui/src/presentation/components/transactions/TransactionFormView.tsx
+++ b/libs/ui/src/presentation/components/transactions/TransactionFormView.tsx
@@ -149,7 +149,7 @@ export const TransactionFormView = ({
                                     name={[`transactionItems.${index}`]}
                                   >
                                     {([
-                                      { variant, amount, discountAmount },
+                                      { price, amount, discountAmount },
                                     ]) => (
                                       <H4
                                         textTransform="none"
@@ -157,7 +157,7 @@ export const TransactionFormView = ({
                                       >
                                         Rp.{' '}
                                         {(
-                                          variant.price * amount -
+                                          price * amount -
                                           discountAmount
                                         ).toLocaleString('id')}
                                       </H4>
@@ -236,7 +236,7 @@ export const TransactionFormView = ({
                                         transactionItems.reduce(
                                           (prev, curr) =>
                                             prev +
-                                            (curr.amount * curr.variant.price -
+                                            (curr.amount * curr.price -
                                               curr.discountAmount),
                                           0
                                         );
@@ -298,7 +298,7 @@ export const TransactionFormView = ({
                         const total = transactionItems.reduce(
                           (prev, curr) =>
                             prev +
-                            (curr.amount * curr.variant.price -
+                            (curr.amount * curr.price -
                               curr.discountAmount),
                           0
                         );

--- a/libs/ui/src/presentation/controllers/TransactionCreateController.tsx
+++ b/libs/ui/src/presentation/controllers/TransactionCreateController.tsx
@@ -74,6 +74,7 @@ export const useTransactionCreateController = (
       itemsFieldArray.append({
         amount,
         variant: newVariant,
+        price: newVariant.price,
         discountAmount: 0,
         note: '',
       });

--- a/libs/ui/src/presentation/controllers/TransactionUpdateController.tsx
+++ b/libs/ui/src/presentation/controllers/TransactionUpdateController.tsx
@@ -74,6 +74,7 @@ export const useTransactionUpdateController = (
       itemsFieldArray.append({
         amount,
         variant: newVariant,
+        price: newVariant.price,
         discountAmount: 0,
         note: '',
       });


### PR DESCRIPTION
## Summary
This PR denormalizes the `price` field in transaction items by storing it directly on the item instead of accessing it through the nested `variant.price` property. This improves data consistency and simplifies price calculations throughout the transaction form.

## Key Changes
- Added `price: number` field to `TransactionItemForm` entity type
- Updated transaction item initialization to capture and store the variant's price at the time of item creation in both create and update controllers
- Modified `TransactionUpdateUsecase` to explicitly map and preserve the `price` field when preparing form values
- Refactored all price calculations in `TransactionFormView` to use the denormalized `price` field instead of `variant.price`
- Updated form field mapping to destructure `price` instead of `variant` where only the price value is needed

## Implementation Details
- The price is captured once when an item is added to the transaction (from `newVariant.price`)
- This ensures the price used for calculations reflects the price at the time of transaction creation/update, not any subsequent variant price changes
- All three locations calculating item totals now consistently use `curr.price * curr.amount - curr.discountAmount`

https://claude.ai/code/session_015Vt79GQ6tT8SeLNMWECXEy