### PR TITLE
Improve stock validation with required field error message

### DIFF
--- a/apps/web/src/pages/stock-checks/create.tsx
+++ b/apps/web/src/pages/stock-checks/create.tsx
@@ -40,7 +40,7 @@ export const getServerSideProps: GetServerSideProps<
           materialId: material.id,
           materialName: material.name,
           purchaseUnit: material.purchaseUnit,
-          currentStock: 0,
+          currentStock: null,
         })),
       },
     },

--- a/libs/ui/src/domain/entities/StockCheck.ts
+++ b/libs/ui/src/domain/entities/StockCheck.ts
@@ -22,7 +22,7 @@ export type StockCheckItemForm = {
   materialId: number;
   materialName: string;
   purchaseUnit: string;
-  currentStock: number;
+  currentStock: number | null;
 };
 
 export type StockCheckForm = {

--- a/libs/ui/src/presentation/controllers/StockCheckCreateController.tsx
+++ b/libs/ui/src/presentation/controllers/StockCheckCreateController.tsx
@@ -10,7 +10,10 @@ const stockCheckItemSchema = z.object({
   materialId: z.number().int().positive(),
   materialName: z.string(),
   purchaseUnit: z.string(),
-  currentStock: z.number().int().min(0),
+  currentStock: z
+    .number({ invalid_type_error: 'Please enter the current stock' })
+    .int()
+    .min(0),
 });
 
 const stockCheckSchema = z.object({

--- a/libs/ui/src/presentation/controllers/StockCheckUpdateController.tsx
+++ b/libs/ui/src/presentation/controllers/StockCheckUpdateController.tsx
@@ -10,7 +10,10 @@ const stockCheckItemSchema = z.object({
   materialId: z.number().int().positive(),
   materialName: z.string(),
   purchaseUnit: z.string(),
-  currentStock: z.number().int().min(0),
+  currentStock: z
+    .number({ invalid_type_error: 'Please enter the current stock' })
+    .int()
+    .min(0),
 });
 
 const stockCheckSchema = z.object({


### PR DESCRIPTION
## Summary
Enhanced the stock check form validation to require users to explicitly enter the current stock value, rather than defaulting to 0. This improves data accuracy by preventing accidental submission of empty stock values.

## Key Changes
- Updated `StockCheckItemForm` type to allow `currentStock` to be `number | null` instead of just `number`
- Modified validation schemas in both `StockCheckCreateController` and `StockCheckUpdateController` to provide a user-friendly error message ("Please enter the current stock") when the currentStock field is missing or invalid
- Changed the default initial value for currentStock from `0` to `null` in the stock check creation form, ensuring users must actively input a value

## Implementation Details
- The Zod schema now explicitly handles the `invalid_type_error` case for the currentStock field, guiding users to provide a value rather than silently accepting a zero default
- This change applies consistently across both create and update stock check workflows
- The null type allows the form to distinguish between "not provided" and "provided as zero", enabling better validation feedback

https://claude.ai/code/session_015t1ofCewV7tghwC1EzgEhA