### PR TITLE
Add isPaymentTarget field to wallet management

### DIFF
--- a/libs/ui/src/data/api/wallet.transformer.ts
+++ b/libs/ui/src/data/api/wallet.transformer.ts
@@ -23,6 +23,7 @@ export function toApiWallet(form: WalletForm) {
     balance: form.balance,
     paymentCostPercentage: form.paymentCostPercentage,
     isCashless: form.isCashless,
+    isPaymentTarget: form.isPaymentTarget,
   };
 }
 

--- a/libs/ui/src/data/mock/wallet.ts
+++ b/libs/ui/src/data/mock/wallet.ts
@@ -69,7 +69,7 @@ export class MockWalletRepository implements WalletRepository {
       balance: formValues.balance,
       paymentCostPercentage: formValues.paymentCostPercentage,
       isCashless: formValues.isCashless,
-      isPaymentTarget: true,
+      isPaymentTarget: formValues.isPaymentTarget,
       createdAt: new Date().toISOString(),
     });
   }
@@ -87,6 +87,7 @@ export class MockWalletRepository implements WalletRepository {
       balance: formValues.balance,
       paymentCostPercentage: formValues.paymentCostPercentage,
       isCashless: formValues.isCashless,
+      isPaymentTarget: formValues.isPaymentTarget,
     };
   }
 

--- a/libs/ui/src/domain/entities/Wallet.ts
+++ b/libs/ui/src/domain/entities/Wallet.ts
@@ -13,4 +13,5 @@ export type WalletForm = {
   balance: number;
   paymentCostPercentage: number;
   isCashless: boolean;
+  isPaymentTarget: boolean;
 };

--- a/libs/ui/src/domain/usecases/walletCreate.test.ts
+++ b/libs/ui/src/domain/usecases/walletCreate.test.ts
@@ -17,7 +17,7 @@ describe('WalletCreateUsecase', () => {
 
       tester.dispatch({
         type: 'SUBMIT',
-        values: { name: 'New Wallet', balance: 0, paymentCostPercentage: 0, isCashless: false },
+        values: { name: 'New Wallet', balance: 0, paymentCostPercentage: 0, isCashless: false, isPaymentTarget: true },
       });
       expect(tester.state.type).toBe('submitting');
 
@@ -37,7 +37,7 @@ describe('WalletCreateUsecase', () => {
 
       tester.dispatch({
         type: 'SUBMIT',
-        values: { name: 'New Wallet', balance: 0, paymentCostPercentage: 0, isCashless: false },
+        values: { name: 'New Wallet', balance: 0, paymentCostPercentage: 0, isCashless: false, isPaymentTarget: true },
       });
       expect(tester.state.type).toBe('submitting');
 

--- a/libs/ui/src/domain/usecases/walletCreate.ts
+++ b/libs/ui/src/domain/usecases/walletCreate.ts
@@ -43,6 +43,7 @@ export class WalletCreateUsecase extends Usecase<
         balance: 0,
         paymentCostPercentage: 0,
         isCashless: false,
+        isPaymentTarget: true,
       },
     };
   }

--- a/libs/ui/src/domain/usecases/walletUpdate.test.ts
+++ b/libs/ui/src/domain/usecases/walletUpdate.test.ts
@@ -22,7 +22,7 @@ describe('WalletUpdateUsecase', () => {
 
       tester.dispatch({
         type: 'SUBMIT',
-        values: { name: 'Updated Wallet', balance: 500000, paymentCostPercentage: 0, isCashless: false },
+        values: { name: 'Updated Wallet', balance: 500000, paymentCostPercentage: 0, isCashless: false, isPaymentTarget: true },
       });
       expect(tester.state.type).toBe('submitting');
 
@@ -66,7 +66,7 @@ describe('WalletUpdateUsecase', () => {
 
       tester.dispatch({
         type: 'SUBMIT',
-        values: { name: 'Updated Wallet', balance: 500000, paymentCostPercentage: 0, isCashless: false },
+        values: { name: 'Updated Wallet', balance: 500000, paymentCostPercentage: 0, isCashless: false, isPaymentTarget: true },
       });
       expect(tester.state.type).toBe('submitting');
 

--- a/libs/ui/src/domain/usecases/walletUpdate.ts
+++ b/libs/ui/src/domain/usecases/walletUpdate.ts
@@ -56,6 +56,7 @@ export class WalletUpdateUsecase extends Usecase<
         balance: this.params.wallet?.balance ?? 0,
         paymentCostPercentage: this.params.wallet?.paymentCostPercentage ?? 0,
         isCashless: this.params.wallet?.isCashless ?? false,
+        isPaymentTarget: this.params.wallet?.isPaymentTarget ?? true,
       },
     };
   }
@@ -151,6 +152,7 @@ export class WalletUpdateUsecase extends Usecase<
                 balance: wallet.balance,
                 paymentCostPercentage: wallet.paymentCostPercentage,
                 isCashless: wallet.isCashless,
+                isPaymentTarget: wallet.isPaymentTarget,
               },
             })
           )

