### PR TITLE
Add search/filter functionality to stock check form items

### DIFF
--- a/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
+++ b/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
@@ -1,13 +1,16 @@
+import { useEffect, useState } from 'react';
 import { FormProvider, useFieldArray, UseFormReturn } from 'react-hook-form';
 import {
   Button,
   Form,
+  Input,
   Label,
   SizableText,
   Spinner,
   XStack,
   YStack,
 } from 'tamagui';
+import { X } from '@tamagui/lucide-icons';
 import { FormErrorBanner, InputNumber } from '../base';
 import { StockCheckForm } from '../../../domain';
 
@@ -27,15 +30,80 @@ export const StockCheckFormView = ({
   serverError,
 }: StockCheckFormViewProps) => {
   const { fields } = useFieldArray({ control: form.control, name: 'items' });
+  const [query, setQuery] = useState('');
+
+  const lowerQuery = query.toLowerCase();
+  const matchCount = lowerQuery
+    ? fields.filter((f) => f.materialName.toLowerCase().includes(lowerQuery))
+        .length
+    : fields.length;
+  const hasQuery = query.length > 0;
+  const noMatches = hasQuery && matchCount === 0;
+
+  // FR-3: if submit surfaces errors on rows hidden by the filter, clear the
+  // filter so the user can see the offending row.
+  const errors = form.formState.errors;
+  useEffect(() => {
+    if (!hasQuery) return;
+    const itemErrors = errors.items;
+    if (!itemErrors) return;
+    const errorIndexes = Object.keys(itemErrors).map(Number);
+    const hasHiddenError = errorIndexes.some((i) => {
+      const name = fields[i]?.materialName ?? '';
+      return !name.toLowerCase().includes(lowerQuery);
+    });
+    if (hasHiddenError) setQuery('');
+  }, [errors]);
 
   return (
     <FormProvider {...form}>
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
         <FormErrorBanner message={serverError} />
 
+        {/* Sticky search bar */}
+        <XStack
+          alignItems="center"
+          gap="$2"
+          position="sticky"
+          top={0}
+          zIndex={10}
+          backgroundColor="$background"
+          paddingVertical="$2"
+        >
+          <Input
+            flex={1}
+            placeholder="Search material by name"
+            value={query}
+            onChangeText={setQuery}
+          />
+          {hasQuery && (
+            <SizableText color="$gray10" flexShrink={0}>
+              {matchCount}/{fields.length}
+            </SizableText>
+          )}
+          {hasQuery && (
+            <Button
+              icon={X}
+              circular
+              size="$2"
+              onPress={() => setQuery('')}
+              accessibilityLabel="Clear search"
+            />
+          )}
+        </XStack>
+
         <YStack maxWidth={640} alignSelf="center" width="100%">
+          {noMatches && (
+            <SizableText color="$gray10" textAlign="center" paddingVertical="$4">
+              No materials match &quot;{query}&quot;
+            </SizableText>
+          )}
+
           {fields.map((field, index) => {
             const inputId = `stock-check-item-${field.id}`;
+            const hidden =
+              hasQuery &&
+              !field.materialName.toLowerCase().includes(lowerQuery);
             return (
               <XStack
                 key={field.id}
@@ -44,6 +112,7 @@ export const StockCheckFormView = ({
                 paddingVertical="$2"
                 borderBottomWidth={1}
                 borderBottomColor="$borderColor"
+                display={hidden ? 'none' : 'flex'}
               >
                 <Label flex={1} numberOfLines={1} htmlFor={inputId}>
                   {field.materialName}


### PR DESCRIPTION
## Summary
Added a sticky search bar to the StockCheckFormView that allows users to filter stock check items by material name. The implementation includes automatic filter clearing when validation errors occur on hidden items.

## Key Changes
- Added a sticky search input at the top of the form with material name filtering
- Displays match count (e.g., "3/10") showing filtered vs total items
- Shows "No materials match" message when search yields no results
- Implements auto-clear functionality: if form submission surfaces errors on items hidden by the current filter, the filter is automatically cleared so users can see the problematic rows
- Hidden items are removed from view using `display: none` CSS property
- Added clear button (X icon) to manually reset the search query

## Implementation Details
- Uses React hooks (`useState`, `useEffect`) to manage search state and filter logic
- Filter is case-insensitive for better UX
- The error detection logic (FR-3) monitors `form.formState.errors` and checks if any error indexes correspond to items hidden by the current filter
- Search bar is sticky positioned with appropriate z-index to remain visible while scrolling through items

https://claude.ai/code/session_01N7hyjryqGGQwJe2ieXrU84