### PR TITLE
Fix pending badge alignment in stock check form

### DIFF
--- a/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
+++ b/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
@@ -202,21 +202,23 @@ export const StockCheckFormView = ({
                 <SizableText width={60} color="$gray10">
                   {field.purchaseUnit}
                 </SizableText>
-                {isPending && (
-                  <XStack
-                    backgroundColor={isErrorRow ? '$red5' : '$yellow5'}
-                    paddingHorizontal="$2"
-                    paddingVertical="$1"
-                    borderRadius="$10"
-                  >
-                    <SizableText
-                      size="$1"
-                      color={isErrorRow ? '$red11' : '$yellow11'}
+                <XStack width={60} justifyContent="center">
+                  {isPending && (
+                    <XStack
+                      backgroundColor={isErrorRow ? '$red5' : '$yellow5'}
+                      paddingHorizontal="$2"
+                      paddingVertical="$1"
+                      borderRadius="$10"
                     >
-                      Pending
-                    </SizableText>
-                  </XStack>
-                )}
+                      <SizableText
+                        size="$1"
+                        color={isErrorRow ? '$red11' : '$yellow11'}
+                      >
+                        Pending
+                      </SizableText>
+                    </XStack>
+                  )}
+                </XStack>
               </XStack>
             );
           })}


### PR DESCRIPTION
## Summary
Wrapped the pending status badge in a fixed-width container with centered alignment to ensure consistent positioning and layout in the stock check form view.

## Key Changes
- Added a wrapper `XStack` with `width={60}` and `justifyContent="center"` around the pending badge
- This ensures the pending badge is properly centered within a fixed-width column, maintaining alignment with other form elements

## Implementation Details
The pending badge (shown when `isPending` is true) is now rendered within a centered container of fixed width, preventing layout shifts and ensuring visual consistency across different states (error vs. warning). This improves the overall UI stability when the pending status is displayed or hidden.

https://claude.ai/code/session_015HYQNd3M5tjUzwZAPb9mM6