--- a/libs/ui/src/presentation/components/wallets/WalletFormView.stories.tsx
+++ b/libs/ui/src/presentation/components/wallets/WalletFormView.stories.tsx
@@ -10,6 +10,7 @@ const defaultValues: WalletForm = {
   balance: 0,
   paymentCostPercentage: 0,
   isCashless: false,
+  isPaymentTarget: true,
 };
 
 const LoadedStory = () => {
@@ -31,6 +32,7 @@ const PopulatedStory = () => {
       balance: 5000000,
       paymentCostPercentage: 0,
       isCashless: false,
+      isPaymentTarget: true,
     },
   });
   return (

--- a/libs/ui/src/presentation/components/wallets/WalletFormView.tsx
+++ b/libs/ui/src/presentation/components/wallets/WalletFormView.tsx
@@ -8,7 +8,7 @@ import {
   Switch,
 } from '../base';
 import { WalletForm } from '../../../domain';
-import { Button, Form, Spinner } from 'tamagui';
+import { Button, Form, Paragraph, Spinner } from 'tamagui';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 
 export type WalletFormViewProps = {
@@ -46,6 +46,12 @@ export const WalletFormView = ({
         </Field>
         <Field name="isCashless" label="Cashless">
           <Switch />
+        </Field>
+        <Field name="isPaymentTarget" label="Can receive transaction payments">
+          <Switch />
+          <Paragraph size="$2" color="$gray10">
+            Turn this off for internal wallets (e.g. a safe or holding account) that should not appear in the checkout payment modal.
+          </Paragraph>
         </Field>
         <Button
           disabled={isSubmitDisabled}

--- a/libs/ui/src/presentation/components/wallets/WalletList.tsx
+++ b/libs/ui/src/presentation/components/wallets/WalletList.tsx
@@ -50,6 +50,7 @@ export const WalletList = ({
                 balance={item.balance}
                 name={item.name}
                 paymentCostPercentage={item.paymentCostPercentage}
+                isPaymentTarget={item.isPaymentTarget}
                 onEditMenuPress={() => onEditMenuPress(item)}
                 onTransferMenuPress={() => onTransferMenuPress(item)}
                 onPress={() => onItemPress(item)}

--- a/libs/ui/src/presentation/components/wallets/WalletListItem.tsx
+++ b/libs/ui/src/presentation/components/wallets/WalletListItem.tsx
@@ -1,4 +1,4 @@
-import { CreditCard, MinusSquare, Pencil, Trash } from '@tamagui/lucide-icons';
+import { CreditCard, MinusSquare, Pencil, ShoppingCart, Trash } from '@tamagui/lucide-icons';
 import { ListItem } from '../base';
 import { XStackProps } from 'tamagui';
 
@@ -6,6 +6,7 @@ export type WalletListItemProps = {
   name: string;
   balance: number;
   paymentCostPercentage: number;
+  isPaymentTarget: boolean;
   onTransferMenuPress?: () => void;
   onEditMenuPress?: () => void;
   onDeleteMenuPress?: () => void;
@@ -15,6 +16,7 @@ export const WalletListItem = ({
   name,
   balance,
   paymentCostPercentage,
+  isPaymentTarget,
   onTransferMenuPress,
   onEditMenuPress,
   onDeleteMenuPress,
@@ -45,7 +47,14 @@ export const WalletListItem = ({
           isShown: typeof onDeleteMenuPress === 'function',
         },
       ]}
-      footerItems={[{ value: `${paymentCostPercentage}%`, icon: MinusSquare }]}
+      footerItems={[
+        { value: `${paymentCostPercentage}%`, icon: MinusSquare },
+        {
+          label: 'Payment Target',
+          value: isPaymentTarget ? 'Yes' : 'No',
+          icon: ShoppingCart,
+        },
+      ]}
       {...xStackProps}
     />
   );

--- a/libs/ui/src/presentation/controllers/WalletCreateController.tsx
+++ b/libs/ui/src/presentation/controllers/WalletCreateController.tsx
@@ -23,6 +23,7 @@ export const useWalletCreateController = (usecase: WalletCreateUsecase) => {
         balance: z.number(),
         paymentCostPercentage: z.number(),
         isCashless: z.boolean(),
+        isPaymentTarget: z.boolean(),
       })
     ),
   });

--- a/libs/ui/src/presentation/controllers/WalletUpdateController.tsx
+++ b/libs/ui/src/presentation/controllers/WalletUpdateController.tsx
@@ -25,6 +25,7 @@ export const useWalletUpdateController = (usecase: WalletUpdateUsecase) => {
         balance: z.number(),
         paymentCostPercentage: z.number(),
         isCashless: z.boolean(),
+        isPaymentTarget: z.boolean(),
       })
     ),
   });

