### PR TITLE
Set itemPerPage to 100 for supplier list parameters

### DIFF
--- a/apps/web/src/pages/materials/[materialId].tsx
+++ b/apps/web/src/pages/materials/[materialId].tsx
@@ -47,7 +47,7 @@ export const getServerSideProps: GetServerSideProps<
   return {
     props: {
       materialUpdateParams: { material, materialId },
-      supplierListParams: { suppliers, totalItem },
+      supplierListParams: { suppliers, totalItem, itemPerPage: 100 },
     },
   };
 };

--- a/apps/web/src/pages/materials/create.tsx
+++ b/apps/web/src/pages/materials/create.tsx
@@ -32,7 +32,7 @@ export const getServerSideProps: GetServerSideProps<
 
   return {
     props: {
-      supplierListParams: { suppliers, totalItem },
+      supplierListParams: { suppliers, totalItem, itemPerPage: 100 },
     },
   };
 };


### PR DESCRIPTION
## Summary
Updated supplier list parameters to include a fixed `itemPerPage` value of 100 across material-related pages.

## Key Changes
- Added `itemPerPage: 100` to `supplierListParams` in the materials detail page (`[materialId].tsx`)
- Added `itemPerPage: 100` to `supplierListParams` in the materials create page (`create.tsx`)

## Implementation Details
Both changes were made in the `getServerSideProps` functions where supplier list parameters are passed as props. This ensures that supplier lists are consistently paginated with 100 items per page across the materials section of the application.

https://claude.ai/code/session_01L2pT3aJyu7fof53BnMUbXr