### PR TITLE
Add IsPaymentTarget field to wallet updates in expense operations

### DIFF
--- a/apps/api/domain/expense_usecase.go
+++ b/apps/api/domain/expense_usecase.go
@@ -64,6 +64,7 @@ func (usecase ExpenseUsecase) CreateExpense(ctx context.Context, expense Expense
 			Balance:               expenseWallet.Balance - expense.Total,
 			PaymentCostPercentage: expenseWallet.PaymentCostPercentage,
 			IsCashless:            expenseWallet.IsCashless,
+			IsPaymentTarget:       expenseWallet.IsPaymentTarget,
 		}, expense.WalletId); err != nil {
 			return err
 		}
@@ -106,6 +107,7 @@ func (usecase ExpenseUsecase) UpdateExpenseById(ctx context.Context, expense Exp
 			Balance:               expenseWallet.Balance + existingExpense.Total,
 			PaymentCostPercentage: expenseWallet.PaymentCostPercentage,
 			IsCashless:            expenseWallet.IsCashless,
+			IsPaymentTarget:       expenseWallet.IsPaymentTarget,
 		}, existingExpense.WalletId); err != nil {
 			return err
 		}
@@ -135,6 +137,7 @@ func (usecase ExpenseUsecase) UpdateExpenseById(ctx context.Context, expense Exp
 			Balance:               expenseWallet.Balance - expense.Total,
 			PaymentCostPercentage: expenseWallet.PaymentCostPercentage,
 			IsCashless:            expenseWallet.IsCashless,
+			IsPaymentTarget:       expenseWallet.IsPaymentTarget,
 		}, expense.WalletId); err != nil {
 			return err
 		}
@@ -178,6 +181,7 @@ func (usecase ExpenseUsecase) DeleteExpenseById(ctx context.Context, id int64) *
 			Balance:               expenseWallet.Balance + existingExpense.Total,
 			PaymentCostPercentage: expenseWallet.PaymentCostPercentage,
 			IsCashless:            expenseWallet.IsCashless,
+			IsPaymentTarget:       expenseWallet.IsPaymentTarget,
 		}, existingExpense.WalletId); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Summary
This change ensures that the `IsPaymentTarget` field is preserved when updating wallet information during expense operations. Previously, this field was not being included in wallet update payloads, which could result in data loss.

## Key Changes
- Added `IsPaymentTarget: expenseWallet.IsPaymentTarget` to wallet update calls in `CreateExpense()`
- Added `IsPaymentTarget: expenseWallet.IsPaymentTarget` to wallet update calls in `UpdateExpenseById()` (both balance increase and decrease scenarios)
- Added `IsPaymentTarget: expenseWallet.IsPaymentTarget` to wallet update call in `DeleteExpenseById()`

## Implementation Details
The `IsPaymentTarget` field is now consistently included alongside other wallet properties (`Balance`, `PaymentCostPercentage`, `IsCashless`) when persisting wallet state changes. This ensures that the payment target designation of a wallet is maintained across all expense-related operations.

https://claude.ai/code/session_013P97rXSE27KPFAPTM1r5ED