### PR TITLE
Add rental duration note to checkout transaction items

### DIFF
--- a/apps/api/domain/rental_usecase.go
+++ b/apps/api/domain/rental_usecase.go
@@ -2,6 +2,8 @@ package domain
 
 import (
 	"context"
+	"fmt"
+	"math"
 	"time"
 )
 
@@ -106,11 +108,24 @@ func (usecase RentalUsecase) CheckoutRentals(ctx context.Context, rentalIds []in
 				return err
 			}
 
-			result, calcErr := CalculatePrice(existingRental.PricingTiers, checkoutAt.Sub(existingRental.CheckinAt))
+			duration := checkoutAt.Sub(existingRental.CheckinAt)
+			result, calcErr := CalculatePrice(existingRental.PricingTiers, duration)
 			if calcErr != nil {
 				return calcErr
 			}
 			total += float64(result.Price)
+
+			totalMinutes := int(math.Ceil(duration.Minutes()))
+			hours := totalMinutes / 60
+			minutes := totalMinutes % 60
+			var durationNote string
+			if hours > 0 && minutes > 0 {
+				durationNote = fmt.Sprintf("%d hour(s) %d minute(s)", hours, minutes)
+			} else if hours > 0 {
+				durationNote = fmt.Sprintf("%d hour(s)", hours)
+			} else {
+				durationNote = fmt.Sprintf("%d minute(s)", totalMinutes)
+			}
 
 			transactionItems = append(transactionItems, TransactionItem{
 				VariantId:      existingRental.VariantId,
@@ -119,6 +134,7 @@ func (usecase RentalUsecase) CheckoutRentals(ctx context.Context, rentalIds []in
 				DiscountAmount: 0,
 				Subtotal:       result.Price,
 				RentalId:       &existingRental.Id,
+				Note:           durationNote,
 			})
 
 			transactionData.Name = existingRental.Name


### PR DESCRIPTION
## Summary
Enhanced the checkout rental functionality to include a human-readable duration note on each transaction item, providing better visibility into the rental period for each item being checked out.

## Key Changes
- Extract rental duration into a variable for reusability
- Calculate total minutes from the rental duration and convert to hours and minutes
- Generate a formatted duration note (e.g., "2 hour(s) 30 minute(s)") based on the rental period
- Add the duration note to each `TransactionItem` in the checkout process
- Added necessary imports: `fmt` and `math` packages

## Implementation Details
- Duration is calculated using `math.Ceil()` to round up partial minutes
- The duration note formatting handles three cases:
  - Both hours and minutes present: "X hour(s) Y minute(s)"
  - Only hours: "X hour(s)"
  - Only minutes: "X minute(s)"
- The note is stored in the `Note` field of each `TransactionItem` for transaction records

https://claude.ai/code/session_01DHRoHySax11b2opyJn5Ag4