--- a/libs/ui/src/presentation/screens/WalletCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/WalletCreateHandler.test.tsx
@@ -40,6 +40,16 @@ describe('WalletCreateHandler', () => {
       render(<WalletCreateHandler {...createProps()} />);
       expect(screen.getByRole('textbox', { name: 'Name' })).toBeTruthy();
     });
+
+    it('should render the isPaymentTarget switch field', () => {
+      render(<WalletCreateHandler {...createProps()} />);
+      expect(screen.getByRole('switch', { name: 'Can receive transaction payments' })).toBeTruthy();
+    });
+
+    it('should render the isPaymentTarget switch as checked by default', () => {
+      render(<WalletCreateHandler {...createProps()} />);
+      expect(screen.getByRole('switch', { name: 'Can receive transaction payments', checked: true })).toBeTruthy();
+    });
   });
 
   describe('navigation', () => {

--- a/libs/ui/src/presentation/screens/WalletCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/WalletCreateScreen.stories.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import { WalletCreateScreen } from './WalletCreateScreen';
 import type { WalletForm } from '../../domain';
 
-const defaultValues: WalletForm = { name: '', balance: 0, paymentCostPercentage: 0, isCashless: false };
+const defaultValues: WalletForm = { name: '', balance: 0, paymentCostPercentage: 0, isCashless: false, isPaymentTarget: true };
 
 const CreateStory = () => {
   const form = useForm<WalletForm>({ defaultValues });

--- a/libs/ui/src/presentation/screens/WalletListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/WalletListHandler.test.tsx
@@ -54,6 +54,16 @@ describe('WalletListHandler', () => {
       expect(screen.getByRole('heading', { name: 'Bank Transfer' })).toBeTruthy();
     });
 
+    it('should show Payment Target badge for each wallet', async () => {
+      render(<WalletListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getAllByText('Yes').length).toBeGreaterThan(0);
+    });
+
     it('should show error state when fetch fails', async () => {
       const walletRepo = new MockWalletRepository();
       walletRepo.setShouldFail(true);

--- a/libs/ui/src/presentation/screens/WalletTransferListHandler.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferListHandler.tsx
@@ -42,6 +42,7 @@ export const WalletTransferListHandler = ({
       paymentCostPercentage={
         walletDetail.state.wallet?.paymentCostPercentage ?? 0
       }
+      isPaymentTarget={walletDetail.state.wallet?.isPaymentTarget ?? true}
       variant={match(walletTransfers.state)
         .returnType<WalletTransferListProps['variant']>()
         .with({ type: P.union('idle', 'loading') }, () => ({

--- a/libs/ui/src/presentation/screens/WalletTransferListScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferListScreen.stories.tsx
@@ -15,6 +15,7 @@ const defaultArgs = {
   name: mockWallet.name,
   balance: mockWallet.balance,
   paymentCostPercentage: mockWallet.paymentCostPercentage,
+  isPaymentTarget: mockWallet.isPaymentTarget,
   onRetryButtonPress: fn(),
 };
 

--- a/libs/ui/src/presentation/screens/WalletTransferListScreen.tsx
+++ b/libs/ui/src/presentation/screens/WalletTransferListScreen.tsx
@@ -14,6 +14,7 @@ export type WalletTransferListScreenProps = {
   name: string;
   balance: number;
   paymentCostPercentage: number;
+  isPaymentTarget: boolean;
   variant: WalletTransferListProps['variant'];
   onRetryButtonPress: () => void;
   isRevalidating?: boolean;
@@ -26,6 +27,7 @@ export const WalletTransferListScreen = ({
   name,
   balance,
   paymentCostPercentage,
+  isPaymentTarget,
   variant,
   onRetryButtonPress,
   isRevalidating,
@@ -42,6 +44,7 @@ export const WalletTransferListScreen = ({
           name={name}
           balance={balance}
           paymentCostPercentage={paymentCostPercentage}
+          isPaymentTarget={isPaymentTarget}
         />
         <YStack flex={1} gap="$3">
           <XStack gap="$3" justifyContent="space-between">

--- a/libs/ui/src/presentation/screens/WalletUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/WalletUpdateHandler.test.tsx
@@ -70,6 +70,22 @@ describe('WalletUpdateHandler', () => {
       });
     });
 
+    it('should render the isPaymentTarget switch field', async () => {
+      render(<WalletUpdateHandler {...createProps({ preloaded: true })} />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.getByRole('switch', { name: 'Can receive transaction payments' })).toBeTruthy();
+    });
+
+    it('should pre-fill isPaymentTarget switch from fetched wallet data', async () => {
+      render(<WalletUpdateHandler {...createProps()} />);
+      await act(async () => {
+        await flushPromises();
+      });
+      expect(screen.getByRole('switch', { name: 'Can receive transaction payments', checked: true })).toBeTruthy();
+    });
+
     it('should show error state when wallet fetch fails', async () => {
       render(<WalletUpdateHandler {...createProps({ shouldFail: true })} />);
 

--- a/libs/ui/src/presentation/screens/WalletUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/WalletUpdateScreen.stories.tsx
@@ -7,7 +7,7 @@ import type { WalletForm } from '../../domain';
 
 const UpdateStory = () => {
   const form = useForm<WalletForm>({
-    defaultValues: { name: 'BCA', balance: 5000000, paymentCostPercentage: 0, isCashless: true },
+    defaultValues: { name: 'BCA', balance: 5000000, paymentCostPercentage: 0, isCashless: true, isPaymentTarget: true },
   });
   return (
     <WalletUpdateScreen
@@ -22,7 +22,7 @@ const UpdateStory = () => {
 
 const LoadingStory = () => {
   const form = useForm<WalletForm>({
-    defaultValues: { name: '', balance: 0, paymentCostPercentage: 0, isCashless: false },
+    defaultValues: { name: '', balance: 0, paymentCostPercentage: 0, isCashless: false, isPaymentTarget: true },
   });
   return (
     <WalletUpdateScreen


### PR DESCRIPTION
## Summary
This PR adds support for the `isPaymentTarget` field to the wallet management system, allowing users to designate whether a wallet can receive transaction payments. This enables the distinction between payment-enabled wallets and internal wallets (e.g., safes or holding accounts) that should not appear in checkout payment modals.

## Key Changes

- **Domain Model**: Added `isPaymentTarget: boolean` field to the `WalletForm` type
- **Form UI**: 
  - Added a new switch field "Can receive transaction payments" in `WalletFormView` with explanatory text
  - Defaults to `true` for new wallets
  - Field is pre-filled from existing wallet data during updates
- **Wallet Display**: 
  - Updated `WalletListItem` to show payment target status with a shopping cart icon
  - Displays "Yes" or "No" in the footer items
- **Data Layer**: 
  - Updated mock repository to respect the form value instead of hardcoding `true`
  - Added field to API wallet transformer
- **Controllers & Usecases**: 
  - Added validation schema for the new field in both create and update controllers
  - Updated wallet create and update usecases to initialize and handle the field
- **Tests**: 
  - Added test coverage for rendering the switch field
  - Added test for pre-filling the field from fetched wallet data
  - Added test for payment target badge display in wallet lists
- **Stories**: Updated all Storybook stories to include the new field with default value `true`

## Implementation Details

- The field defaults to `true` for new wallets, making them payment-enabled by default
- The switch includes helper text explaining its purpose for internal vs. payment wallets
- The field is properly threaded through all layers: form → controller → usecase → repository → API
- All existing tests updated to include the new field in test data

https://claude.ai/code/session_01HbFJGdr7ra62AjP74edSKg