### PR TITLE
Add wallet payment target filtering and empty state handling

### DIFF
--- a/go.work
+++ b/go.work
@@ -3,3 +3,4 @@ go 1.24.0
 toolchain go1.24.7
 
 use ./apps/api
+use ./libs/api-contract/src/__generated__/go

--- a/libs/api-contract/src/__generated__/go/go.mod
+++ b/libs/api-contract/src/__generated__/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/GIT_USER_ID/GIT_REPO_ID
+module libs/api-contract
 
 go 1.18
 

--- a/libs/ui/.storybook/mocks/mockData.ts
+++ b/libs/ui/.storybook/mocks/mockData.ts
@@ -185,6 +185,7 @@ export const mockWallet: Wallet = {
   balance: 5000000,
   paymentCostPercentage: 0,
   isCashless: false,
+  isPaymentTarget: true,
   createdAt: '2024-01-15T08:00:00.000Z',
 };
 
@@ -196,6 +197,7 @@ export const mockWallets: Wallet[] = [
     balance: 25000000,
     paymentCostPercentage: 1.5,
     isCashless: true,
+    isPaymentTarget: true,
     createdAt: '2024-01-16T08:00:00.000Z',
   },
   {
@@ -204,6 +206,7 @@ export const mockWallets: Wallet[] = [
     balance: 8000000,
     paymentCostPercentage: 0.7,
     isCashless: true,
+    isPaymentTarget: true,
     createdAt: '2024-01-17T08:00:00.000Z',
   },
 ];

--- a/libs/ui/src/data/api/wallet.transformer.ts
+++ b/libs/ui/src/data/api/wallet.transformer.ts
@@ -13,6 +13,7 @@ export function toWallet(wallet: ApiWallet): Wallet {
     balance: wallet.balance,
     paymentCostPercentage: wallet.paymentCostPercentage,
     isCashless: wallet.isCashless,
+    isPaymentTarget: wallet.isPaymentTarget,
   };
 }
 

--- a/libs/ui/src/data/mock/calculation.ts
+++ b/libs/ui/src/data/mock/calculation.ts
@@ -7,6 +7,7 @@ const mockWallet = {
   balance: 1000,
   paymentCostPercentage: 0,
   isCashless: false,
+  isPaymentTarget: true,
   createdAt: '2024-03-20T00:00:00.000Z',
 };
 

--- a/libs/ui/src/data/mock/expense.ts
+++ b/libs/ui/src/data/mock/expense.ts
@@ -7,6 +7,7 @@ const mockWallet = {
   balance: 1000,
   paymentCostPercentage: 0,
   isCashless: false,
+  isPaymentTarget: true,
   createdAt: '2024-03-20T00:00:00.000Z',
 };
 

--- a/libs/ui/src/data/mock/wallet.ts
+++ b/libs/ui/src/data/mock/wallet.ts
@@ -13,6 +13,7 @@ const initialWallets: Wallet[] = [
     balance: 1000000,
     paymentCostPercentage: 0,
     isCashless: false,
+    isPaymentTarget: true,
     createdAt: '2024-03-20T00:00:00.000Z',
   },
   {
@@ -21,6 +22,7 @@ const initialWallets: Wallet[] = [
     balance: 5000000,
     paymentCostPercentage: 2,
     isCashless: true,
+    isPaymentTarget: true,
     createdAt: '2024-03-21T00:00:00.000Z',
   },
 ];
@@ -67,6 +69,7 @@ export class MockWalletRepository implements WalletRepository {
       balance: formValues.balance,
       paymentCostPercentage: formValues.paymentCostPercentage,
       isCashless: formValues.isCashless,
+      isPaymentTarget: true,
       createdAt: new Date().toISOString(),
     });
   }

--- a/libs/ui/src/domain/entities/Wallet.ts
+++ b/libs/ui/src/domain/entities/Wallet.ts
@@ -4,6 +4,7 @@ export type Wallet = {
   balance: number;
   paymentCostPercentage: number;
   isCashless: boolean;
+  isPaymentTarget: boolean;
   createdAt: string;
 };
 

