### PR TITLE
Handle rental items differently in transaction form

### DIFF
--- a/libs/ui/src/presentation/components/transactions/TransactionFormView.tsx
+++ b/libs/ui/src/presentation/components/transactions/TransactionFormView.tsx
@@ -90,7 +90,9 @@ export const TransactionFormView = ({
                       <H4>Items</H4>
                       <YStack gap="$3">
                         {itemsFieldArray.fields.map(
-                          ({ variant, key }, index) => {
+                          ({ variant, price: fieldPrice, key }, index) => {
+                            const isRental =
+                              variant.product.saleType === 'rental';
                             return (
                               <YStack key={key} gap="$5">
                                 <XStack
@@ -129,7 +131,11 @@ export const TransactionFormView = ({
                                     textTransform="none"
                                     textAlign="left"
                                   >
-                                    Rp. {variant.price.toLocaleString('id')}
+                                    Rp.{' '}
+                                    {(isRental
+                                      ? fieldPrice
+                                      : variant.price
+                                    ).toLocaleString('id')}
                                   </Paragraph>
                                 </XStack>
 
@@ -138,11 +144,17 @@ export const TransactionFormView = ({
                                   justifyContent="flex-end"
                                   alignItems="center"
                                 >
-                                  <InputNumber
-                                    name={`transactionItems.${index}.amount`}
-                                    min={1}
-                                    maxWidth={50}
-                                  />
+                                  {isRental ? (
+                                    <Paragraph minWidth={50} textAlign="center">
+                                      1
+                                    </Paragraph>
+                                  ) : (
+                                    <InputNumber
+                                      name={`transactionItems.${index}.amount`}
+                                      min={1}
+                                      maxWidth={50}
+                                    />
+                                  )}
 
                                   <FieldWatch
                                     control={form.control}


### PR DESCRIPTION
## Summary
Updated the TransactionFormView to handle rental items differently from regular sale items by displaying the rental price from the form field and disabling quantity adjustment for rentals.

## Key Changes
- Extract `fieldPrice` from the items field array to access the form-managed price value
- Add `isRental` flag based on the product's `saleType` to differentiate rental items
- Display `fieldPrice` for rental items instead of `variant.price` to reflect any form-level price modifications
- Replace the quantity input (`InputNumber`) with a static display of "1" for rental items, preventing users from adjusting quantities for rentals

## Implementation Details
- The `isRental` check uses `variant.product.saleType === 'rental'` to determine item type
- For rental items, the quantity field is replaced with a read-only `Paragraph` component showing "1"
- Regular sale items retain the existing `InputNumber` component for quantity adjustment
- This ensures rental transactions maintain a fixed quantity of 1 while allowing price customization through the form field

https://claude.ai/code/session_01K8cWMKXrRCHPvumrvNro8t