### PR TITLE
Fix typo in README: "Pint" → "Point" Of Sale

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Gatherloop POS (Pint Of Sale)
+# Gatherloop POS (Point Of Sale)
 
 ## 1. Overviews
 


### PR DESCRIPTION
## Summary
Corrected a typo in the project README title where "Pint Of Sale" was changed to the correct "Point Of Sale".

## Changes
- Fixed typo in README.md header: "Gatherloop POS (Pint Of Sale)" → "Gatherloop POS (Point Of Sale)"

## Notes
This is a minor documentation fix that corrects the project acronym expansion to the proper terminology.

https://claude.ai/code/session_01KaN3vHmFGZhgQYKMuZ59Zq