### PR TITLE
Eager load suppliers in material list query

### DIFF
--- a/apps/api/data/mysql/material_repo.go
+++ b/apps/api/data/mysql/material_repo.go
@@ -16,7 +16,11 @@ func NewMaterialRepository(db *gorm.DB) domain.MaterialRepository {
 func (repo Repository) GetMaterialList(ctx context.Context, query string, sortBy domain.SortBy, order domain.Order, skip int, limit int) ([]domain.Material, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 	var materials []Material
-	result := db.Table("materials").Where("deleted_at", nil).Order(fmt.Sprintf("%s %s", ToSortByColumn(sortBy), ToOrderColumn(order)))
+	result := db.Table("materials").
+		Preload("Suppliers", "deleted_at IS NULL").
+		Preload("Suppliers.Supplier").
+		Where("deleted_at", nil).
+		Order(fmt.Sprintf("%s %s", ToSortByColumn(sortBy), ToOrderColumn(order)))
 
 	if query != "" {
 		result = result.Where("name LIKE ?", "%"+query+"%")


### PR DESCRIPTION
## Summary
Updated the `GetMaterialList` query to eagerly load associated suppliers and their details, improving query efficiency and preventing N+1 query problems.

## Key Changes
- Added `Preload("Suppliers", "deleted_at IS NULL")` to load only non-deleted suppliers for each material
- Added `Preload("Suppliers.Supplier")` to load the supplier details associated with each material-supplier relationship
- Reformatted the query builder chain for improved readability

## Implementation Details
The preload conditions ensure that:
- Only active (non-deleted) supplier relationships are loaded
- The actual supplier information is eagerly fetched in a single query rather than lazily loaded
- This prevents N+1 query issues when accessing supplier data from the returned materials

https://claude.ai/code/session_01U4ogPrjSoLJSRTBxSZsNdA