### PR TITLE
Extract debounce logic into DebouncedInput component

### DIFF
--- a/libs/ui/src/presentation/components/base/Form/DebouncedInput.tsx
+++ b/libs/ui/src/presentation/components/base/Form/DebouncedInput.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef, useState } from 'react';
+import { Input, InputProps } from 'tamagui';
+import { createDebounce } from '../../../../utils';
+
+export type DebouncedInputProps = {
+  value: string;
+  onChangeText: (value: string) => void;
+  delay?: number;
+} & Omit<InputProps, 'value' | 'onChangeText'>;
+
+export const DebouncedInput = ({
+  value,
+  onChangeText,
+  delay = 400,
+  ...inputProps
+}: DebouncedInputProps) => {
+  const [localValue, setLocalValue] = useState(value);
+  const debounceRef = useRef(createDebounce());
+  const lastReportedRef = useRef(value);
+
+  useEffect(() => {
+    if (value !== lastReportedRef.current) {
+      setLocalValue(value);
+      lastReportedRef.current = value;
+      debounceRef.current(() => {}, 0);
+    }
+  }, [value]);
+
+  const handleChangeText = (text: string) => {
+    setLocalValue(text);
+    debounceRef.current(() => {
+      lastReportedRef.current = text;
+      onChangeText(text);
+    }, delay);
+  };
+
+  return (
+    <Input {...inputProps} value={localValue} onChangeText={handleChangeText} />
+  );
+};

--- a/libs/ui/src/presentation/components/base/Form/index.ts
+++ b/libs/ui/src/presentation/components/base/Form/index.ts
@@ -1,3 +1,4 @@
+export * from './DebouncedInput';
 export * from './ErrorMessage';
 export * from './Field';
 export * from './FieldWatch';

