### PR TITLE
Filter total estimated cost by purchase type

### DIFF
--- a/libs/ui/src/presentation/components/purchaseLists/PurchaseListView.tsx
+++ b/libs/ui/src/presentation/components/purchaseLists/PurchaseListView.tsx
@@ -56,11 +56,22 @@ export const PurchaseListView = ({
             />
           </YStack>
         ))
-        .with({ type: 'loaded' }, ({ purchaseList }) => (
+        .with({ type: 'loaded' }, ({ purchaseList }) => {
+          const filteredTotalEstimatedCost =
+            purchaseTypeFilter === 'all'
+              ? purchaseList.totalEstimatedCost
+              : purchaseList.items
+                  .filter((item) =>
+                    item.suppliers.some(
+                      (s) => s.purchaseType === purchaseTypeFilter
+                    )
+                  )
+                  .reduce((sum, item) => sum + item.estimatedCost, 0);
+          return (
           <YStack gap="$3" flex={1}>
             <PurchaseListHeader
               stockCheckDate={purchaseList.stockCheckDate}
-              totalEstimatedCost={purchaseList.totalEstimatedCost}
+              totalEstimatedCost={filteredTotalEstimatedCost}
             />
             <PurchaseTypeFilterControl
               purchaseTypeFilter={purchaseTypeFilter}
@@ -74,7 +85,8 @@ export const PurchaseListView = ({
               />
             </ScrollView>
           </YStack>
-        ))
+          );
+        })
         .with({ type: 'error' }, () => (
           <ErrorView
             title="Failed to Fetch Purchase List"


### PR DESCRIPTION
## Summary
Updated the PurchaseListView to calculate the total estimated cost based on the currently selected purchase type filter, rather than always displaying the unfiltered total.

## Key Changes
- Added logic to compute `filteredTotalEstimatedCost` that respects the `purchaseTypeFilter` state
  - When filter is 'all', uses the full `purchaseList.totalEstimatedCost`
  - When a specific purchase type is selected, filters items by supplier purchase type and recalculates the sum of estimated costs
- Updated `PurchaseListHeader` to receive the filtered total cost instead of the unfiltered total
- Fixed code formatting by converting the pattern match handler from an arrow function expression to a block statement with explicit return

## Implementation Details
The filtered cost calculation uses a two-step approach:
1. Filter items to only those with suppliers matching the selected purchase type
2. Reduce the filtered items to sum their estimated costs

This ensures the header displays an accurate total that corresponds to the currently visible filtered items.

https://claude.ai/code/session_01So3LX3g8WsvRiZL4fPZBSr