### PR TITLE
Add pending filter and progress tracking to stock check form

### DIFF
--- a/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
+++ b/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { FormProvider, useFieldArray, UseFormReturn, useWatch } from 'react-hook-form';
+import { FormProvider, useFieldArray, UseFormReturn } from 'react-hook-form';
 import {
   Button,
   Form,
@@ -13,9 +12,6 @@ import {
 import { Filter, X } from '@tamagui/lucide-icons';
 import { FormErrorBanner, InputNumber } from '../base';
 import { StockCheckForm } from '../../../domain';
-import { createDebounce } from '../../../utils';
-
-const changeQueryDebounce = createDebounce();
 
 export type StockCheckFormViewProps = {
   form: UseFormReturn<StockCheckForm>;
@@ -23,6 +19,13 @@ export type StockCheckFormViewProps = {
   isSubmitDisabled: boolean;
   isSubmitting: boolean;
   serverError?: string;
+  query: string;
+  onQueryChange: (value: string) => void;
+  showOnlyPending: boolean;
+  onShowOnlyPendingToggle: () => void;
+  filled: number;
+  total: number;
+  pendingRows: boolean[];
 };
 
 export const StockCheckFormView = ({
@@ -31,15 +34,15 @@ export const StockCheckFormView = ({
   isSubmitDisabled,
   isSubmitting,
   serverError,
+  query,
+  onQueryChange,
+  showOnlyPending,
+  onShowOnlyPendingToggle,
+  filled,
+  total,
+  pendingRows,
 }: StockCheckFormViewProps) => {
   const { fields } = useFieldArray({ control: form.control, name: 'items' });
-  const [query, setQuery] = useState('');
-  const [showOnlyPending, setShowOnlyPending] = useState(false);
-
-  const watchedItems = useWatch({ control: form.control, name: 'items' });
-
-  const total = fields.length;
-  const filled = watchedItems.filter((item) => item.currentStock !== null).length;
 
   const lowerQuery = query.toLowerCase();
   const matchCount = lowerQuery
@@ -48,10 +51,6 @@ export const StockCheckFormView = ({
     : fields.length;
   const hasQuery = query.length > 0;
   const noMatches = hasQuery && matchCount === 0;
-
-  const handleChange = (value: string) => {
-    changeQueryDebounce(() => setQuery(value), 400);
-  };
 
   return (
     <FormProvider {...form}>
@@ -72,16 +71,14 @@ export const StockCheckFormView = ({
           <Input
             flex={1}
             placeholder="Search material by name"
-            onChangeText={handleChange}
+            onChangeText={onQueryChange}
           />
           {hasQuery && (
             <Button
               icon={X}
               circular
               size="$2"
-              onPress={() => {
-                handleChange('');
-              }}
+              onPress={() => onQueryChange('')}
               accessibilityLabel="Clear search"
             />
           )}
@@ -89,7 +86,7 @@ export const StockCheckFormView = ({
             icon={Filter}
             circular
             size="$2"
-            onPress={() => setShowOnlyPending((prev) => !prev)}
+            onPress={onShowOnlyPendingToggle}
             theme={showOnlyPending ? 'yellow' : undefined}
             accessibilityLabel={
               showOnlyPending ? 'Show all materials' : 'Show only pending'
@@ -114,8 +111,7 @@ export const StockCheckFormView = ({
 
           {fields.map((field, index) => {
             const inputId = `stock-check-item-${field.id}`;
-            const currentStock = watchedItems[index]?.currentStock ?? null;
-            const isPending = currentStock === null;
+            const isPending = pendingRows[index] ?? false;
 
             const hiddenBySearch =
               hasQuery &&

--- a/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
+++ b/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { FormProvider, useFieldArray, UseFormReturn } from 'react-hook-form';
+import { FormProvider, useFieldArray, UseFormReturn, useWatch } from 'react-hook-form';
 import {
   Button,
   Form,
@@ -10,7 +10,7 @@ import {
   XStack,
   YStack,
 } from 'tamagui';
-import { X } from '@tamagui/lucide-icons';
+import { Filter, X } from '@tamagui/lucide-icons';
 import { FormErrorBanner, InputNumber } from '../base';
 import { StockCheckForm } from '../../../domain';
 import { createDebounce } from '../../../utils';
@@ -34,6 +34,12 @@ export const StockCheckFormView = ({
 }: StockCheckFormViewProps) => {
   const { fields } = useFieldArray({ control: form.control, name: 'items' });
   const [query, setQuery] = useState('');
+  const [showOnlyPending, setShowOnlyPending] = useState(false);
+
+  const watchedItems = useWatch({ control: form.control, name: 'items' });
+
+  const total = fields.length;
+  const filled = watchedItems.filter((item) => item.currentStock !== null).length;
 
   const lowerQuery = query.toLowerCase();
   const matchCount = lowerQuery
@@ -79,9 +85,23 @@ export const StockCheckFormView = ({
               accessibilityLabel="Clear search"
             />
           )}
+          <Button
+            icon={Filter}
+            circular
+            size="$2"
+            onPress={() => setShowOnlyPending((prev) => !prev)}
+            theme={showOnlyPending ? 'yellow' : undefined}
+            accessibilityLabel={
+              showOnlyPending ? 'Show all materials' : 'Show only pending'
+            }
+          />
         </XStack>
 
         <YStack maxWidth={640} alignSelf="center" width="100%">
+          <SizableText color="$gray10" paddingBottom="$2">
+            {filled} / {total} materials checked
+          </SizableText>
+
           {noMatches && (
             <SizableText
               color="$gray10"
@@ -94,18 +114,27 @@ export const StockCheckFormView = ({
 
           {fields.map((field, index) => {
             const inputId = `stock-check-item-${field.id}`;
-            const hidden =
+            const currentStock = watchedItems[index]?.currentStock ?? null;
+            const isPending = currentStock === null;
+
+            const hiddenBySearch =
               hasQuery &&
               !field.materialName.toLowerCase().includes(lowerQuery);
+            const hiddenByPendingFilter = showOnlyPending && !isPending;
+            const hidden = hiddenBySearch || hiddenByPendingFilter;
+
             return (
               <XStack
                 key={field.id}
                 gap="$2"
                 alignItems="center"
                 paddingVertical="$2"
+                paddingHorizontal="$2"
                 borderBottomWidth={1}
                 borderBottomColor="$borderColor"
                 display={hidden ? 'none' : 'flex'}
+                backgroundColor={isPending ? '$yellow3' : undefined}
+                borderRadius="$2"
               >
                 <Label flex={1} numberOfLines={1} htmlFor={inputId}>
                   {field.materialName}
@@ -118,6 +147,18 @@ export const StockCheckFormView = ({
                 <SizableText width={60} color="$gray10">
                   {field.purchaseUnit}
                 </SizableText>
+                {isPending && (
+                  <XStack
+                    backgroundColor="$yellow5"
+                    paddingHorizontal="$2"
+                    paddingVertical="$1"
+                    borderRadius="$10"
+                  >
+                    <SizableText size="$1" color="$yellow11">
+                      Pending
+                    </SizableText>
+                  </XStack>
+                )}
               </XStack>
             );
           })}

--- a/libs/ui/src/presentation/controllers/StockCheckCreateController.tsx
+++ b/libs/ui/src/presentation/controllers/StockCheckCreateController.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { StockCheckCreateUsecase } from '../../domain';
 import { useController } from './controller';
 import { useToastController } from '@tamagui/toast';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { createDebounce } from '../../utils';
 
 const stockCheckItemSchema = z.object({
   materialId: z.number().int().positive(),
@@ -34,9 +35,31 @@ export const useStockCheckCreateController = (usecase: StockCheckCreateUsecase) 
     resolver: zodResolver(stockCheckSchema),
   });
 
+  const [query, setQuery] = useState('');
+  const [showOnlyPending, setShowOnlyPending] = useState(false);
+  const debounceRef = useRef(createDebounce());
+
+  const watchedItems = useWatch({ control: form.control, name: 'items' });
+  const total = watchedItems.length;
+  const filled = watchedItems.filter((item) => item.currentStock !== null).length;
+  const pendingRows = watchedItems.map((item) => item.currentStock === null);
+
+  const handleQueryChange = (value: string) => {
+    debounceRef.current(() => setQuery(value), 400);
+  };
+
+  const toggleShowOnlyPending = () => setShowOnlyPending((prev) => !prev);
+
   return {
     state,
     dispatch,
     form,
+    query,
+    handleQueryChange,
+    showOnlyPending,
+    toggleShowOnlyPending,
+    filled,
+    total,
+    pendingRows,
   };
 };

--- a/libs/ui/src/presentation/controllers/StockCheckUpdateController.tsx
+++ b/libs/ui/src/presentation/controllers/StockCheckUpdateController.tsx
@@ -1,10 +1,11 @@
-import { useEffect } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { StockCheckUpdateUsecase } from '../../domain';
 import { useController } from './controller';
 import { useToastController } from '@tamagui/toast';
-import { useForm } from 'react-hook-form';
+import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
+import { createDebounce } from '../../utils';
 
 const stockCheckItemSchema = z.object({
   materialId: z.number().int().positive(),
@@ -34,9 +35,31 @@ export const useStockCheckUpdateController = (usecase: StockCheckUpdateUsecase) 
     resolver: zodResolver(stockCheckSchema),
   });
 
+  const [query, setQuery] = useState('');
+  const [showOnlyPending, setShowOnlyPending] = useState(false);
+  const debounceRef = useRef(createDebounce());
+
+  const watchedItems = useWatch({ control: form.control, name: 'items' });
+  const total = watchedItems.length;
+  const filled = watchedItems.filter((item) => item.currentStock !== null).length;
+  const pendingRows = watchedItems.map((item) => item.currentStock === null);
+
+  const handleQueryChange = (value: string) => {
+    debounceRef.current(() => setQuery(value), 400);
+  };
+
+  const toggleShowOnlyPending = () => setShowOnlyPending((prev) => !prev);
+
   return {
     state,
     dispatch,
     form,
+    query,
+    handleQueryChange,
+    showOnlyPending,
+    toggleShowOnlyPending,
+    filled,
+    total,
+    pendingRows,
   };
 };

--- a/libs/ui/src/presentation/screens/StockCheckCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/StockCheckCreateHandler.tsx
@@ -45,6 +45,13 @@ export const StockCheckCreateHandler = ({
           : undefined
       }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
+      query={stockCheckCreate.query}
+      onQueryChange={stockCheckCreate.handleQueryChange}
+      showOnlyPending={stockCheckCreate.showOnlyPending}
+      onShowOnlyPendingToggle={stockCheckCreate.toggleShowOnlyPending}
+      filled={stockCheckCreate.filled}
+      total={stockCheckCreate.total}
+      pendingRows={stockCheckCreate.pendingRows}
     />
   );
 };

--- a/libs/ui/src/presentation/screens/StockCheckCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/StockCheckCreateScreen.tsx
@@ -10,6 +10,13 @@ export type StockCheckCreateScreenProps = {
   isSubmitting: boolean;
   onLogoutPress: () => void;
   serverError?: string;
+  query: string;
+  onQueryChange: (value: string) => void;
+  showOnlyPending: boolean;
+  onShowOnlyPendingToggle: () => void;
+  filled: number;
+  total: number;
+  pendingRows: boolean[];
 };
 
 export const StockCheckCreateScreen = (props: StockCheckCreateScreenProps) => {
@@ -26,6 +33,13 @@ export const StockCheckCreateScreen = (props: StockCheckCreateScreenProps) => {
           isSubmitDisabled={props.isSubmitDisabled}
           isSubmitting={props.isSubmitting}
           serverError={props.serverError}
+          query={props.query}
+          onQueryChange={props.onQueryChange}
+          showOnlyPending={props.showOnlyPending}
+          onShowOnlyPendingToggle={props.onShowOnlyPendingToggle}
+          filled={props.filled}
+          total={props.total}
+          pendingRows={props.pendingRows}
         />
       </ScrollView>
     </Layout>

--- a/libs/ui/src/presentation/screens/StockCheckUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/StockCheckUpdateHandler.tsx
@@ -44,6 +44,13 @@ export const StockCheckUpdateHandler = ({
           : undefined
       }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
+      query={stockCheckUpdate.query}
+      onQueryChange={stockCheckUpdate.handleQueryChange}
+      showOnlyPending={stockCheckUpdate.showOnlyPending}
+      onShowOnlyPendingToggle={stockCheckUpdate.toggleShowOnlyPending}
+      filled={stockCheckUpdate.filled}
+      total={stockCheckUpdate.total}
+      pendingRows={stockCheckUpdate.pendingRows}
     />
   );
 };

--- a/libs/ui/src/presentation/screens/StockCheckUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/StockCheckUpdateScreen.tsx
@@ -10,6 +10,13 @@ export type StockCheckUpdateScreenProps = {
   isSubmitting: boolean;
   onLogoutPress: () => void;
   serverError?: string;
+  query: string;
+  onQueryChange: (value: string) => void;
+  showOnlyPending: boolean;
+  onShowOnlyPendingToggle: () => void;
+  filled: number;
+  total: number;
+  pendingRows: boolean[];
 };
 
 export const StockCheckUpdateScreen = (props: StockCheckUpdateScreenProps) => {
@@ -26,6 +33,13 @@ export const StockCheckUpdateScreen = (props: StockCheckUpdateScreenProps) => {
           isSubmitDisabled={props.isSubmitDisabled}
           isSubmitting={props.isSubmitting}
           serverError={props.serverError}
+          query={props.query}
+          onQueryChange={props.onQueryChange}
+          showOnlyPending={props.showOnlyPending}
+          onShowOnlyPendingToggle={props.onShowOnlyPendingToggle}
+          filled={props.filled}
+          total={props.total}
+          pendingRows={props.pendingRows}
         />
       </ScrollView>
     </Layout>


### PR DESCRIPTION
## Summary
Enhanced the stock check form with filtering capabilities and visual progress tracking to help users identify and focus on incomplete items.

## Key Changes
- **Pending Filter**: Added a filter button that toggles display of only pending (unchecked) materials, with visual feedback via yellow theme when active
- **Progress Tracking**: Display a counter showing how many materials have been checked (e.g., "5 / 10 materials checked")
- **Visual Indicators**: 
  - Pending items are highlighted with a yellow background
  - Added a "Pending" badge label on unchecked items
  - Filter button changes color when active
- **State Management**: 
  - Added `useWatch` hook to track form item changes in real-time
  - Introduced `showOnlyPending` state for filter toggle
  - Calculate pending status based on `currentStock` being null
- **UI Improvements**: Enhanced spacing and styling with padding and border radius on item rows

## Implementation Details
- The filter logic combines search query matching with the pending filter state
- Progress counter updates dynamically as users fill in stock values
- Pending items are identified by checking if `currentStock` is null
- Filter button uses the existing Filter icon from tamagui/lucide-icons

https://claude.ai/code/session_01WmdhJCn8kebbjDNLsGtCwE