--- a/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
+++ b/libs/ui/src/presentation/components/stockChecks/StockCheckFormView.tsx
@@ -8,7 +8,6 @@ import {
 import {
   Button,
   Form,
-  Input,
   Label,
   SizableText,
   Spinner,
@@ -16,7 +15,7 @@ import {
   YStack,
 } from 'tamagui';
 import { Filter, X } from '@tamagui/lucide-icons';
-import { FormErrorBanner, InputNumber } from '../base';
+import { DebouncedInput, FormErrorBanner, InputNumber } from '../base';
 import { StockCheckForm } from '../../../domain';
 
 export type StockCheckFormViewProps = {
@@ -27,7 +26,6 @@ export type StockCheckFormViewProps = {
   serverError?: string;
   query: string;
   onQueryChange: (value: string) => void;
-  onClearQuery: () => void;
   showOnlyPending: boolean;
   onShowOnlyPendingToggle: () => void;
   filled: number;
@@ -43,7 +41,6 @@ export const StockCheckFormView = ({
   serverError,
   query,
   onQueryChange,
-  onClearQuery,
   showOnlyPending,
   onShowOnlyPendingToggle,
   filled,
@@ -66,7 +63,7 @@ export const StockCheckFormView = ({
 
   const handleSubmit = () => {
     if (pendingCount > 0) {
-      onClearQuery();
+      onQueryChange('');
       if (!showOnlyPending) onShowOnlyPendingToggle();
       const firstPendingIndex = pendingRows.findIndex(Boolean);
       if (firstPendingIndex >= 0) {
@@ -105,11 +102,12 @@ export const StockCheckFormView = ({
           backgroundColor="$background"
           paddingVertical="$2"
         >
-          <Input
+          <DebouncedInput
             flex={1}
             placeholder="Search material by name"
             value={query}
             onChangeText={onQueryChange}
+            delay={400}
           />
           {hasQuery && (
             <Button

--- a/libs/ui/src/presentation/controllers/StockCheckCreateController.tsx
+++ b/libs/ui/src/presentation/controllers/StockCheckCreateController.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { StockCheckCreateUsecase } from '../../domain';
 import { useController } from './controller';
 import { useToastController } from '@tamagui/toast';
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { createDebounce } from '../../utils';
 
 const stockCheckItemSchema = z.object({
   materialId: z.number().int().positive(),
@@ -37,18 +36,11 @@ export const useStockCheckCreateController = (usecase: StockCheckCreateUsecase) 
 
   const [query, setQuery] = useState('');
   const [showOnlyPending, setShowOnlyPending] = useState(false);
-  const debounceRef = useRef(createDebounce());
 
   const watchedItems = useWatch({ control: form.control, name: 'items' });
   const total = watchedItems.length;
   const filled = watchedItems.filter((item) => item.currentStock !== null).length;
   const pendingRows = watchedItems.map((item) => item.currentStock === null);
-
-  const handleQueryChange = (value: string) => {
-    debounceRef.current(() => setQuery(value), 400);
-  };
-
-  const clearQuery = () => setQuery('');
 
   const toggleShowOnlyPending = () => setShowOnlyPending((prev) => !prev);
 
@@ -57,8 +49,7 @@ export const useStockCheckCreateController = (usecase: StockCheckCreateUsecase) 
     dispatch,
     form,
     query,
-    handleQueryChange,
-    clearQuery,
+    setQuery,
     showOnlyPending,
     toggleShowOnlyPending,
     filled,

--- a/libs/ui/src/presentation/controllers/StockCheckUpdateController.tsx
+++ b/libs/ui/src/presentation/controllers/StockCheckUpdateController.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { StockCheckUpdateUsecase } from '../../domain';
 import { useController } from './controller';
 import { useToastController } from '@tamagui/toast';
 import { useForm, useWatch } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
-import { createDebounce } from '../../utils';
 
 const stockCheckItemSchema = z.object({
   materialId: z.number().int().positive(),
@@ -37,18 +36,11 @@ export const useStockCheckUpdateController = (usecase: StockCheckUpdateUsecase) 
 
   const [query, setQuery] = useState('');
   const [showOnlyPending, setShowOnlyPending] = useState(false);
-  const debounceRef = useRef(createDebounce());
 
   const watchedItems = useWatch({ control: form.control, name: 'items' });
   const total = watchedItems.length;
   const filled = watchedItems.filter((item) => item.currentStock !== null).length;
   const pendingRows = watchedItems.map((item) => item.currentStock === null);
-
-  const handleQueryChange = (value: string) => {
-    debounceRef.current(() => setQuery(value), 400);
-  };
-
-  const clearQuery = () => setQuery('');
 
   const toggleShowOnlyPending = () => setShowOnlyPending((prev) => !prev);
 
@@ -57,8 +49,7 @@ export const useStockCheckUpdateController = (usecase: StockCheckUpdateUsecase) 
     dispatch,
     form,
     query,
-    handleQueryChange,
-    clearQuery,
+    setQuery,
     showOnlyPending,
     toggleShowOnlyPending,
     filled,

--- a/libs/ui/src/presentation/screens/StockCheckCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/StockCheckCreateHandler.tsx
@@ -46,8 +46,7 @@ export const StockCheckCreateHandler = ({
       }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       query={stockCheckCreate.query}
-      onQueryChange={stockCheckCreate.handleQueryChange}
-      onClearQuery={stockCheckCreate.clearQuery}
+      onQueryChange={stockCheckCreate.setQuery}
       showOnlyPending={stockCheckCreate.showOnlyPending}
       onShowOnlyPendingToggle={stockCheckCreate.toggleShowOnlyPending}
       filled={stockCheckCreate.filled}

--- a/libs/ui/src/presentation/screens/StockCheckCreateScreen.tsx
+++ b/libs/ui/src/presentation/screens/StockCheckCreateScreen.tsx
@@ -12,7 +12,6 @@ export type StockCheckCreateScreenProps = {
   serverError?: string;
   query: string;
   onQueryChange: (value: string) => void;
-  onClearQuery: () => void;
   showOnlyPending: boolean;
   onShowOnlyPendingToggle: () => void;
   filled: number;
@@ -36,7 +35,6 @@ export const StockCheckCreateScreen = (props: StockCheckCreateScreenProps) => {
           serverError={props.serverError}
           query={props.query}
           onQueryChange={props.onQueryChange}
-          onClearQuery={props.onClearQuery}
           showOnlyPending={props.showOnlyPending}
           onShowOnlyPendingToggle={props.onShowOnlyPendingToggle}
           filled={props.filled}

--- a/libs/ui/src/presentation/screens/StockCheckUpdateHandler.tsx
+++ b/libs/ui/src/presentation/screens/StockCheckUpdateHandler.tsx
@@ -45,8 +45,7 @@ export const StockCheckUpdateHandler = ({
       }
       onLogoutPress={() => authLogout.dispatch({ type: 'LOGOUT' })}
       query={stockCheckUpdate.query}
-      onQueryChange={stockCheckUpdate.handleQueryChange}
-      onClearQuery={stockCheckUpdate.clearQuery}
+      onQueryChange={stockCheckUpdate.setQuery}
       showOnlyPending={stockCheckUpdate.showOnlyPending}
       onShowOnlyPendingToggle={stockCheckUpdate.toggleShowOnlyPending}
       filled={stockCheckUpdate.filled}

--- a/libs/ui/src/presentation/screens/StockCheckUpdateScreen.tsx
+++ b/libs/ui/src/presentation/screens/StockCheckUpdateScreen.tsx
@@ -12,7 +12,6 @@ export type StockCheckUpdateScreenProps = {
   serverError?: string;
   query: string;
   onQueryChange: (value: string) => void;
-  onClearQuery: () => void;
   showOnlyPending: boolean;
   onShowOnlyPendingToggle: () => void;
   filled: number;
@@ -36,7 +35,6 @@ export const StockCheckUpdateScreen = (props: StockCheckUpdateScreenProps) => {
           serverError={props.serverError}
           query={props.query}
           onQueryChange={props.onQueryChange}
-          onClearQuery={props.onClearQuery}
           showOnlyPending={props.showOnlyPending}
           onShowOnlyPendingToggle={props.onShowOnlyPendingToggle}
           filled={props.filled}


### PR DESCRIPTION
## Summary
Refactored debounce handling for search input fields by extracting the debounce logic into a reusable `DebouncedInput` component. This simplifies controllers and screens by removing manual debounce management.

## Key Changes
- **New Component**: Created `DebouncedInput` component that encapsulates debounce logic internally
  - Manages local state for immediate UI feedback
  - Accepts configurable `delay` prop (defaults to 400ms)
  - Handles external value updates via `useEffect`
  - Prevents duplicate callbacks using refs to track last reported value

- **Simplified Controllers**: Removed debounce implementation from `StockCheckCreateController` and `StockCheckUpdateController`
  - Removed `useRef` and `createDebounce` imports
  - Removed `handleQueryChange` and `clearQuery` methods
  - Exposed `setQuery` directly instead of wrapped debounced handler

- **Updated Views & Screens**: Replaced `Input` with `DebouncedInput` in `StockCheckFormView`
  - Removed `onClearQuery` prop (now handled by calling `onQueryChange('')`)
  - Updated all screen and handler components to use `setQuery` directly
  - Simplified prop passing throughout the component hierarchy

## Implementation Details
The `DebouncedInput` component uses a ref-based approach to track the last reported value, preventing unnecessary debounce calls when the parent component updates the value externally. This ensures smooth UX with immediate local feedback while debouncing the parent callback.

https://claude.ai/code/session_0199YTTBqx4jaM9vBKEyfPYj