### PR TITLE
Add IsPaymentTarget field to wallet updates in transactions

### DIFF
--- a/apps/api/domain/transaction_usecase.go
+++ b/apps/api/domain/transaction_usecase.go
@@ -224,6 +224,7 @@ func (usecase TransactionUsecase) PayTransaction(ctx context.Context, walletId i
 			PaymentCostPercentage: paymentWallet.PaymentCostPercentage,
 			Balance:               newBalance,
 			IsCashless:            paymentWallet.IsCashless,
+			IsPaymentTarget:       paymentWallet.IsPaymentTarget,
 		},
 			walletId); err != nil {
 			return err
@@ -300,6 +301,7 @@ func (usecase TransactionUsecase) UnpayTransaction(ctx context.Context, id int64
 			PaymentCostPercentage: paymentWallet.PaymentCostPercentage,
 			Balance:               newBalance,
 			IsCashless:            paymentWallet.IsCashless,
+			IsPaymentTarget:       paymentWallet.IsPaymentTarget,
 		},
 			*transaction.WalletId); err != nil {
 			return err

--- a/apps/api/domain/wallet_usecase.go
+++ b/apps/api/domain/wallet_usecase.go
@@ -54,6 +54,7 @@ func (usecase WalletUsecase) CreateWalletTransfer(ctx context.Context, walletTra
 			Name:                  fromWallet.Name,
 			PaymentCostPercentage: fromWallet.PaymentCostPercentage,
 			IsCashless:            fromWallet.IsCashless,
+			IsPaymentTarget:       fromWallet.IsPaymentTarget,
 			Balance:               fromWallet.Balance - walletTransfer.Amount,
 		}, fromWalletId); err != nil {
 			return err
@@ -68,6 +69,7 @@ func (usecase WalletUsecase) CreateWalletTransfer(ctx context.Context, walletTra
 			Name:                  toWallet.Name,
 			PaymentCostPercentage: toWallet.PaymentCostPercentage,
 			IsCashless:            toWallet.IsCashless,
+			IsPaymentTarget:       toWallet.IsPaymentTarget,
 			Balance:               toWallet.Balance + walletTransfer.Amount,
 		}, walletTransfer.ToWalletId); err != nil {
 			return err


### PR DESCRIPTION
## Summary
This PR adds the `IsPaymentTarget` field to wallet update operations across transaction and wallet transfer use cases. This ensures the payment target status is preserved when updating wallet state during payment, unpayment, and transfer operations.

## Key Changes
- **TransactionUsecase**: Added `IsPaymentTarget` field to wallet updates in both `PayTransaction` and `UnpayTransaction` methods
- **WalletUsecase**: Added `IsPaymentTarget` field to wallet updates for both source and destination wallets in `CreateWalletTransfer` method

## Implementation Details
The `IsPaymentTarget` field is now consistently included alongside other wallet properties (`IsCashless`, `PaymentCostPercentage`) when persisting wallet state changes. This prevents the field from being lost or reset to a default value during transaction operations.

https://claude.ai/code/session_01TAaNcDLbyqP6L3Z4Yp9pGA