### PR TITLE
Add supplier information to material list items

### DIFF
--- a/libs/ui/src/presentation/components/materials/MaterialList.tsx
+++ b/libs/ui/src/presentation/components/materials/MaterialList.tsx
@@ -94,6 +94,7 @@ export const MaterialList = ({
                 purchaseUnit={item.purchaseUnit}
                 minimumStock={item.minimumStock}
                 normalStock={item.normalStock}
+                supplierName={item.suppliers[0]?.supplier.name}
                 onEditMenuPress={
                   onEditMenuPress ? () => onEditMenuPress(item) : undefined
                 }

--- a/libs/ui/src/presentation/components/materials/MaterialListItem.stories.tsx
+++ b/libs/ui/src/presentation/components/materials/MaterialListItem.stories.tsx
@@ -8,8 +8,12 @@ const meta: Meta<typeof MaterialListItem> = {
   args: {
     name: 'Coffee Bean',
     price: 80000,
-    unit: 'kg',
-    weeklyUsage: 20,
+    unit: 'Gram',
+    weeklyUsage: 395,
+    purchaseUnit: 'Kg',
+    minimumStock: 1,
+    normalStock: 2,
+    supplierName: 'PT. Coffee Supplier',
     onEditMenuPress: fn(),
     onDeleteMenuPress: fn(),
   },
@@ -27,12 +31,22 @@ export const WithoutMenus: Story = {
   },
 };
 
+export const WithoutSupplier: Story = {
+  args: {
+    supplierName: undefined,
+  },
+};
+
 export const HighUsage: Story = {
   args: {
     name: 'Fresh Milk',
     price: 15000,
-    unit: 'liter',
+    unit: 'Liter',
     weeklyUsage: 50,
+    purchaseUnit: 'Liter',
+    minimumStock: 5,
+    normalStock: 10,
+    supplierName: 'Dairy Farm Co.',
   },
 };
 
@@ -40,7 +54,10 @@ export const LowUsage: Story = {
   args: {
     name: 'Sugar',
     price: 12000,
-    unit: 'kg',
+    unit: 'Gram',
     weeklyUsage: 10,
+    purchaseUnit: 'Kg',
+    minimumStock: 2,
+    normalStock: 5,
   },
 };

--- a/libs/ui/src/presentation/components/materials/MaterialListItem.tsx
+++ b/libs/ui/src/presentation/components/materials/MaterialListItem.tsx
@@ -1,4 +1,4 @@
-import { Box, Layers, Pencil, ShoppingCart, Trash } from '@tamagui/lucide-icons';
+import { Layers, Pencil, ShoppingCart, Store, Trash } from '@tamagui/lucide-icons';
 import { ListItem } from '../base';
 import { XStackProps } from 'tamagui';
 
@@ -10,6 +10,7 @@ export type MaterialListItemProps = {
   purchaseUnit: string;
   minimumStock: number;
   normalStock: number;
+  supplierName?: string;
   onEditMenuPress?: () => void;
   onDeleteMenuPress?: () => void;
 } & XStackProps;
@@ -22,6 +23,7 @@ export function MaterialListItem({
   purchaseUnit,
   minimumStock,
   normalStock,
+  supplierName,
   onEditMenuPress,
   onDeleteMenuPress,
   ...xStackProps
@@ -46,23 +48,22 @@ export function MaterialListItem({
       ]}
       footerItems={[
         {
-          value: weeklyUsage.toString(),
+          value: `${weeklyUsage} ${unit}`,
           icon: ShoppingCart,
           label: 'Weekly Usage',
           isShown: weeklyUsage > 0,
         },
-        { value: unit, icon: Box, label: 'Unit' },
         {
-          value: purchaseUnit,
-          icon: Layers,
-          label: 'Purchase Unit',
-          isShown: purchaseUnit.length > 0,
-        },
-        {
-          value: `${minimumStock} / ${normalStock}`,
+          value: `${minimumStock} / ${normalStock} ${purchaseUnit}`,
           icon: Layers,
           label: 'Min / Normal Stock',
           isShown: normalStock > 0,
+        },
+        {
+          value: supplierName ?? '',
+          icon: Store,
+          label: 'Supplier',
+          isShown: (supplierName ?? '').length > 0,
         },
       ]}
       {...xStackProps}

--- a/libs/ui/src/presentation/components/variants/VariantFormView.tsx
+++ b/libs/ui/src/presentation/components/variants/VariantFormView.tsx
@@ -292,6 +292,7 @@ export const VariantFormView = ({
                               purchaseUnit={material.purchaseUnit}
                               minimumStock={material.minimumStock}
                               normalStock={material.normalStock}
+                              supplierName={material.suppliers[0]?.supplier.name}
                               flex={1}
                             />
                             <YStack alignItems="flex-end" gap="$3">


### PR DESCRIPTION
## Summary
Enhanced the MaterialListItem component to display supplier information and improved the presentation of material details by consolidating related fields and updating the visual layout.

## Key Changes
- **Added supplier support**: Introduced optional `supplierName` prop to MaterialListItem component to display supplier information with a Store icon
- **Improved field presentation**: 
  - Combined weekly usage with its unit (e.g., "395 Gram" instead of separate fields)
  - Combined minimum/normal stock with purchase unit (e.g., "1 / 2 Kg")
  - Removed redundant "Unit" footer item display
- **Updated icon usage**: Replaced Box icon with Store icon for supplier field
- **Connected data flow**: Updated MaterialList and VariantFormView to pass supplier information from the data model to MaterialListItem
- **Enhanced stories**: Updated Storybook stories with complete material data including new supplier and stock fields, added "WithoutSupplier" story variant

## Implementation Details
- The `supplierName` prop is optional and only displays when a supplier is available
- Stock information now includes the purchase unit for better clarity
- Weekly usage now displays with its corresponding unit for improved readability
- All changes maintain backward compatibility through optional props

https://claude.ai/code/session_011Br81WqYapBk6NfEVcMA8j