### PR TITLE
docs: Add PRD for inventory management system (#86)

### DIFF
--- a/libs/ui/src/app/PurchaseList.tsx
+++ b/libs/ui/src/app/PurchaseList.tsx
@@ -1,4 +1,4 @@
-import { ApiAuthRepository, ApiPurchaseListRepository } from '../data';
+import { ApiAuthRepository, ApiPurchaseListRepository, UrlPurchaseListQueryRepository } from '../data';
 import {
   AuthLogoutUsecase,
   PurchaseListGetParams,
@@ -16,11 +16,13 @@ export function StockCheckPurchaseList({
 }: StockCheckPurchaseListProps) {
   const client = new QueryClient();
   const purchaseListRepository = new ApiPurchaseListRepository(client);
+  const purchaseListQueryRepository = new UrlPurchaseListQueryRepository();
   const authRepository = new ApiAuthRepository();
 
   const authLogoutUsecase = new AuthLogoutUsecase(authRepository);
   const purchaseListGetUsecase = new PurchaseListGetUsecase(
     purchaseListRepository,
+    purchaseListQueryRepository,
     purchaseListGetParams
   );
 

--- a/libs/ui/src/data/mock/index.ts
+++ b/libs/ui/src/data/mock/index.ts
@@ -24,3 +24,4 @@ export * from './wallet';
 export * from './stockCheck';
 export * from './stockCheckListQuery';
 export * from './purchaseList';
+export * from './purchaseListQuery';

--- a/libs/ui/src/data/mock/purchaseListQuery.ts
+++ b/libs/ui/src/data/mock/purchaseListQuery.ts
@@ -1,0 +1,8 @@
+import { PurchaseListQueryRepository, PurchaseTypeFilter } from '../../domain';
+
+export class MockPurchaseListQueryRepository
+  implements PurchaseListQueryRepository
+{
+  getPurchaseTypeFilter = (): PurchaseTypeFilter => 'all';
+  setPurchaseTypeFilter = (_filter: PurchaseTypeFilter) => undefined;
+}

--- a/libs/ui/src/data/url/index.ts
+++ b/libs/ui/src/data/url/index.ts
@@ -7,3 +7,4 @@ export * from './transactionStatisticListQuery';
 export * from './rentalListQuery';
 export * from './supplierListQuery';
 export * from './stockCheckListQuery';
+export * from './purchaseListQuery';

--- a/libs/ui/src/data/url/purchaseListQuery.ts
+++ b/libs/ui/src/data/url/purchaseListQuery.ts
@@ -1,0 +1,24 @@
+// eslint-disable-next-line @nx/enforce-module-boundaries
+import { PurchaseListQueryRepository, PurchaseTypeFilter } from '../../domain';
+import { getQueryParam, setQueryParam } from '../../utils/queryParam';
+import { createStringUnionParser } from '../../utils/stringUnionParser';
+
+const toPurchaseTypeFilter = createStringUnionParser<PurchaseTypeFilter[]>([
+  'all',
+  'online',
+  'offline',
+  'delivery',
+]);
+
+export class UrlPurchaseListQueryRepository
+  implements PurchaseListQueryRepository
+{
+  getPurchaseTypeFilter = (): PurchaseTypeFilter => {
+    const param = getQueryParam('purchaseType');
+    return toPurchaseTypeFilter(param ?? '') ?? 'all';
+  };
+
+  setPurchaseTypeFilter = (filter: PurchaseTypeFilter) => {
+    setQueryParam('purchaseType', filter);
+  };
+}

--- a/libs/ui/src/domain/entities/Material.ts
+++ b/libs/ui/src/domain/entities/Material.ts
@@ -2,6 +2,8 @@ import { Supplier } from './Supplier';
 
 export type PurchaseType = 'online' | 'offline' | 'delivery';
 
+export type PurchaseTypeFilter = 'all' | PurchaseType;
+
 export type MaterialSupplier = {
   id: number;
   supplierId: number;

--- a/libs/ui/src/domain/repositories/index.ts
+++ b/libs/ui/src/domain/repositories/index.ts
@@ -24,3 +24,4 @@ export * from './checklistSession';
 export * from './stockCheck';
 export * from './stockCheckListQuery';
 export * from './purchaseList';
+export * from './purchaseListQuery';

--- a/libs/ui/src/domain/repositories/purchaseListQuery.ts
+++ b/libs/ui/src/domain/repositories/purchaseListQuery.ts
@@ -1,0 +1,6 @@
+import { PurchaseTypeFilter } from '../entities/Material';
+
+export interface PurchaseListQueryRepository {
+  getPurchaseTypeFilter: () => PurchaseTypeFilter;
+  setPurchaseTypeFilter: (filter: PurchaseTypeFilter) => void;
+}

--- a/libs/ui/src/domain/usecases/purchaseListGet.ts
+++ b/libs/ui/src/domain/usecases/purchaseListGet.ts
@@ -1,11 +1,13 @@
 import { match, P } from 'ts-pattern';
 import { PurchaseList } from '../entities';
-import { PurchaseListRepository } from '../repositories';
+import { PurchaseListQueryRepository, PurchaseListRepository } from '../repositories';
+import { PurchaseTypeFilter } from '../entities/Material';
 import { Usecase } from './IUsecase';
 
 type Context = {
   purchaseList: PurchaseList | null;
   errorMessage: string | null;
+  purchaseTypeFilter: PurchaseTypeFilter;
 };
 
 export type PurchaseListGetState = (
@@ -20,7 +22,8 @@ export type PurchaseListGetState = (
 export type PurchaseListGetAction =
   | { type: 'FETCH' }
   | { type: 'FETCH_SUCCESS'; purchaseList: PurchaseList }
-  | { type: 'FETCH_ERROR'; message: string };
+  | { type: 'FETCH_ERROR'; message: string }
+  | { type: 'CHANGE_PURCHASE_TYPE_FILTER'; filter: PurchaseTypeFilter };
 
 export type PurchaseListGetParams = {
   stockCheckId: number;
@@ -34,13 +37,16 @@ export class PurchaseListGetUsecase extends Usecase<
 > {
   params: PurchaseListGetParams;
   purchaseListRepository: PurchaseListRepository;
+  purchaseListQueryRepository: PurchaseListQueryRepository;
 
   constructor(
     purchaseListRepository: PurchaseListRepository,
+    purchaseListQueryRepository: PurchaseListQueryRepository,
     params: PurchaseListGetParams
   ) {
     super();
     this.purchaseListRepository = purchaseListRepository;
+    this.purchaseListQueryRepository = purchaseListQueryRepository;
     this.params = params;
   }
 
@@ -49,6 +55,7 @@ export class PurchaseListGetUsecase extends Usecase<
       type: this.params.purchaseList !== null ? 'loaded' : 'idle',
       purchaseList: this.params.purchaseList,
       errorMessage: null,
+      purchaseTypeFilter: this.purchaseListQueryRepository.getPurchaseTypeFilter(),
     };
   }
 
@@ -96,6 +103,10 @@ export class PurchaseListGetUsecase extends Usecase<
         ...state,
         type: 'loaded',
       }))
+      .with(
+        [P.any, { type: 'CHANGE_PURCHASE_TYPE_FILTER' }],
+        ([state, { filter }]) => ({ ...state, purchaseTypeFilter: filter })
+      )
       .otherwise(() => state);
   }
 
@@ -117,6 +128,9 @@ export class PurchaseListGetUsecase extends Usecase<
               message: 'Failed to fetch purchase list',
             })
           );