--- a/libs/ui/src/presentation/components/transactions/TransactionPaymentAlert.test.tsx
+++ b/libs/ui/src/presentation/components/transactions/TransactionPaymentAlert.test.tsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { TransactionPaymentAlert } from './TransactionPaymentAlert';
+import { Wallet } from '../../../domain';
+
+const mockWallet: Wallet = {
+  id: 1,
+  name: 'Cash',
+  balance: 1000000,
+  paymentCostPercentage: 0,
+  isCashless: false,
+  isPaymentTarget: true,
+  createdAt: '2024-03-20T00:00:00.000Z',
+};
+
+const internalWallet: Wallet = {
+  id: 2,
+  name: 'Brankas',
+  balance: 500000,
+  paymentCostPercentage: 0,
+  isCashless: false,
+  isPaymentTarget: false,
+  createdAt: '2024-03-21T00:00:00.000Z',
+};
+
+const Wrapper = ({
+  walletSelectOptions,
+  isButtonDisabled = false,
+  isOpen = true,
+}: {
+  walletSelectOptions: { label: string; value: Wallet }[];
+  isButtonDisabled?: boolean;
+  isOpen?: boolean;
+}) => {
+  const form = useForm<{ wallet: Wallet; paidAmount: number }>({
+    defaultValues: { wallet: mockWallet, paidAmount: 50000 },
+  });
+  return (
+    <TransactionPaymentAlert
+      isOpen={isOpen}
+      onCancel={jest.fn()}
+      form={form}
+      onSubmit={jest.fn()}
+      walletSelectOptions={walletSelectOptions}
+      transactionTotal={50000}
+      isButtonDisabled={isButtonDisabled}
+    />
+  );
+};
+
+describe('TransactionPaymentAlert', () => {
+  describe('with eligible wallets', () => {
+    it('renders the wallet select when options are provided', () => {
+      const options = [{ label: mockWallet.name, value: mockWallet }];
+      render(<Wrapper walletSelectOptions={options} />);
+      expect(screen.getByRole('option', { name: 'Cash' })).toBeTruthy();
+    });
+
+    it('does not show the empty-state message when wallets are present', () => {
+      const options = [{ label: mockWallet.name, value: mockWallet }];
+      render(<Wrapper walletSelectOptions={options} />);
+      expect(
+        screen.queryByText(/No wallets are configured to receive payments/)
+      ).toBeNull();
+    });
+
+    it('enables the Submit button when wallets are present and isButtonDisabled is false', () => {
+      const options = [{ label: mockWallet.name, value: mockWallet }];
+      render(<Wrapper walletSelectOptions={options} isButtonDisabled={false} />);
+      expect(
+        (screen.getByRole('button', { name: 'Submit' }) as HTMLButtonElement).disabled
+      ).toBe(false);
+    });
+  });
+
+  describe('with no eligible wallets (empty-state)', () => {
+    it('shows the empty-state message when no wallet options are provided', () => {
+      render(<Wrapper walletSelectOptions={[]} />);
+      expect(
+        screen.getByText(
+          /No wallets are configured to receive payments\. Configure one in Wallet Settings\./
+        )
+      ).toBeTruthy();
+    });
+
+    it('does not render the wallet select when no options are provided', () => {
+      render(<Wrapper walletSelectOptions={[]} />);
+      expect(screen.queryByRole('option')).toBeNull();
+    });
+
+    it('disables the Submit button when no wallet options are provided', () => {
+      render(<Wrapper walletSelectOptions={[]} isButtonDisabled={false} />);
+      expect(
+        (screen.getByRole('button', { name: 'Submit' }) as HTMLButtonElement).disabled
+      ).toBe(true);
+    });
+  });
+
+  describe('filtering responsibility', () => {
+    it('renders only the options passed in — internal wallets must be excluded upstream', () => {
+      const eligibleOptions = [{ label: mockWallet.name, value: mockWallet }];
+      render(<Wrapper walletSelectOptions={eligibleOptions} />);
+      expect(screen.getByRole('option', { name: 'Cash' })).toBeTruthy();
+      expect(screen.queryByRole('option', { name: internalWallet.name })).toBeNull();
+    });
+  });
+
+  it('renders the transaction total amount', () => {
+    const options = [{ label: mockWallet.name, value: mockWallet }];
+    render(<Wrapper walletSelectOptions={options} />);
+    expect(screen.getByText(/50\.000/)).toBeTruthy();
+  });
+
+  it('is not rendered when isOpen is false', () => {
+    const { container } = render(
+      <Wrapper
+        walletSelectOptions={[{ label: mockWallet.name, value: mockWallet }]}
+        isOpen={false}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/libs/ui/src/presentation/components/transactions/TransactionPaymentAlert.tsx
+++ b/libs/ui/src/presentation/components/transactions/TransactionPaymentAlert.tsx
@@ -1,4 +1,4 @@
-import { AlertDialog, Button, H4, Label, XStack, YStack } from 'tamagui';
+import { AlertDialog, Button, H4, Label, Paragraph, XStack, YStack } from 'tamagui';
 import { Field, FieldWatch, InputNumber, Select } from '../base';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { Wallet } from '../../../domain';
@@ -59,9 +59,16 @@ export const TransactionPaymentAlert = ({
               </AlertDialog.Description>
 
               <XStack gap="$5" alignItems="center">
-                <Field name="wallet" label="Wallet Name" flex={1}>
-                  <Select items={walletSelectOptions} />
-                </Field>
+                {walletSelectOptions.length === 0 ? (
+                  <Paragraph color="$red10" flex={1}>
+                    No wallets are configured to receive payments. Configure one
+                    in Wallet Settings.
+                  </Paragraph>
+                ) : (
+                  <Field name="wallet" label="Wallet Name" flex={1}>
+                    <Select items={walletSelectOptions} />
+                  </Field>
+                )}
 
                 <YStack gap="$3" flex={1}>
                   <Label>Total Amount</Label>
@@ -96,7 +103,7 @@ export const TransactionPaymentAlert = ({
                   <Button disabled={isButtonDisabled}>Cancel</Button>
                 </AlertDialog.Cancel>
                 <Button
-                  disabled={isButtonDisabled}
+                  disabled={isButtonDisabled || walletSelectOptions.length === 0}
                   onPress={form.handleSubmit(onSubmit)}
                   theme="active"
                   flex={1}

--- a/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
@@ -309,12 +309,12 @@ export const TransactionCreateHandler = ({
           paidAmount: values.paidAmount,
         }),
       transactionTotal: transactionPayController.state.transactionTotal,
-      walletSelectOptions: transactionPayController.state.wallets.map(
-        (wallet) => ({
+      walletSelectOptions: transactionPayController.state.wallets
+        .filter((wallet) => wallet.isPaymentTarget)
+        .map((wallet) => ({
           label: wallet.name,
           value: wallet,
-        })
-      ),
+        })),
     },
   };
 


### PR DESCRIPTION
## Summary
This PR adds support for filtering wallets by payment eligibility and improves the transaction payment flow by handling the empty state when no eligible wallets are available.

## Key Changes
- **Added `isPaymentTarget` field to Wallet entity**: New boolean property to identify wallets that can receive payments
- **Implemented wallet filtering in TransactionCreateHandler**: Only wallets with `isPaymentTarget: true` are now passed to the payment alert component
- **Enhanced TransactionPaymentAlert component**:
  - Displays an empty state message when no eligible wallets are configured
  - Automatically disables the Submit button when no wallets are available
  - Prevents users from attempting payment without a valid wallet selection
- **Updated all mock data and transformers**: Added `isPaymentTarget` property to all wallet instances and API transformation logic
- **Added comprehensive test coverage**: New test suite for TransactionPaymentAlert covering eligible wallets, empty state, and filtering responsibility

## Implementation Details
- The filtering logic is centralized in `TransactionCreateHandler`, ensuring upstream responsibility for wallet eligibility
- The component gracefully handles the empty state with a user-friendly message directing users to Wallet Settings
- Submit button is disabled both when `isButtonDisabled` prop is true OR when no wallet options are available, preventing invalid submissions
- All existing wallet mocks and API contracts have been updated to include the new `isPaymentTarget` field with appropriate default values

https://claude.ai/code/session_01K6hhtJp7BBphTarcNzfEGc