### PR TITLE
Store price at transaction item level instead of variant

### DIFF
--- a/libs/ui/src/domain/entities/Transaction.ts
+++ b/libs/ui/src/domain/entities/Transaction.ts
@@ -37,6 +37,7 @@ type TransactionItemForm = {
   id?: number;
   variant: Variant;
   amount: number;
+  price: number;
   discountAmount: number;
   note: string;
 };

--- a/libs/ui/src/presentation/controllers/TransactionCreateController.tsx
+++ b/libs/ui/src/presentation/controllers/TransactionCreateController.tsx
@@ -74,6 +74,7 @@ export const useTransactionCreateController = (
       itemsFieldArray.append({
         amount,
         variant: newVariant,
+        price: newVariant.price,
         discountAmount: 0,
         note: '',
       });

--- a/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
@@ -66,7 +66,7 @@ export const TransactionCreateHandler = ({
       let transactionTotal =
         transactionCreateController.state.values.transactionItems.reduce(
           (prev, curr) =>
-            prev + (curr.variant.price * curr.amount - curr.discountAmount),
+            prev + (curr.price * curr.amount - curr.discountAmount),
           0
         );
 
@@ -117,11 +117,11 @@ export const TransactionCreateHandler = ({
           .sort((a, b) =>
             a.variant.product.name.localeCompare(b.variant.product.name)
           )
-          .map(({ variant, amount, discountAmount, note }) => ({
+          .map(({ variant, price, amount, discountAmount, note }) => ({
             name: `${variant.product.name} - ${variant.values
               .map(({ optionValue: { name } }) => name)
               .join(' - ')}`,
-            price: variant.price,
+            price,
             amount,
             discountAmount,
             note,

--- a/libs/ui/src/presentation/screens/TransactionListHandler.tsx
+++ b/libs/ui/src/presentation/screens/TransactionListHandler.tsx
@@ -94,11 +94,11 @@ export const TransactionListHandler = ({
       .sort((a, b) =>
         a.variant.product.name.localeCompare(b.variant.product.name)
       )
-      .map(({ variant, amount, discountAmount, note }) => ({
+      .map(({ variant, price, amount, discountAmount, note }) => ({
         name: `${variant.product.name} - ${variant.values
           .map(({ optionValue: { name } }) => name)
           .join(' - ')}`,
-        price: variant.price,
+        price,
         amount,
         discountAmount,
         note,


### PR DESCRIPTION
## Summary
This change refactors how prices are handled in transactions by storing the price directly on each transaction item rather than always referencing the variant's price. This allows transaction items to maintain their price at the time of creation, even if the variant's price changes later.

## Key Changes
- Added `price: number` field to `TransactionItemForm` type in the Transaction entity
- Updated `TransactionCreateController` to capture and store the variant's price when adding a new item
- Modified transaction total calculation in `TransactionCreateHandler` to use the item's stored price instead of `variant.price`
- Updated both `TransactionCreateHandler` and `TransactionListHandler` to destructure and use the `price` field from transaction items instead of accessing `variant.price`

## Implementation Details
- When a new transaction item is created, the current variant price is captured and stored as `price: newVariant.price`
- The transaction total calculation now uses `curr.price` directly, making it independent of variant price changes
- The mapping functions in both handlers now explicitly extract the `price` property and use it for display, ensuring consistency across the application

https://claude.ai/code/session_0162ZsVNr312zQUR5YceJ1jS