+      })
+      .with({ type: 'loaded' }, ({ purchaseTypeFilter }) => {
+        this.purchaseListQueryRepository.setPurchaseTypeFilter(purchaseTypeFilter);
       })
       .otherwise(() => {
         // noop

--- a/libs/ui/src/presentation/components/purchaseLists/PurchaseListGroupedView.tsx
+++ b/libs/ui/src/presentation/components/purchaseLists/PurchaseListGroupedView.tsx
@@ -11,8 +11,12 @@ import {
 import { Button, H5, Paragraph, Separator, XStack, YStack } from 'tamagui';
 import { Linking, Platform } from 'react-native';
 import { PurchaseList, PurchaseListItem } from '../../../domain';
-import { MaterialSupplier, PurchaseType } from '../../../domain/entities/Material';
-import { ListItem } from '../base';
+import {
+  MaterialSupplier,
+  PurchaseType,
+  PurchaseTypeFilter,
+} from '../../../domain/entities/Material';
+import { EmptyView, ListItem } from '../base';
 
 type SupplierGroup = {
   supplierId: number | null;
@@ -270,18 +274,44 @@ function buildSupplierGroups(purchaseList: PurchaseList): SupplierGroup[] {
   return assigned;
 }
 
+function applyFilter(
+  groups: SupplierGroup[],
+  filter: PurchaseTypeFilter
+): SupplierGroup[] {
+  if (filter === 'all') return groups;
+
+  return groups
+    .filter((group) => group.supplierId !== null)
+    .map((group) => ({
+      ...group,
+      items: group.items.filter(({ supplier }) => supplier?.purchaseType === filter),
+    }))
+    .filter((group) => group.items.length > 0);
+}
+
 export type PurchaseListGroupedViewProps = {
   purchaseList: PurchaseList;
   getMaterialEditUrl?: (materialId: number) => string;
+  purchaseTypeFilter: PurchaseTypeFilter;
 };
 
 export function PurchaseListGroupedView({
   purchaseList,
   getMaterialEditUrl,
+  purchaseTypeFilter,
 }: PurchaseListGroupedViewProps) {
-  const groups = buildSupplierGroups(purchaseList);
+  const allGroups = buildSupplierGroups(purchaseList);
+  const groups = applyFilter(allGroups, purchaseTypeFilter);
 
   if (groups.length === 0) {
+    if (purchaseTypeFilter !== 'all') {
+      return (
+        <EmptyView
+          title={`No ${purchaseTypeFilter.charAt(0).toUpperCase() + purchaseTypeFilter.slice(1)} Purchases`}
+          subtitle={`No materials need to be purchased via ${purchaseTypeFilter} right now.`}
+        />
+      );
+    }
     return null;
   }
 

--- a/libs/ui/src/presentation/components/purchaseLists/PurchaseListView.tsx
+++ b/libs/ui/src/presentation/components/purchaseLists/PurchaseListView.tsx
@@ -1,14 +1,24 @@
-import { H4, Paragraph, Separator, Spinner, YStack } from 'tamagui';
+import { Button, H4, Paragraph, Separator, Spinner, XStack, YStack } from 'tamagui';
 import { match } from 'ts-pattern';
 import { ScrollView } from 'react-native';
 import { EmptyView, ErrorView, SkeletonList } from '../base';
 import { PurchaseList } from '../../../domain';
+import { PurchaseTypeFilter } from '../../../domain/entities/Material';
 import { PurchaseListGroupedView } from './PurchaseListGroupedView';
+
+const FILTER_OPTIONS: { value: PurchaseTypeFilter; label: string }[] = [
+  { value: 'all', label: 'All' },
+  { value: 'online', label: 'Online' },
+  { value: 'offline', label: 'Offline' },
+  { value: 'delivery', label: 'Delivery' },
+];
 
 export type PurchaseListViewProps = {
   onRetryButtonPress: () => void;
   isRevalidating?: boolean;
   getMaterialEditUrl: (materialId: number) => string;
+  purchaseTypeFilter: PurchaseTypeFilter;
+  onPurchaseTypeFilterChange: (filter: PurchaseTypeFilter) => void;
   variant:
     | { type: 'loading' }
     | { type: 'error' }
@@ -20,6 +30,8 @@ export const PurchaseListView = ({
   onRetryButtonPress,
   isRevalidating,
   getMaterialEditUrl,
+  purchaseTypeFilter,
+  onPurchaseTypeFilterChange,
   variant,
 }: PurchaseListViewProps) => {
   return (
@@ -50,10 +62,15 @@ export const PurchaseListView = ({
               stockCheckDate={purchaseList.stockCheckDate}
               totalEstimatedCost={purchaseList.totalEstimatedCost}
             />
+            <PurchaseTypeFilterControl
+              purchaseTypeFilter={purchaseTypeFilter}
+              onPurchaseTypeFilterChange={onPurchaseTypeFilterChange}
+            />
             <ScrollView nestedScrollEnabled>
               <PurchaseListGroupedView
                 purchaseList={purchaseList}
                 getMaterialEditUrl={getMaterialEditUrl}
+                purchaseTypeFilter={purchaseTypeFilter}
               />
             </ScrollView>
           </YStack>
@@ -69,6 +86,29 @@ export const PurchaseListView = ({
     </YStack>
   );
 };
+
+function PurchaseTypeFilterControl({
+  purchaseTypeFilter,
+  onPurchaseTypeFilterChange,
+}: {
+  purchaseTypeFilter: PurchaseTypeFilter;
+  onPurchaseTypeFilterChange: (filter: PurchaseTypeFilter) => void;
+}) {
+  return (
+    <XStack gap="$2" flexWrap="wrap">
+      {FILTER_OPTIONS.map(({ value, label }) => (
+        <Button
+          key={value}
+          size="$3"
+          onPress={() => onPurchaseTypeFilterChange(value)}
+          variant={purchaseTypeFilter === value ? undefined : 'outlined'}
+        >
+          {label}
+        </Button>
+      ))}
+    </XStack>
+  );
+}
 
 function PurchaseListHeader({
   stockCheckDate,

--- a/libs/ui/src/presentation/screens/PurchaseListHandler.tsx
+++ b/libs/ui/src/presentation/screens/PurchaseListHandler.tsx
@@ -1,7 +1,28 @@
 import { match, P } from 'ts-pattern';
+import { useEffect, useState } from 'react';
+import { Platform } from 'react-native';
 import { AuthLogoutUsecase, PurchaseList, PurchaseListGetUsecase } from '../../domain';
+import { PurchaseTypeFilter } from '../../domain/entities/Material';
 import { PurchaseListScreen, PurchaseListScreenProps } from './PurchaseListScreen';
 import { useAuthLogoutController, usePurchaseListGetController } from '../controllers';
+
+function readFilterFromUrl(): PurchaseTypeFilter {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return 'all';
+  const param = new URLSearchParams(window.location.search).get('purchaseType');
+  if (param === 'online' || param === 'offline' || param === 'delivery') return param;
+  return 'all';
+}
+
+function writeFilterToUrl(filter: PurchaseTypeFilter) {
+  if (Platform.OS !== 'web' || typeof window === 'undefined') return;
+  const url = new URL(window.location.href);
+  if (filter === 'all') {
+    url.searchParams.delete('purchaseType');
+  } else {
+    url.searchParams.set('purchaseType', filter);
+  }
+  window.history.replaceState(null, '', url.toString());
+}
 
 export type PurchaseListHandlerProps = {
   authLogoutUsecase: AuthLogoutUsecase;
@@ -14,6 +35,16 @@ export const PurchaseListHandler = ({
 }: PurchaseListHandlerProps) => {
   const authLogout = useAuthLogoutController(authLogoutUsecase);
   const purchaseListGet = usePurchaseListGetController(purchaseListGetUsecase);
+  const [purchaseTypeFilter, setPurchaseTypeFilter] = useState<PurchaseTypeFilter>('all');
+
+  useEffect(() => {
+    setPurchaseTypeFilter(readFilterFromUrl());
+  }, []);
+
+  const handlePurchaseTypeFilterChange = (filter: PurchaseTypeFilter) => {
+    setPurchaseTypeFilter(filter);
+    writeFilterToUrl(filter);
+  };
 
   return (
     <PurchaseListScreen
@@ -21,6 +52,8 @@ export const PurchaseListHandler = ({
       onRetryButtonPress={() => purchaseListGet.dispatch({ type: 'FETCH' })}
       isRevalidating={purchaseListGet.state.type === 'revalidating'}
       getMaterialEditUrl={(materialId) => `/materials/${materialId}`}
+      purchaseTypeFilter={purchaseTypeFilter}
+      onPurchaseTypeFilterChange={handlePurchaseTypeFilterChange}
       variant={match(purchaseListGet.state)
         .returnType<PurchaseListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/PurchaseListHandler.tsx
+++ b/libs/ui/src/presentation/screens/PurchaseListHandler.tsx
@@ -1,28 +1,7 @@
 import { match, P } from 'ts-pattern';
-import { useEffect, useState } from 'react';
-import { Platform } from 'react-native';
 import { AuthLogoutUsecase, PurchaseList, PurchaseListGetUsecase } from '../../domain';
-import { PurchaseTypeFilter } from '../../domain/entities/Material';
 import { PurchaseListScreen, PurchaseListScreenProps } from './PurchaseListScreen';
 import { useAuthLogoutController, usePurchaseListGetController } from '../controllers';
-
-function readFilterFromUrl(): PurchaseTypeFilter {
-  if (Platform.OS !== 'web' || typeof window === 'undefined') return 'all';
-  const param = new URLSearchParams(window.location.search).get('purchaseType');
-  if (param === 'online' || param === 'offline' || param === 'delivery') return param;
-  return 'all';
-}
-
-function writeFilterToUrl(filter: PurchaseTypeFilter) {
-  if (Platform.OS !== 'web' || typeof window === 'undefined') return;
-  const url = new URL(window.location.href);
-  if (filter === 'all') {
-    url.searchParams.delete('purchaseType');
-  } else {
-    url.searchParams.set('purchaseType', filter);
-  }
-  window.history.replaceState(null, '', url.toString());
-}
 
 export type PurchaseListHandlerProps = {
   authLogoutUsecase: AuthLogoutUsecase;
@@ -35,16 +14,6 @@ export const PurchaseListHandler = ({
 }: PurchaseListHandlerProps) => {
   const authLogout = useAuthLogoutController(authLogoutUsecase);
   const purchaseListGet = usePurchaseListGetController(purchaseListGetUsecase);
-  const [purchaseTypeFilter, setPurchaseTypeFilter] = useState<PurchaseTypeFilter>('all');
-
-  useEffect(() => {
-    setPurchaseTypeFilter(readFilterFromUrl());
-  }, []);
-
-  const handlePurchaseTypeFilterChange = (filter: PurchaseTypeFilter) => {
-    setPurchaseTypeFilter(filter);
-    writeFilterToUrl(filter);
-  };
 
   return (
     <PurchaseListScreen
@@ -52,8 +21,10 @@ export const PurchaseListHandler = ({
       onRetryButtonPress={() => purchaseListGet.dispatch({ type: 'FETCH' })}
       isRevalidating={purchaseListGet.state.type === 'revalidating'}
       getMaterialEditUrl={(materialId) => `/materials/${materialId}`}
-      purchaseTypeFilter={purchaseTypeFilter}
-      onPurchaseTypeFilterChange={handlePurchaseTypeFilterChange}
+      purchaseTypeFilter={purchaseListGet.state.purchaseTypeFilter}
+      onPurchaseTypeFilterChange={(filter) =>
+        purchaseListGet.dispatch({ type: 'CHANGE_PURCHASE_TYPE_FILTER', filter })
+      }
       variant={match(purchaseListGet.state)
         .returnType<PurchaseListScreenProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({ type: 'loading' }))

--- a/libs/ui/src/presentation/screens/PurchaseListScreen.tsx
+++ b/libs/ui/src/presentation/screens/PurchaseListScreen.tsx
@@ -1,6 +1,7 @@
 import { Printer } from '@tamagui/lucide-icons';
 import { Button, Tooltip } from 'tamagui';
 import { Layout, PurchaseListView, PurchaseListViewProps } from '../components';
+import { PurchaseTypeFilter } from '../../domain/entities/Material';
 
 export type PurchaseListScreenProps = {
   onLogoutPress: () => void;
@@ -8,6 +9,8 @@ export type PurchaseListScreenProps = {
   variant: PurchaseListViewProps['variant'];
   isRevalidating?: boolean;
   getMaterialEditUrl: (materialId: number) => string;
+  purchaseTypeFilter: PurchaseTypeFilter;
+  onPurchaseTypeFilterChange: (filter: PurchaseTypeFilter) => void;
 };
 
 export const PurchaseListScreen = ({
@@ -16,6 +19,8 @@ export const PurchaseListScreen = ({
   variant,
   isRevalidating,
   getMaterialEditUrl,
+  purchaseTypeFilter,
+  onPurchaseTypeFilterChange,
 }: PurchaseListScreenProps) => {
   return (
     <Layout
@@ -44,6 +49,8 @@ export const PurchaseListScreen = ({
         onRetryButtonPress={onRetryButtonPress}
         isRevalidating={isRevalidating}
         getMaterialEditUrl={getMaterialEditUrl}
+        purchaseTypeFilter={purchaseTypeFilter}
+        onPurchaseTypeFilterChange={onPurchaseTypeFilterChange}
       />
     </Layout>
   );


### PR DESCRIPTION
* docs: add PRD and phased plan for inventory management

Captures the closing-night stock-count flow and the morning purchase-list
view, plus the four new material fields (purchase_unit, purchase_unit_size,
minimum_stock, normal_stock) needed to drive the calculation. Splits the
rollout into five sequentially-mergeable PRs so each layer can be reviewed
and shipped on its own without breaking main.

https://claude.ai/code/session_01WSSkABsjjVD4iQiUbHKAYX

* docs: record stock policy in purchase units, not recipe units

Per review on PR #86: the closing crew counts the storeroom in
human-readable purchase units ("3 sacks, 1.5 boxes"), so storing
current_stock — and the minimum_stock / normal_stock policy it's
compared against — in recipe units forced a mental conversion that
hurt usability with no upside. Switches all three stock fields to
purchase units, keeps price per recipe unit (variant/recipe module
untouched), and routes the conversion through purchase_unit_size only
where it's actually needed: computing estimated cost.

https://claude.ai/code/session_01WSSkABsjjVD4iQiUbHKAYX

* docs: rework inventory PRD per PR review feedback

Addresses the nine comments on PR #86:

- Purchase list becomes a per-stock-check action surfaced via the
  triple-dot menu on the Stock Check list, not a separate "opening"
  route. Drops the "latest stock check" lookup and its empty state.
- Stock Check Items snapshot six material fields at creation time
  (name, price, purchase_unit, purchase_unit_size, minimum_stock,
  normal_stock) so the derived purchase list is stable against later
  edits to the Material row. Stored as dedicated columns to match
  existing GORM patterns.
- Every Stock Check now covers every non-deleted material (item per
  material, current_stock defaults to 0). Removes the "not_counted"
  concept entirely.
- current_stock, minimum_stock, normal_stock are integers (whole
  containers only). Staff is instructed to take whole containers, so
  the ceil() step in the calculation goes away.
- Single "Stock Check" nav entry instead of split Closing/Opening
  routes.
- Plan collapses from 5 PRs to 4: the purchase-list endpoint rides
  along with the Stock Check API PR since it's a sibling handler on
  the same resource.

https://claude.ai/code/session_01WSSkABsjjVD4iQiUbHKAYX

---------

Co-authored-by: Claude <noreply@anthropic.com>