### PR TITLE
docs: add rental coupons PRD and implementation plan

### DIFF
--- a/docs/plan-rental-coupons.md
+++ b/docs/plan-rental-coupons.md
@@ -1,0 +1,306 @@
+# Implementation Plan: Rental Coupons
+
+Companion to [`prd-rental-coupons.md`](./prd-rental-coupons.md).
+
+## Overview
+
+Give coupons three new dimensions — **scope** (`transaction` | `rental_item`), a **`free_duration`** type, and a **`min_play_minutes`** eligibility gate — then apply them **per ticket at rental checkout**, where play-time is finally known. The discount is materialized as money on `TransactionItem.DiscountAmount` (which already exists), so `transaction.Total = Σ subtotals` and the existing income/budget math in `PayTransaction` is untouched.
+
+**Design rules driving this plan (from the PRD):**
+- One rental row = one ticket = one `TransactionItem`. Per-ticket discounts live on that item.
+- "Free X hours" = reduce billable minutes by `amount`, then re-price through the existing `CalculatePrice`. (PRD D1)
+- Billable minutes ≤ 0 ⇒ ticket is free. (PRD D2)
+- ≤ 1 coupon per ticket, no stacking. (PRD D4)
+- All new columns are additive with defaults; only the checkout request body is a non-additive change, isolated to Phase 5–7. (PRD D9)
+- Reuse `RoundToNearest500` for percentage discounts. (PRD D8)
+
+Phases are independently shippable and ordered: schema/seed → domain → data → checkout usecase+handler → contract → coupon admin UI → checkout UI → mobile → docs. Each phase is one small PR.
+
+---
+
+## Phase 1: Database Schema + Seed
+
+**Goal:** Coupons can carry scope/eligibility; `transaction_coupons` can point at a ticket; the three coupons exist. Existing data untouched and behaviorally identical.
+
+### 1.1 Migration `000012_rental_coupons`
+
+`apps/api/migrations/000012_rental_coupons.up.sql`:
+```sql
+ALTER TABLE coupons
+  ADD COLUMN scope            VARCHAR(50) NOT NULL DEFAULT 'transaction',
+  ADD COLUMN min_play_minutes INT         NOT NULL DEFAULT 0;
+
+ALTER TABLE transaction_coupons
+  ADD COLUMN transaction_item_id BIGINT NULL,
+  ADD KEY idx_tc_transaction_item_id (transaction_item_id),
+  ADD CONSTRAINT fk_tc_transaction_item
+      FOREIGN KEY (transaction_item_id) REFERENCES transaction_items(id);
+
+-- Seed the three coupons, idempotent on unique code
+INSERT INTO coupons (code, type, amount, scope, min_play_minutes)
+SELECT * FROM (
+  SELECT 'FREE 1 HOUR'      AS code, 'free_duration' AS type, 60  AS amount, 'rental_item' AS scope, 120 AS min_play_minutes UNION ALL
+  SELECT 'FREE 2 HOUR',           'free_duration',          120,        'rental_item',                 0 UNION ALL
+  SELECT 'STUDENT DISCOUNT',      'percentage',              40,        'rental_item',                 0
+) seed
+WHERE NOT EXISTS (SELECT 1 FROM coupons c WHERE c.code = seed.code);
+```
+
+`apps/api/migrations/000012_rental_coupons.down.sql`:
+```sql
+DELETE FROM coupons WHERE code IN ('FREE 1 HOUR','FREE 2 HOUR','STUDENT DISCOUNT');
+ALTER TABLE transaction_coupons
+  DROP FOREIGN KEY fk_tc_transaction_item,
+  DROP KEY idx_tc_transaction_item_id,
+  DROP COLUMN transaction_item_id;
+ALTER TABLE coupons DROP COLUMN min_play_minutes, DROP COLUMN scope;
+```
+
+### 1.2 Verify
+- Migrate up → down → up (idempotency); seed insert does not duplicate on re-run.
+- `SELECT scope, min_play_minutes FROM coupons` — pre-existing coupons all `('transaction', 0)`.
+- `go test ./apps/api/...` still green (no Go reads the new columns yet).
+
+**Exit criteria:** Migration applies/reverts cleanly on a DB with existing coupons + transactions.
+
+---
+
+## Phase 2: Domain Layer (Go)
+
+**Goal:** Entity + a pure per-ticket discount calculator with exhaustive unit tests. No handlers wired.
+
+### 2.1 Extend the coupon entity
+
+`apps/api/domain/coupon_entity.go`:
+```go
+const FreeDuration CouponType = "free_duration"
+
+type CouponScope string
+const ( ScopeTransaction CouponScope = "transaction"; ScopeRentalItem CouponScope = "rental_item" )
+
+type Coupon struct {
+    Id; Code; Type CouponType; Amount int64
+    Scope          CouponScope   // new
+    MinPlayMinutes int64         // new
+    CreatedAt; DeletedAt
+}
+```
+Add `Scope`/`MinPlayMinutes` to `TransactionCoupon` snapshot only if needed for display; otherwise add a nullable `TransactionItemId *int64` to `TransactionCoupon` in `transaction_entity.go`.
+
+### 2.2 Per-ticket discount calculator
+
+New `apps/api/domain/coupon_calculator.go` — pure, no DB, implements PRD FR-3:
+```go
+type TicketDiscount struct { Base, Discount, Subtotal float32 }
+
+func CalculateRentalCouponDiscount(
+    tiers []PricingTier, duration time.Duration, coupon *Coupon,
+) (TicketDiscount, *Error) {
+    base, err := CalculatePrice(tiers, duration)
+    if err != nil { return TicketDiscount{}, err }
+    if coupon == nil { return TicketDiscount{base.Price, 0, base.Price}, nil }
+    if coupon.Scope != ScopeRentalItem {
+        return TicketDiscount{}, &Error{Type: BadRequest, Message: "coupon not applicable to rental ticket"}
+    }
+    actualMin := int64(math.Ceil(duration.Minutes()))
+    if actualMin < coupon.MinPlayMinutes {
+        return TicketDiscount{}, &Error{Type: BadRequest, Message: "play time below coupon minimum"}
+    }
+    var discount float32
+    switch coupon.Type {
+    case FreeDuration:
+        billable := actualMin - coupon.Amount
+        var discounted float32
+        if billable > 0 {
+            d, _ := CalculatePrice(tiers, time.Duration(billable)*time.Minute)
+            discounted = d.Price
+        } // billable <= 0 -> discounted stays 0 (PRD D2)
+        discount = base.Price - discounted
+    case Percentage:
+        discount = float32(utils.RoundToNearest500(int(base.Price) * int(coupon.Amount) / 100))
+    case Fixed:
+        discount = float32(coupon.Amount)
+        if discount > base.Price { discount = base.Price }
+    }
+    return TicketDiscount{base.Price, discount, base.Price - discount}, nil
+}
+```
+
+### 2.3 Calculator tests
+
+`apps/api/domain/coupon_calculator_test.go` — table-driven, covering **every PRD FR-3 row 1–7**, plus:
+- Wrong scope (`transaction` coupon) → error.
+- `free_duration` exactly reducing to a tier boundary.
+- `fixed` larger than base → clamped, subtotal 0, no negative.
+- `nil` coupon → zero discount.
+
+### 2.4 Coupon usecase validation
+
+`apps/api/domain/coupon_usecase.go` create/update: enforce PRD FR-1 (`free_duration ⇒ rental_item & amount>0`; `percentage ⇒ 0<amount≤100`; `fixed ⇒ amount>0`; `min_play_minutes ≥ 0`). Add tests.
+
+### 2.5 Verify
+`go test ./apps/api/domain/...` green.
+
+**Exit criteria:** Domain complete and tested in isolation; no SQL, no handlers.
+
+---
+
+## Phase 3: Data Layer (MySQL)
+
+**Goal:** Repos read/write the new columns and the ticket link.
+
+### 3.1 GORM models + transformers
+- `apps/api/data/mysql/coupon_entity.go` + transformer: map `scope`, `min_play_minutes` both ways.
+- `apps/api/data/mysql/transaction_entity.go` (transaction_coupons model) + transformer: map nullable `transaction_item_id`.
+
+### 3.2 Verify
+- Existing coupon repo tests pass.
+- Round-trip test: create a `rental_item` coupon → read back scope + min_play intact.
+
+**Exit criteria:** Repos persist/read new fields; existing tests untouched.
+
+---
+
+## Phase 4: Rental Checkout Usecase + Handler
+
+**Goal:** Checkout accepts an optional coupon per ticket, applies the discount, records the link. This is the core behavioral PR.
+
+### 4.1 Change the checkout input shape (backend)
+
+`apps/api/domain/rental_usecase.go` — `CheckoutRentals` signature changes from `rentalIds []int64` to a slice of `{ RentalId int64; CouponId *int64 }`. For each rental:
+1. Load rental, guard double-checkout (unchanged).
+2. `duration = checkoutAt − checkin_at`.
+3. If `CouponId != nil`: load coupon via `couponRepository.GetCouponById`, call `CalculateRentalCouponDiscount(snapshot, duration, &coupon)`. On error → return it (the surrounding `BeginTransaction` rolls everything back).
+4. Build `TransactionItem` with `Price=base`, `DiscountAmount=discount`, `Subtotal=base−discount`.
+5. After the transaction is created, insert a `transaction_coupons` row `{transaction_id, coupon_id, transaction_item_id, type, amount}` per applied coupon.
+
+`RentalUsecase` needs a `couponRepository` dependency — add it to the constructor and `apps/api/main.go` DI wiring.
+
+### 4.2 Handler
+
+`apps/api/presentation/restapi/rental_handler.go` — checkout handler parses the new request `{ rentals: [{ rentalId, couponId? }] }`. Keep accepting the old `rentalIds` shape for one release **only if** any non-frontend consumer exists; otherwise change outright (internal API, both frontends updated in Phase 5–7).
+
+### 4.3 Tests
+
+`rental_usecase_test.go`:
+- Checkout, no coupons → unchanged totals (regression).
+- FREE 1 HOUR on a 2h ticket → subtotal 15K (PRD FR-3 #1).
+- FREE 1 HOUR on a 90m ticket → 400.
+- FREE 2 HOUR on a 1h ticket → subtotal 0 (PRD FR-3 #5).
+- Multi-ticket: 3 tickets, STUDENT on the middle one → only it discounted (PRD FR-5).
+- `transaction_coupons` row written with correct `transaction_item_id`.
+
+### 4.4 Verify
+`go test ./apps/api/...` green; `curl` smoke for one free-duration and one percentage checkout.
+
+**Exit criteria:** Backend reproduces every PRD FR-3/FR-5 case end-to-end.
+
+---
+
+## Phase 5: API Contract + Codegen
+
+**Goal:** TS clients reflect new shapes; both apps compile.
+
+### 5.1 Edit `libs/api-contract/src/api.yaml`
+- `Coupon` + `CouponForm`: add `scope` enum, `minPlayMinutes`; `type` enum gains `free_duration`. (additive)
+- Checkout request: `{ rentals: [{ rentalId, couponId? }] }`. (**breaking** — coordinated here)
+- `TransactionCoupon`: add optional `transactionItemId`. (additive)
+
+### 5.2 Codegen
+Run the project's codegen (per `libs/api-contract/package.json` / `openapitools.json`).
+
+### 5.3 Update the FE checkout usecase signature
+`libs/ui/src/domain/usecases/rentalCheckout.ts` + its test: pass `{ rentalId, couponId? }[]`. Keep callers compiling (Phase 7 wires real UI; here just default `couponId` undefined so behavior is identical).
+
+### 5.4 Verify
+`nx build api-contract`, `nx build web`, `nx build mobile`, `nx test ui` all green.
+
+**Exit criteria:** Generated types include new shapes; checkout still works with no coupons selected.
+
+---
+
+## Phase 6: Coupon Admin UI
+
+**Goal:** Owner can create/edit all coupon kinds, including the three rental coupons.
+
+### 6.1 Frontend entity + form
+- `libs/ui/src/domain/entities/Coupon.ts`: extend `CouponType` with `'free_duration'`; add `scope`, `minPlayMinutes` to `Coupon` and `CouponForm`.
+- Coupon form component + Zod schema (PRD FR-6): scope selector; `free_duration` type; conditional `min_play_minutes` input; adaptive amount label ("Amount (Rp)" / "Percent (%)" / "Free minutes"). Mirror Phase 2.4 validation.
+- `apps/web/src/pages/coupons/...` create/edit pages render the extended form.
+
+### 6.2 Verify
+`nx test web`/`nx test ui`; manually create FREE 1 HOUR / FREE 2 HOUR / STUDENT DISCOUNT and confirm they persist with correct scope + min play.
+
+**Exit criteria:** All three coupons are creatable/editable from the web admin.
+
+---
+
+## Phase 7: Web Checkout Screen
+
+**Goal:** Per-ticket coupon selection with eligibility + live totals (PRD FR-7).
+
+### 7.1 Checkout screen
+The `libs/ui` screen behind `apps/web/src/pages/rentals/checkout.tsx`:
+- Per ticket: player • variant • duration • base price.
+- "Apply coupon" control listing only `rental_item` coupons; disable coupons where `ceil(actualMinutes) < minPlayMinutes` with a hint.
+- On select: show discount + new subtotal for that ticket; recompute the grand total live. Allow clearing. One coupon per ticket.
+- Submit sends `{ rentals: [{ rentalId, couponId? }] }`.
+
+Reuse the existing `CouponList` sheet pattern (`libs/ui/src/presentation/components/coupons/CouponList.tsx`), filtered to `rental_item` scope and parameterized by per-ticket eligibility.
+
+### 7.2 Verify
+`nx serve web` walkthrough reproducing PRD FR-3 #1, #3 (disabled), #5, #6 and the FR-5 multi-ticket case. `nx test web`.
+
+**Exit criteria:** Every PRD FR-3/FR-5 case reproduces in the web checkout UI; transaction-create screen visibly unchanged.
+
+---
+
+## Phase 8: Mobile Parity
+
+**Goal:** React Native checkout offers the same per-ticket coupon picker (PRD FR-8).
+
+- `apps/mobile/` checkout screen: same per-ticket picker, reusing shared `libs/ui` primitives where possible.
+- Coupon **admin** editing stays web-only for v1.
+- `nx test mobile`; walk the same acceptance cases on emulator.
+
+**Exit criteria:** Mobile staff can apply per-ticket coupons at checkout with correct totals.
+
+---
+
+## Phase 9: Documentation + Release
+
+1. Short owner guide under `docs/`: "Rental coupons — how FREE 1 HOUR / FREE 2 HOUR / STUDENT DISCOUNT work and when each applies."
+2. Update `E2E_TEST_PLAN.md` with the new checkout-coupon scenarios.
+3. Update `README.md` feature list if present.
+4. PR description links the PRD and lists every FR-3/FR-5 case verified.
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Checkout request shape change breaks an un-updated consumer | Low | High | Internal API; both frontends updated in Phases 5/7/8 in lockstep with the contract. Optionally accept the legacy `rentalIds` shape for one release. |
+| Free-duration math drifts from staff expectation (D1/D2) | Medium | Medium | PRD worked examples are the acceptance tests; surface "Billed as Xh (1h free)" on the checkout line so staff see the reasoning. Open Question #1 confirms D2 with the owner. |
+| Income/budget math regresses if discount isn't on `Subtotal` | Low | High | Discount always lands on `TransactionItem.DiscountAmount`; `Subtotal = base − discount`; `Total = Σ subtotals`. Phase 4 regression test asserts unchanged totals for the no-coupon path. |
+| A `transaction`-scope coupon gets applied to a ticket (or vice versa) | Low | Medium | Calculator rejects wrong scope (Phase 2.2); UI offers only the matching scope per surface (PRD D5). |
+| Negative subtotal from an over-large `fixed` coupon | Low | Medium | `fixed` discount clamped to base in the calculator. |
+| Eligible-coupon UI lets staff pick an ineligible one | Low | Medium | UI disables ineligible coupons **and** the server re-validates (PRD D6); checkout rolls back on violation. |
+
+---
+
+## Estimated Sequence
+
+| Phase | Est. effort | Blocks |
+|---|---|---|
+| 1 Schema + seed | 0.5 day | 2 |
+| 2 Domain + calculator | 1 day | 3, 4 |
+| 3 Data layer | 0.5 day | 4 |
+| 4 Checkout usecase + handler | 1.5 days | 5 |
+| 5 Contract + codegen | 0.5 day | 6, 7 |
+| 6 Coupon admin UI | 1 day | 7 |
+| 7 Web checkout UI | 1.5 days | 8 |
+| 8 Mobile parity | 1 day | 9 |
+| 9 Docs + release | 0.5 day | — |
+
+**Total:** ~8 working days, single engineer. Each phase is one reviewable PR.

--- a/docs/plan-rental-coupons.md
+++ b/docs/plan-rental-coupons.md
@@ -4,50 +4,47 @@ Companion to [`prd-rental-coupons.md`](./prd-rental-coupons.md).
 
 ## Overview
 
-Let a coupon target **one `TransactionItem`** instead of the whole transaction. That single capability covers all three requested coupons:
+Let an existing coupon target **one `TransactionItem`** instead of the whole transaction. That single capability covers all three requested coupons — they are ordinary `fixed`/`percentage` coupons, made "per-item" only by how staff attach them:
 
-| Coupon | type | amount | scope |
-|---|---|---:|---|
-| FREE 1 HOUR | `fixed` | 15,000 | `item` |
-| FREE 2 HOUR | `fixed` | 30,000 | `item` |
-| STUDENT DISCOUNT | `percentage` | 40 | `item` |
+| Coupon | type | amount |
+|---|---|---:|
+| FREE 1 HOUR | `fixed` | 15,000 |
+| FREE 2 HOUR | `fixed` | 30,000 |
+| STUDENT DISCOUNT | `percentage` | 40 |
 
 Coupons are attached **after checkout, on the transaction edit screen** (PRD D2). Rental checkout is unchanged. The discount lands on `TransactionItem.DiscountAmount`, so `Total = Σ subtotals` and the `PayTransaction` income/budget math is untouched.
 
 **Design rules (from the PRD):**
-- New coupon dimension is just `scope` (`transaction` | `item`); types stay `fixed`/`percentage`. (No `free_duration`.)
-- "Free N hours" = fixed rupiah, clamped to the item price. (D1, D3)
-- ≤ 1 item-coupon per line, no stacking. (D4)
+- **No coupon "scope".** The coupon model is unchanged; placement (bill vs line) is decided by whether `transaction_item_id` is set. Staff choose. (D5)
+- "Free N hours" = fixed rupiah, clamped to the base. (D1, D3)
+- ≤ 1 coupon per line, no stacking. (D4)
 - 2-hour minimum for FREE 1 HOUR is staff discretion, shown via the line's duration note. (D6)
-- **Prerequisite — ✅ done on main (#131):** `UpdateTransactionById` now preserves rental-item prices instead of re-deriving them from `variants.price = 0`. Phase 3 builds on it. (D7)
+- **Prerequisite — ✅ done on main (#131):** `UpdateTransactionById` preserves rental-item prices instead of re-deriving them from `variants.price = 0`. Phase 3 builds on it. (D7)
 - All schema and contract changes additive. (D10)
 
-Phases are independently shippable and ordered: schema/seed → domain → rental-safe update + item-coupon application → data layer → contract → coupon admin UI → transaction edit UI → mobile → docs. Each phase is one small PR.
+Phases are independently shippable and ordered: schema/seed → domain → item-coupon application → data layer → contract → transaction edit UI → mobile → docs. Each phase is one small PR. **No coupon-admin work** — the three coupons are plain coupons the existing admin already creates.
 
 ---
 
 ## Phase 1: Database Schema + Seed
 
-**Goal:** Coupons carry a scope; `transaction_coupons` can point at an item; the three coupons exist. Existing data behaviorally identical.
+**Goal:** `transaction_coupons` can point at a line item; the three coupons exist. Existing data behaviorally identical. The `coupons` table is **not** touched.
 
 ### 1.1 Migration `000012_item_coupons`
 
 `apps/api/migrations/000012_item_coupons.up.sql`:
 ```sql
-ALTER TABLE coupons
-  ADD COLUMN scope VARCHAR(50) NOT NULL DEFAULT 'transaction';
-
 ALTER TABLE transaction_coupons
   ADD COLUMN transaction_item_id BIGINT NULL,
   ADD KEY idx_tc_transaction_item_id (transaction_item_id),
   ADD CONSTRAINT fk_tc_transaction_item
       FOREIGN KEY (transaction_item_id) REFERENCES transaction_items(id);
 
-INSERT INTO coupons (code, type, amount, scope)
+INSERT INTO coupons (code, type, amount)
 SELECT * FROM (
-  SELECT 'FREE 1 HOUR'      AS code, 'fixed'      AS type, 15000 AS amount, 'item' AS scope UNION ALL
-  SELECT 'FREE 2 HOUR',           'fixed',            30000,        'item' UNION ALL
-  SELECT 'STUDENT DISCOUNT',      'percentage',          40,        'item'
+  SELECT 'FREE 1 HOUR'      AS code, 'fixed'      AS type, 15000 AS amount UNION ALL
+  SELECT 'FREE 2 HOUR',           'fixed',            30000 UNION ALL
+  SELECT 'STUDENT DISCOUNT',      'percentage',          40
 ) seed
 WHERE NOT EXISTS (SELECT 1 FROM coupons c WHERE c.code = seed.code);
 ```
@@ -59,34 +56,30 @@ ALTER TABLE transaction_coupons
   DROP FOREIGN KEY fk_tc_transaction_item,
   DROP KEY idx_tc_transaction_item_id,
   DROP COLUMN transaction_item_id;
-ALTER TABLE coupons DROP COLUMN scope;
 ```
 
 ### 1.2 Verify
 - Up → down → up; seed does not duplicate on re-run.
-- Pre-existing coupons all read `scope = 'transaction'`.
-- `go test ./apps/api/...` green (no Go reads the new columns yet).
+- Existing `transaction_coupons` rows all read `transaction_item_id = NULL`.
+- `go test ./apps/api/...` green (no Go reads the new column yet).
 
 **Exit criteria:** Migration applies/reverts cleanly on a DB with existing coupons + transactions.
 
 ---
 
-## Phase 2: Domain Entities + Item-Discount Calculator
+## Phase 2: Domain Entity + Discount Calculator
 
-**Goal:** Entity changes + a pure per-item discount function with exhaustive tests. No usecase wiring yet.
+**Goal:** Add the item link to the junction entity + a pure discount helper with exhaustive tests. No usecase wiring yet.
 
-### 2.1 Entities
-- `apps/api/domain/coupon_entity.go`: add `CouponScope` (`ScopeTransaction`/`ScopeItem`) and `Scope CouponScope` on `Coupon`.
+### 2.1 Entity
 - `apps/api/domain/transaction_entity.go`: add `TransactionItemId *int64` to `TransactionCoupon`.
+- The `Coupon` entity is **unchanged** (no scope field).
 
 ### 2.2 Calculator
 
-New `apps/api/domain/coupon_calculator.go` — pure, implements PRD §3 / FR-4:
+New `apps/api/domain/coupon_calculator.go` — pure, scope-free, implements the PRD application math / FR-4. The same helper serves both the whole-bill and per-line paths:
 ```go
-func CalculateItemDiscount(base float32, coupon Coupon) (float32, *Error) {
-    if coupon.Scope != ScopeItem {
-        return 0, &Error{Type: BadRequest, Message: "coupon is not item-scoped"}
-    }
+func ApplyCouponToBase(base float32, coupon Coupon) (float32, *Error) {
     switch coupon.Type {
     case Fixed:
         d := float32(coupon.Amount)
@@ -100,29 +93,26 @@ func CalculateItemDiscount(base float32, coupon Coupon) (float32, *Error) {
 ```
 
 ### 2.3 Tests
-`apps/api/domain/coupon_calculator_test.go` — table-driven over **every PRD FR-4 row 1–7**, plus: non-item scope → error; fixed exactly equal to base → subtotal 0.
+`apps/api/domain/coupon_calculator_test.go` — table-driven over **every PRD FR-4 row 1–7**, plus: fixed exactly equal to base → discount = base, subtotal 0; percentage rounding boundary.
 
-### 2.4 Coupon usecase validation
-`apps/api/domain/coupon_usecase.go` create/update: enforce FR-1 (`scope` valid; `percentage` 0<amt≤100; `fixed` amt>0). Add tests.
-
-**Exit criteria:** Domain compiles; calculator + validation tested in isolation.
+**Exit criteria:** Domain compiles; calculator tested in isolation. (No coupon-usecase validation change — the coupon model is untouched.)
 
 ---
 
 ## Phase 3: Item-Coupon Application (core PR)
 
-**Goal:** Item-scoped coupons discount the right line — including rental tickets — on both create and update.
+**Goal:** A coupon attached to a line discounts that line — including rental tickets — on both create and update.
 
 ### 3.1 Rental-price preservation — ✅ DONE on main (#131)
 `UpdateTransactionById` already preserves the stored `Price`/`Subtotal`/`DiscountAmount`/`RentalId`/`Note` of rental items and ships a regression test. **No work here** — but note its shape: rental items hit an early `if existingItem.RentalId != nil { … continue }` branch (`transaction_usecase.go`, ~:137-152) that copies stored values and skips the variant recompute. Phase 3.2 hooks coupons *into* that branch. (`CreateTransaction` never receives rental items, so it needed no preservation fix.)
 
-### 3.2 Apply item-scoped coupons
-Update the coupon loop (`transaction.TransactionCoupons`) in **both** `CreateTransaction` and `UpdateTransactionById` (~:178-202):
+### 3.2 Apply item-linked coupons
+Refactor the coupon loop (`transaction.TransactionCoupons`) in **both** `CreateTransaction` and `UpdateTransactionById` (~:178-202) to use the shared `ApplyCouponToBase` helper:
 - For each `TransactionCoupon`:
-  - If `TransactionItemId == nil` → transaction-scope: subtract from `Total` exactly as today.
-  - If set → locate the target item in `transaction.TransactionItems`, derive its `base`, call `CalculateItemDiscount(base, coupon)`, set that item's `DiscountAmount = discount` and `Subtotal = base − discount`, adjust the running `Total` by the delta. Enforce ≤1 item-coupon per line (D4); reject a non-`item` coupon carrying a `TransactionItemId` (D5, 400).
+  - If `TransactionItemId == nil` → whole-bill: `discount = ApplyCouponToBase(Total, coupon)`, subtract from `Total` (same as today, now with the D3 clamp as a bonus).
+  - If set → locate the target item in `transaction.TransactionItems`, derive its `base`, `discount = ApplyCouponToBase(base, coupon)`, set that item's `DiscountAmount = discount` and `Subtotal = base − discount`, adjust the running `Total` by the delta. Enforce ≤1 coupon per line (D4). **No scope check** — any coupon may target any line (D5).
 - **Base derivation (matches #131):** rental item → `base = existingItem.Price * existingItem.Amount` (full duration-based price; recompute from `Price` each save so discounts never compound). Non-rental → `base = variant.Price * item.Amount`.
-- **Rental-branch hook:** in `UpdateTransactionById`, when a rental item has an attached item-coupon, recompute its `DiscountAmount`/`Subtotal` from `Price` instead of blindly copying the stored `Subtotal`. A rental ticket with no item-coupon stays byte-for-byte as #131 leaves it.
+- **Rental-branch hook:** in `UpdateTransactionById`, when a rental item has an attached coupon, recompute its `DiscountAmount`/`Subtotal` from `Price` instead of blindly copying the stored `Subtotal`. A rental ticket with no coupon stays byte-for-byte as #131 leaves it.
 - Snapshot `{type, amount, transaction_item_id}` into the `transaction_coupons` rows (the current loop drops `transaction_item_id` — add it).
 
 ### 3.3 Tests
@@ -132,8 +122,8 @@ Extend `transaction_usecase_test.go` (keep #131's rental-regression test):
 - FREE 2 HOUR on a 15K item → subtotal 0 (FR-4 #4, clamp).
 - STUDENT on a 30K item → 17,500 (FR-4 #5).
 - Multi-item: 3 items, STUDENT on the middle → only it discounted (FR-5).
-- `transaction`-scope coupon carrying a `TransactionItemId` → 400 (D5).
-- Item-coupon on a new transaction via `CreateTransaction` (non-rental path).
+- Whole-bill coupon (no `TransactionItemId`) still subtracts from `Total` as before.
+- Coupon on a new transaction via `CreateTransaction` (non-rental path).
 
 **Exit criteria:** Backend reproduces every FR-4/FR-5 case; a coupon on a rental ticket re-prices it without breaking #131's preservation guarantee.
 
@@ -141,13 +131,13 @@ Extend `transaction_usecase_test.go` (keep #131's rental-regression test):
 
 ## Phase 4: Data Layer (MySQL)
 
-**Goal:** Repos map the new columns and the item link.
+**Goal:** Repos map the new link.
 
-- `apps/api/data/mysql/coupon_entity.go` + transformer: map `scope`.
 - `apps/api/data/mysql/transaction_entity.go` (transaction_coupons model) + transformer: map nullable `transaction_item_id`. Ensure item-coupon rows persist/read the link, and `transaction_items.discount_amount`/`subtotal` round-trip.
-- Round-trip test: create a transaction with an item-scoped coupon → reload → discount + link intact.
+- Round-trip test: create a transaction with a line-linked coupon → reload → discount + link intact.
+- The coupon repository/transformer is **unchanged** (no scope).
 
-**Exit criteria:** Repos persist/read the new fields; existing tests untouched.
+**Exit criteria:** Repos persist/read the new field; existing tests untouched.
 
 > Note: domain tests in Phases 2–3 mock the repositories, so the order (domain before data) is fine; this phase makes the core PR runnable end-to-end against MySQL.
 
@@ -155,40 +145,26 @@ Extend `transaction_usecase_test.go` (keep #131's rental-regression test):
 
 ## Phase 5: API Contract + Codegen
 
-**Goal:** TS clients reflect the additive shapes; both apps compile.
+**Goal:** TS clients reflect the additive shape; both apps compile.
 
 ### 5.1 Edit `libs/api-contract/src/api.yaml`
-- `Coupon` + `CouponForm`: add `scope` enum (`transaction`|`item`).
 - `TransactionCoupon` (in transaction request + response): add optional `transactionItemId`.
-- All additive — no breaking changes; `POST /rentals/checkout` untouched.
+- **Coupon schemas unchanged.** All additive — no breaking changes; `POST /rentals/checkout` and the coupon endpoints untouched.
 
 ### 5.2 Codegen + verify
 Run the project codegen (`libs/api-contract/package.json` / `openapitools.json`). `nx build api-contract`, `nx build web`, `nx build mobile`, `nx test ui` green.
 
-**Exit criteria:** Generated types include `scope` and `transactionItemId`; existing flows compile unchanged.
+**Exit criteria:** Generated types include `transactionItemId`; existing flows compile unchanged.
 
 ---
 
-## Phase 6: Coupon Admin UI
+## Phase 6: Transaction Edit Screen — Per-Line Coupon Picker
 
-**Goal:** Owner can create/edit coupons of either scope, including the three rental coupons.
+**Goal:** Staff attach a coupon to a specific line (PRD FR-6).
 
-- `libs/ui/src/domain/entities/Coupon.ts`: add `scope` to `Coupon` and `CouponForm`.
-- Coupon form + Zod: **scope** selector; adaptive amount label ("Amount (Rp)" / "Percent (%)"); mirror Phase 2.4 validation.
-- `apps/web/src/pages/coupons/...` create/edit pages render the extended form.
-- `nx test web`/`nx test ui`; manually create FREE 1 HOUR / FREE 2 HOUR / STUDENT DISCOUNT.
-
-**Exit criteria:** All three coupons creatable/editable from the web admin.
-
----
-
-## Phase 7: Transaction Edit Screen — Per-Item Coupon Picker
-
-**Goal:** Staff attach an item-scoped coupon to a specific line (PRD FR-7).
-
-- The `libs/ui` transaction screen (`TransactionCreateScreen.tsx` and its update counterpart): each line item gains an "Apply coupon" control listing only `item`-scoped coupons (reuse the `CouponList.tsx` sheet, filtered by scope).
+- The `libs/ui` transaction screen (`TransactionCreateScreen.tsx` and its update counterpart): each line item gains an "Apply coupon" control listing **all** coupons (reuse the `CouponList.tsx` sheet — no scope filter, D5).
 - On select: show the line discount + new subtotal; recompute the grand total live; allow clearing; ≤1 per line.
-- Filter the existing whole-bill picker to `transaction`-scoped coupons.
+- The existing whole-bill picker is unchanged.
 - Show the rental duration note next to each rental line (D6).
 - Form submits each line's optional `couponId`; map into `transactionCoupons[].transactionItemId` on save.
 
@@ -199,21 +175,21 @@ Run the project codegen (`libs/api-contract/package.json` / `openapitools.json`)
 
 ---
 
-## Phase 8: Mobile Parity
+## Phase 7: Mobile Parity
 
-**Goal:** React Native transaction edit screen offers the same per-item picker (PRD FR-8).
+**Goal:** React Native transaction edit screen offers the same per-line picker (PRD FR-7).
 
-- `apps/mobile/` transaction screen: per-item coupon picker reusing shared `libs/ui` primitives. Coupon **admin** editing stays web-only for v1.
+- `apps/mobile/` transaction screen: per-line coupon picker reusing shared `libs/ui` primitives.
 - `nx test mobile`; walk the same acceptance cases on emulator.
 
-**Exit criteria:** Mobile staff can attach per-item coupons with correct totals.
+**Exit criteria:** Mobile staff can attach per-line coupons with correct totals.
 
 ---
 
-## Phase 9: Documentation + Release
+## Phase 8: Documentation + Release
 
 1. Short owner guide under `docs/`: "Rental coupons — what FREE 1 HOUR / FREE 2 HOUR / STUDENT DISCOUNT do and how to apply them on a transaction."
-2. Update `E2E_TEST_PLAN.md` with the per-item coupon scenarios.
+2. Update `E2E_TEST_PLAN.md` with the per-line coupon scenarios.
 3. Update `README.md` feature list if present.
 4. PR description links the PRD and lists every FR-4/FR-5 case verified.
 
@@ -224,11 +200,11 @@ Run the project codegen (`libs/api-contract/package.json` / `openapitools.json`)
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
 | Editing a rental transaction zeroes its prices (was a live bug) | — | High | **Resolved on main (#131):** rental items keep stored price/subtotal on update, covered by a regression test. Phase 3.2's coupon hook must preserve this guarantee for the no-coupon case. |
-| Fixed 15K/30K over-discounts all-day or capped rentals (D1) | Medium | Low | Documented; staff only apply FREE 1/2 HOUR to standard hourly rentals. Open Question #1 confirms with owner. Duration note shown on the line. |
+| Fixed 15K/30K over-discounts all-day or capped rentals (D1) | Medium | Low | Documented; staff only apply FREE 1/2 HOUR to standard hourly rentals (D1, owner-confirmed). Duration note shown on the line. |
 | Income/budget math regresses | Low | High | Discount always lands on `DiscountAmount`; `Subtotal = base − discount`; `Total = Σ subtotals`. Regression test on the no-coupon path. |
-| A `transaction` coupon attached to a line (or vice versa) | Low | Medium | Calculator rejects wrong scope (Phase 2.2); UI offers only the matching scope per surface (D5). |
-| Fixed coupon drives a negative subtotal | Low | Medium | Clamp to base in the calculator (D3). |
-| Stacking accidentally allowed | Low | Low | ≤1 item-coupon per line enforced in usecase + UI (D4). |
+| Staff attach a coupon to the "wrong" place | Low | Low | Accepted by design — no scope guard (D5). Both pickers show all coupons; staff judgment, like the 2h-minimum and STUDENT-eligibility rules. |
+| Fixed coupon drives a negative base | Low | Medium | Clamp to base in `ApplyCouponToBase` (D3) — now applied to the whole-bill path too. |
+| Stacking accidentally allowed | Low | Low | ≤1 coupon per line enforced in usecase + UI (D4). |
 
 ---
 
@@ -240,10 +216,9 @@ Run the project codegen (`libs/api-contract/package.json` / `openapitools.json`)
 | 2 Domain + calculator | 0.5 day | 3 |
 | 3 Item-coupon application (core; rental-safe update already done #131) | 1 day | 4 |
 | 4 Data layer | 0.5 day | 5 |
-| 5 Contract + codegen | 0.5 day | 6, 7 |
-| 6 Coupon admin UI | 0.5 day | 7 |
-| 7 Transaction edit UI | 1.5 days | 8 |
-| 8 Mobile parity | 1 day | 9 |
-| 9 Docs + release | 0.5 day | — |
+| 5 Contract + codegen | 0.5 day | 6 |
+| 6 Transaction edit UI | 1.5 days | 7 |
+| 7 Mobile parity | 1 day | 8 |
+| 8 Docs + release | 0.5 day | — |
 
-**Total:** ~6.5 working days, single engineer (the rental-safe update prerequisite already shipped in #131). Each phase is one reviewable PR.
+**Total:** ~6 working days, single engineer (rental-safe update already shipped in #131; no coupon-admin work needed). Each phase is one reviewable PR.

--- a/docs/plan-rental-coupons.md
+++ b/docs/plan-rental-coupons.md
@@ -1,34 +1,41 @@
-# Implementation Plan: Rental Coupons
+# Implementation Plan: Per-Item Coupons
 
 Companion to [`prd-rental-coupons.md`](./prd-rental-coupons.md).
 
 ## Overview
 
-Give coupons three new dimensions — **scope** (`transaction` | `rental_item`), a **`free_duration`** type, and a **`min_play_minutes`** eligibility gate — then apply them **per ticket at rental checkout**, where play-time is finally known. The discount is materialized as money on `TransactionItem.DiscountAmount` (which already exists), so `transaction.Total = Σ subtotals` and the existing income/budget math in `PayTransaction` is untouched.
+Let a coupon target **one `TransactionItem`** instead of the whole transaction. That single capability covers all three requested coupons:
 
-**Design rules driving this plan (from the PRD):**
-- One rental row = one ticket = one `TransactionItem`. Per-ticket discounts live on that item.
-- "Free X hours" = reduce billable minutes by `amount`, then re-price through the existing `CalculatePrice`. (PRD D1)
-- Billable minutes ≤ 0 ⇒ ticket is free. (PRD D2)
-- ≤ 1 coupon per ticket, no stacking. (PRD D4)
-- All new columns are additive with defaults; only the checkout request body is a non-additive change, isolated to Phase 5–7. (PRD D9)
-- Reuse `RoundToNearest500` for percentage discounts. (PRD D8)
+| Coupon | type | amount | scope |
+|---|---|---:|---|
+| FREE 1 HOUR | `fixed` | 15,000 | `item` |
+| FREE 2 HOUR | `fixed` | 30,000 | `item` |
+| STUDENT DISCOUNT | `percentage` | 40 | `item` |
 
-Phases are independently shippable and ordered: schema/seed → domain → data → checkout usecase+handler → contract → coupon admin UI → checkout UI → mobile → docs. Each phase is one small PR.
+Coupons are attached **after checkout, on the transaction edit screen** (PRD D2). Rental checkout is unchanged. The discount lands on `TransactionItem.DiscountAmount`, so `Total = Σ subtotals` and the `PayTransaction` income/budget math is untouched.
+
+**Design rules (from the PRD):**
+- New coupon dimension is just `scope` (`transaction` | `item`); types stay `fixed`/`percentage`. (No `free_duration`.)
+- "Free N hours" = fixed rupiah, clamped to the item price. (D1, D3)
+- ≤ 1 item-coupon per line, no stacking. (D4)
+- 2-hour minimum for FREE 1 HOUR is staff discretion, shown via the line's duration note. (D6)
+- **Prerequisite:** make the transaction create/update path preserve rental-item prices (today it re-derives them from `variants.price = 0`). (D7 / Phase 3)
+- All schema and contract changes additive. (D10)
+
+Phases are independently shippable and ordered: schema/seed → domain → rental-safe update + item-coupon application → data layer → contract → coupon admin UI → transaction edit UI → mobile → docs. Each phase is one small PR.
 
 ---
 
 ## Phase 1: Database Schema + Seed
 
-**Goal:** Coupons can carry scope/eligibility; `transaction_coupons` can point at a ticket; the three coupons exist. Existing data untouched and behaviorally identical.
+**Goal:** Coupons carry a scope; `transaction_coupons` can point at an item; the three coupons exist. Existing data behaviorally identical.
 
-### 1.1 Migration `000012_rental_coupons`
+### 1.1 Migration `000012_item_coupons`
 
-`apps/api/migrations/000012_rental_coupons.up.sql`:
+`apps/api/migrations/000012_item_coupons.up.sql`:
 ```sql
 ALTER TABLE coupons
-  ADD COLUMN scope            VARCHAR(50) NOT NULL DEFAULT 'transaction',
-  ADD COLUMN min_play_minutes INT         NOT NULL DEFAULT 0;
+  ADD COLUMN scope VARCHAR(50) NOT NULL DEFAULT 'transaction';
 
 ALTER TABLE transaction_coupons
   ADD COLUMN transaction_item_id BIGINT NULL,
@@ -36,243 +43,176 @@ ALTER TABLE transaction_coupons
   ADD CONSTRAINT fk_tc_transaction_item
       FOREIGN KEY (transaction_item_id) REFERENCES transaction_items(id);
 
--- Seed the three coupons, idempotent on unique code
-INSERT INTO coupons (code, type, amount, scope, min_play_minutes)
+INSERT INTO coupons (code, type, amount, scope)
 SELECT * FROM (
-  SELECT 'FREE 1 HOUR'      AS code, 'free_duration' AS type, 60  AS amount, 'rental_item' AS scope, 120 AS min_play_minutes UNION ALL
-  SELECT 'FREE 2 HOUR',           'free_duration',          120,        'rental_item',                 0 UNION ALL
-  SELECT 'STUDENT DISCOUNT',      'percentage',              40,        'rental_item',                 0
+  SELECT 'FREE 1 HOUR'      AS code, 'fixed'      AS type, 15000 AS amount, 'item' AS scope UNION ALL
+  SELECT 'FREE 2 HOUR',           'fixed',            30000,        'item' UNION ALL
+  SELECT 'STUDENT DISCOUNT',      'percentage',          40,        'item'
 ) seed
 WHERE NOT EXISTS (SELECT 1 FROM coupons c WHERE c.code = seed.code);
 ```
 
-`apps/api/migrations/000012_rental_coupons.down.sql`:
+`...down.sql`:
 ```sql
 DELETE FROM coupons WHERE code IN ('FREE 1 HOUR','FREE 2 HOUR','STUDENT DISCOUNT');
 ALTER TABLE transaction_coupons
   DROP FOREIGN KEY fk_tc_transaction_item,
   DROP KEY idx_tc_transaction_item_id,
   DROP COLUMN transaction_item_id;
-ALTER TABLE coupons DROP COLUMN min_play_minutes, DROP COLUMN scope;
+ALTER TABLE coupons DROP COLUMN scope;
 ```
 
 ### 1.2 Verify
-- Migrate up → down → up (idempotency); seed insert does not duplicate on re-run.
-- `SELECT scope, min_play_minutes FROM coupons` — pre-existing coupons all `('transaction', 0)`.
-- `go test ./apps/api/...` still green (no Go reads the new columns yet).
+- Up → down → up; seed does not duplicate on re-run.
+- Pre-existing coupons all read `scope = 'transaction'`.
+- `go test ./apps/api/...` green (no Go reads the new columns yet).
 
 **Exit criteria:** Migration applies/reverts cleanly on a DB with existing coupons + transactions.
 
 ---
 
-## Phase 2: Domain Layer (Go)
+## Phase 2: Domain Entities + Item-Discount Calculator
 
-**Goal:** Entity + a pure per-ticket discount calculator with exhaustive unit tests. No handlers wired.
+**Goal:** Entity changes + a pure per-item discount function with exhaustive tests. No usecase wiring yet.
 
-### 2.1 Extend the coupon entity
+### 2.1 Entities
+- `apps/api/domain/coupon_entity.go`: add `CouponScope` (`ScopeTransaction`/`ScopeItem`) and `Scope CouponScope` on `Coupon`.
+- `apps/api/domain/transaction_entity.go`: add `TransactionItemId *int64` to `TransactionCoupon`.
 
-`apps/api/domain/coupon_entity.go`:
+### 2.2 Calculator
+
+New `apps/api/domain/coupon_calculator.go` — pure, implements PRD §3 / FR-4:
 ```go
-const FreeDuration CouponType = "free_duration"
-
-type CouponScope string
-const ( ScopeTransaction CouponScope = "transaction"; ScopeRentalItem CouponScope = "rental_item" )
-
-type Coupon struct {
-    Id; Code; Type CouponType; Amount int64
-    Scope          CouponScope   // new
-    MinPlayMinutes int64         // new
-    CreatedAt; DeletedAt
-}
-```
-Add `Scope`/`MinPlayMinutes` to `TransactionCoupon` snapshot only if needed for display; otherwise add a nullable `TransactionItemId *int64` to `TransactionCoupon` in `transaction_entity.go`.
-
-### 2.2 Per-ticket discount calculator
-
-New `apps/api/domain/coupon_calculator.go` — pure, no DB, implements PRD FR-3:
-```go
-type TicketDiscount struct { Base, Discount, Subtotal float32 }
-
-func CalculateRentalCouponDiscount(
-    tiers []PricingTier, duration time.Duration, coupon *Coupon,
-) (TicketDiscount, *Error) {
-    base, err := CalculatePrice(tiers, duration)
-    if err != nil { return TicketDiscount{}, err }
-    if coupon == nil { return TicketDiscount{base.Price, 0, base.Price}, nil }
-    if coupon.Scope != ScopeRentalItem {
-        return TicketDiscount{}, &Error{Type: BadRequest, Message: "coupon not applicable to rental ticket"}
+func CalculateItemDiscount(base float32, coupon Coupon) (float32, *Error) {
+    if coupon.Scope != ScopeItem {
+        return 0, &Error{Type: BadRequest, Message: "coupon is not item-scoped"}
     }
-    actualMin := int64(math.Ceil(duration.Minutes()))
-    if actualMin < coupon.MinPlayMinutes {
-        return TicketDiscount{}, &Error{Type: BadRequest, Message: "play time below coupon minimum"}
-    }
-    var discount float32
     switch coupon.Type {
-    case FreeDuration:
-        billable := actualMin - coupon.Amount
-        var discounted float32
-        if billable > 0 {
-            d, _ := CalculatePrice(tiers, time.Duration(billable)*time.Minute)
-            discounted = d.Price
-        } // billable <= 0 -> discounted stays 0 (PRD D2)
-        discount = base.Price - discounted
-    case Percentage:
-        discount = float32(utils.RoundToNearest500(int(base.Price) * int(coupon.Amount) / 100))
     case Fixed:
-        discount = float32(coupon.Amount)
-        if discount > base.Price { discount = base.Price }
+        d := float32(coupon.Amount)
+        if d > base { d = base }            // clamp (D3)
+        return d, nil
+    case Percentage:
+        return float32(utils.RoundToNearest500(int(base) * int(coupon.Amount) / 100)), nil
     }
-    return TicketDiscount{base.Price, discount, base.Price - discount}, nil
+    return 0, &Error{Type: BadRequest, Message: "unsupported coupon type"}
 }
 ```
 
-### 2.3 Calculator tests
-
-`apps/api/domain/coupon_calculator_test.go` — table-driven, covering **every PRD FR-3 row 1–7**, plus:
-- Wrong scope (`transaction` coupon) → error.
-- `free_duration` exactly reducing to a tier boundary.
-- `fixed` larger than base → clamped, subtotal 0, no negative.
-- `nil` coupon → zero discount.
+### 2.3 Tests
+`apps/api/domain/coupon_calculator_test.go` — table-driven over **every PRD FR-4 row 1–7**, plus: non-item scope → error; fixed exactly equal to base → subtotal 0.
 
 ### 2.4 Coupon usecase validation
+`apps/api/domain/coupon_usecase.go` create/update: enforce FR-1 (`scope` valid; `percentage` 0<amt≤100; `fixed` amt>0). Add tests.
 
-`apps/api/domain/coupon_usecase.go` create/update: enforce PRD FR-1 (`free_duration ⇒ rental_item & amount>0`; `percentage ⇒ 0<amount≤100`; `fixed ⇒ amount>0`; `min_play_minutes ≥ 0`). Add tests.
-
-### 2.5 Verify
-`go test ./apps/api/domain/...` green.
-
-**Exit criteria:** Domain complete and tested in isolation; no SQL, no handlers.
+**Exit criteria:** Domain compiles; calculator + validation tested in isolation.
 
 ---
 
-## Phase 3: Data Layer (MySQL)
+## Phase 3: Rental-Safe Update + Item-Coupon Application (core PR)
 
-**Goal:** Repos read/write the new columns and the ticket link.
+**Goal:** Editing a rental transaction no longer destroys its prices, and item-scoped coupons discount the right line.
 
-### 3.1 GORM models + transformers
-- `apps/api/data/mysql/coupon_entity.go` + transformer: map `scope`, `min_play_minutes` both ways.
-- `apps/api/data/mysql/transaction_entity.go` (transaction_coupons model) + transformer: map nullable `transaction_item_id`.
+### 3.1 Preserve rental-item prices (PRD FR-2 / D7)
+In `transaction_usecase.go`, both `CreateTransaction` (~:51-73) and `UpdateTransactionById` (~:126-149): for items with `RentalId != nil`, take `base` from the item's **stored** price (`item.Price * item.Amount`, or the persisted subtotal on update) instead of `variant.Price`. Non-rental items keep `base = variant.Price * item.Amount`.
 
-### 3.2 Verify
-- Existing coupon repo tests pass.
-- Round-trip test: create a `rental_item` coupon → read back scope + min_play intact.
+### 3.2 Apply item-scoped coupons
+Refactor the coupon loops (`:75-98`, `:151-174`):
+- For each `TransactionCoupon`:
+  - If `TransactionItemId == nil` → transaction-scope: subtract from `Total` exactly as today.
+  - If set → load coupon, call `CalculateItemDiscount(itemBase, coupon)`, add to that item's `DiscountAmount`, recompute that item's `Subtotal = base − discount`. Enforce ≤1 item-coupon per line (D4).
+- Compute `Total = Σ item.Subtotal` first, then apply transaction-scope coupons. Snapshot `{type, amount, transaction_item_id}` into the `transaction_coupons` rows.
 
-**Exit criteria:** Repos persist/read new fields; existing tests untouched.
+### 3.3 Tests
+`transaction_usecase_test.go`:
+- **Regression:** edit + re-save a rental transaction → line prices and total unchanged (guards FR-2).
+- FREE 1 HOUR on a 30K item → subtotal 15K (FR-4 #1).
+- FREE 2 HOUR on a 15K item → subtotal 0 (FR-4 #4, clamp).
+- STUDENT on a 30K item → 17,500 (FR-4 #5).
+- Multi-item: 3 items, STUDENT on the middle → only it discounted (FR-5).
+- Item coupon with a `transaction` scope → 400 (D5).
+
+**Exit criteria:** Backend reproduces every FR-4/FR-5 case; rental transactions survive an edit.
 
 ---
 
-## Phase 4: Rental Checkout Usecase + Handler
+## Phase 4: Data Layer (MySQL)
 
-**Goal:** Checkout accepts an optional coupon per ticket, applies the discount, records the link. This is the core behavioral PR.
+**Goal:** Repos map the new columns and the item link.
 
-### 4.1 Change the checkout input shape (backend)
+- `apps/api/data/mysql/coupon_entity.go` + transformer: map `scope`.
+- `apps/api/data/mysql/transaction_entity.go` (transaction_coupons model) + transformer: map nullable `transaction_item_id`. Ensure item-coupon rows persist/read the link, and `transaction_items.discount_amount`/`subtotal` round-trip.
+- Round-trip test: create a transaction with an item-scoped coupon → reload → discount + link intact.
 
-`apps/api/domain/rental_usecase.go` — `CheckoutRentals` signature changes from `rentalIds []int64` to a slice of `{ RentalId int64; CouponId *int64 }`. For each rental:
-1. Load rental, guard double-checkout (unchanged).
-2. `duration = checkoutAt − checkin_at`.
-3. If `CouponId != nil`: load coupon via `couponRepository.GetCouponById`, call `CalculateRentalCouponDiscount(snapshot, duration, &coupon)`. On error → return it (the surrounding `BeginTransaction` rolls everything back).
-4. Build `TransactionItem` with `Price=base`, `DiscountAmount=discount`, `Subtotal=base−discount`.
-5. After the transaction is created, insert a `transaction_coupons` row `{transaction_id, coupon_id, transaction_item_id, type, amount}` per applied coupon.
+**Exit criteria:** Repos persist/read the new fields; existing tests untouched.
 
-`RentalUsecase` needs a `couponRepository` dependency — add it to the constructor and `apps/api/main.go` DI wiring.
-
-### 4.2 Handler
-
-`apps/api/presentation/restapi/rental_handler.go` — checkout handler parses the new request `{ rentals: [{ rentalId, couponId? }] }`. Keep accepting the old `rentalIds` shape for one release **only if** any non-frontend consumer exists; otherwise change outright (internal API, both frontends updated in Phase 5–7).
-
-### 4.3 Tests
-
-`rental_usecase_test.go`:
-- Checkout, no coupons → unchanged totals (regression).
-- FREE 1 HOUR on a 2h ticket → subtotal 15K (PRD FR-3 #1).
-- FREE 1 HOUR on a 90m ticket → 400.
-- FREE 2 HOUR on a 1h ticket → subtotal 0 (PRD FR-3 #5).
-- Multi-ticket: 3 tickets, STUDENT on the middle one → only it discounted (PRD FR-5).
-- `transaction_coupons` row written with correct `transaction_item_id`.
-
-### 4.4 Verify
-`go test ./apps/api/...` green; `curl` smoke for one free-duration and one percentage checkout.
-
-**Exit criteria:** Backend reproduces every PRD FR-3/FR-5 case end-to-end.
+> Note: domain tests in Phases 2–3 mock the repositories, so the order (domain before data) is fine; this phase makes the core PR runnable end-to-end against MySQL.
 
 ---
 
 ## Phase 5: API Contract + Codegen
 
-**Goal:** TS clients reflect new shapes; both apps compile.
+**Goal:** TS clients reflect the additive shapes; both apps compile.
 
 ### 5.1 Edit `libs/api-contract/src/api.yaml`
-- `Coupon` + `CouponForm`: add `scope` enum, `minPlayMinutes`; `type` enum gains `free_duration`. (additive)
-- Checkout request: `{ rentals: [{ rentalId, couponId? }] }`. (**breaking** — coordinated here)
-- `TransactionCoupon`: add optional `transactionItemId`. (additive)
+- `Coupon` + `CouponForm`: add `scope` enum (`transaction`|`item`).
+- `TransactionCoupon` (in transaction request + response): add optional `transactionItemId`.
+- All additive — no breaking changes; `POST /rentals/checkout` untouched.
 
-### 5.2 Codegen
-Run the project's codegen (per `libs/api-contract/package.json` / `openapitools.json`).
+### 5.2 Codegen + verify
+Run the project codegen (`libs/api-contract/package.json` / `openapitools.json`). `nx build api-contract`, `nx build web`, `nx build mobile`, `nx test ui` green.
 
-### 5.3 Update the FE checkout usecase signature
-`libs/ui/src/domain/usecases/rentalCheckout.ts` + its test: pass `{ rentalId, couponId? }[]`. Keep callers compiling (Phase 7 wires real UI; here just default `couponId` undefined so behavior is identical).
-
-### 5.4 Verify
-`nx build api-contract`, `nx build web`, `nx build mobile`, `nx test ui` all green.
-
-**Exit criteria:** Generated types include new shapes; checkout still works with no coupons selected.
+**Exit criteria:** Generated types include `scope` and `transactionItemId`; existing flows compile unchanged.
 
 ---
 
 ## Phase 6: Coupon Admin UI
 
-**Goal:** Owner can create/edit all coupon kinds, including the three rental coupons.
+**Goal:** Owner can create/edit coupons of either scope, including the three rental coupons.
 
-### 6.1 Frontend entity + form
-- `libs/ui/src/domain/entities/Coupon.ts`: extend `CouponType` with `'free_duration'`; add `scope`, `minPlayMinutes` to `Coupon` and `CouponForm`.
-- Coupon form component + Zod schema (PRD FR-6): scope selector; `free_duration` type; conditional `min_play_minutes` input; adaptive amount label ("Amount (Rp)" / "Percent (%)" / "Free minutes"). Mirror Phase 2.4 validation.
+- `libs/ui/src/domain/entities/Coupon.ts`: add `scope` to `Coupon` and `CouponForm`.
+- Coupon form + Zod: **scope** selector; adaptive amount label ("Amount (Rp)" / "Percent (%)"); mirror Phase 2.4 validation.
 - `apps/web/src/pages/coupons/...` create/edit pages render the extended form.
+- `nx test web`/`nx test ui`; manually create FREE 1 HOUR / FREE 2 HOUR / STUDENT DISCOUNT.
 
-### 6.2 Verify
-`nx test web`/`nx test ui`; manually create FREE 1 HOUR / FREE 2 HOUR / STUDENT DISCOUNT and confirm they persist with correct scope + min play.
-
-**Exit criteria:** All three coupons are creatable/editable from the web admin.
+**Exit criteria:** All three coupons creatable/editable from the web admin.
 
 ---
 
-## Phase 7: Web Checkout Screen
+## Phase 7: Transaction Edit Screen — Per-Item Coupon Picker
 
-**Goal:** Per-ticket coupon selection with eligibility + live totals (PRD FR-7).
+**Goal:** Staff attach an item-scoped coupon to a specific line (PRD FR-7).
 
-### 7.1 Checkout screen
-The `libs/ui` screen behind `apps/web/src/pages/rentals/checkout.tsx`:
-- Per ticket: player • variant • duration • base price.
-- "Apply coupon" control listing only `rental_item` coupons; disable coupons where `ceil(actualMinutes) < minPlayMinutes` with a hint.
-- On select: show discount + new subtotal for that ticket; recompute the grand total live. Allow clearing. One coupon per ticket.
-- Submit sends `{ rentals: [{ rentalId, couponId? }] }`.
+- The `libs/ui` transaction screen (`TransactionCreateScreen.tsx` and its update counterpart): each line item gains an "Apply coupon" control listing only `item`-scoped coupons (reuse the `CouponList.tsx` sheet, filtered by scope).
+- On select: show the line discount + new subtotal; recompute the grand total live; allow clearing; ≤1 per line.
+- Filter the existing whole-bill picker to `transaction`-scoped coupons.
+- Show the rental duration note next to each rental line (D6).
+- Form submits each line's optional `couponId`; map into `transactionCoupons[].transactionItemId` on save.
 
-Reuse the existing `CouponList` sheet pattern (`libs/ui/src/presentation/components/coupons/CouponList.tsx`), filtered to `rental_item` scope and parameterized by per-ticket eligibility.
+### Verify
+`nx serve web` walkthrough: check out a 2h rental → open the transaction → apply FREE 1 HOUR → subtotal 15K; apply STUDENT to one of several tickets → only that line discounts (FR-5). `nx test web`.
 
-### 7.2 Verify
-`nx serve web` walkthrough reproducing PRD FR-3 #1, #3 (disabled), #5, #6 and the FR-5 multi-ticket case. `nx test web`.
-
-**Exit criteria:** Every PRD FR-3/FR-5 case reproduces in the web checkout UI; transaction-create screen visibly unchanged.
+**Exit criteria:** Every FR-4/FR-5 case reproduces in the web transaction edit UI; whole-bill coupon behavior unchanged.
 
 ---
 
 ## Phase 8: Mobile Parity
 
-**Goal:** React Native checkout offers the same per-ticket coupon picker (PRD FR-8).
+**Goal:** React Native transaction edit screen offers the same per-item picker (PRD FR-8).
 
-- `apps/mobile/` checkout screen: same per-ticket picker, reusing shared `libs/ui` primitives where possible.
-- Coupon **admin** editing stays web-only for v1.
+- `apps/mobile/` transaction screen: per-item coupon picker reusing shared `libs/ui` primitives. Coupon **admin** editing stays web-only for v1.
 - `nx test mobile`; walk the same acceptance cases on emulator.
 
-**Exit criteria:** Mobile staff can apply per-ticket coupons at checkout with correct totals.
+**Exit criteria:** Mobile staff can attach per-item coupons with correct totals.
 
 ---
 
 ## Phase 9: Documentation + Release
 
-1. Short owner guide under `docs/`: "Rental coupons — how FREE 1 HOUR / FREE 2 HOUR / STUDENT DISCOUNT work and when each applies."
-2. Update `E2E_TEST_PLAN.md` with the new checkout-coupon scenarios.
+1. Short owner guide under `docs/`: "Rental coupons — what FREE 1 HOUR / FREE 2 HOUR / STUDENT DISCOUNT do and how to apply them on a transaction."
+2. Update `E2E_TEST_PLAN.md` with the per-item coupon scenarios.
 3. Update `README.md` feature list if present.
-4. PR description links the PRD and lists every FR-3/FR-5 case verified.
+4. PR description links the PRD and lists every FR-4/FR-5 case verified.
 
 ---
 
@@ -280,12 +220,12 @@ Reuse the existing `CouponList` sheet pattern (`libs/ui/src/presentation/compone
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| Checkout request shape change breaks an un-updated consumer | Low | High | Internal API; both frontends updated in Phases 5/7/8 in lockstep with the contract. Optionally accept the legacy `rentalIds` shape for one release. |
-| Free-duration math drifts from staff expectation (D1/D2) | Medium | Medium | PRD worked examples are the acceptance tests; surface "Billed as Xh (1h free)" on the checkout line so staff see the reasoning. Open Question #1 confirms D2 with the owner. |
-| Income/budget math regresses if discount isn't on `Subtotal` | Low | High | Discount always lands on `TransactionItem.DiscountAmount`; `Subtotal = base − discount`; `Total = Σ subtotals`. Phase 4 regression test asserts unchanged totals for the no-coupon path. |
-| A `transaction`-scope coupon gets applied to a ticket (or vice versa) | Low | Medium | Calculator rejects wrong scope (Phase 2.2); UI offers only the matching scope per surface (PRD D5). |
-| Negative subtotal from an over-large `fixed` coupon | Low | Medium | `fixed` discount clamped to base in the calculator. |
-| Eligible-coupon UI lets staff pick an ineligible one | Low | Medium | UI disables ineligible coupons **and** the server re-validates (PRD D6); checkout rolls back on violation. |
+| Editing a rental transaction zeroes its prices (current bug) | High if unaddressed | High | Phase 3.1 preserves stored prices for `RentalId != nil` items; Phase 3.3 regression test asserts unchanged totals. Hard prerequisite, done before any UI ships. |
+| Fixed 15K/30K over-discounts all-day or capped rentals (D1) | Medium | Low | Documented; staff only apply FREE 1/2 HOUR to standard hourly rentals. Open Question #1 confirms with owner. Duration note shown on the line. |
+| Income/budget math regresses | Low | High | Discount always lands on `DiscountAmount`; `Subtotal = base − discount`; `Total = Σ subtotals`. Regression test on the no-coupon path. |
+| A `transaction` coupon attached to a line (or vice versa) | Low | Medium | Calculator rejects wrong scope (Phase 2.2); UI offers only the matching scope per surface (D5). |
+| Fixed coupon drives a negative subtotal | Low | Medium | Clamp to base in the calculator (D3). |
+| Stacking accidentally allowed | Low | Low | ≤1 item-coupon per line enforced in usecase + UI (D4). |
 
 ---
 
@@ -294,13 +234,13 @@ Reuse the existing `CouponList` sheet pattern (`libs/ui/src/presentation/compone
 | Phase | Est. effort | Blocks |
 |---|---|---|
 | 1 Schema + seed | 0.5 day | 2 |
-| 2 Domain + calculator | 1 day | 3, 4 |
-| 3 Data layer | 0.5 day | 4 |
-| 4 Checkout usecase + handler | 1.5 days | 5 |
+| 2 Domain + calculator | 0.5 day | 3 |
+| 3 Rental-safe update + item application (core) | 1.5 days | 4 |
+| 4 Data layer | 0.5 day | 5 |
 | 5 Contract + codegen | 0.5 day | 6, 7 |
-| 6 Coupon admin UI | 1 day | 7 |
-| 7 Web checkout UI | 1.5 days | 8 |
+| 6 Coupon admin UI | 0.5 day | 7 |
+| 7 Transaction edit UI | 1.5 days | 8 |
 | 8 Mobile parity | 1 day | 9 |
 | 9 Docs + release | 0.5 day | — |
 
-**Total:** ~8 working days, single engineer. Each phase is one reviewable PR.
+**Total:** ~7 working days, single engineer. Each phase is one reviewable PR.

--- a/docs/plan-rental-coupons.md
+++ b/docs/plan-rental-coupons.md
@@ -19,7 +19,7 @@ Coupons are attached **after checkout, on the transaction edit screen** (PRD D2)
 - "Free N hours" = fixed rupiah, clamped to the item price. (D1, D3)
 - ≤ 1 item-coupon per line, no stacking. (D4)
 - 2-hour minimum for FREE 1 HOUR is staff discretion, shown via the line's duration note. (D6)
-- **Prerequisite:** make the transaction create/update path preserve rental-item prices (today it re-derives them from `variants.price = 0`). (D7 / Phase 3)
+- **Prerequisite — ✅ done on main (#131):** `UpdateTransactionById` now preserves rental-item prices instead of re-deriving them from `variants.price = 0`. Phase 3 builds on it. (D7)
 - All schema and contract changes additive. (D10)
 
 Phases are independently shippable and ordered: schema/seed → domain → rental-safe update + item-coupon application → data layer → contract → coupon admin UI → transaction edit UI → mobile → docs. Each phase is one small PR.
@@ -109,30 +109,33 @@ func CalculateItemDiscount(base float32, coupon Coupon) (float32, *Error) {
 
 ---
 
-## Phase 3: Rental-Safe Update + Item-Coupon Application (core PR)
+## Phase 3: Item-Coupon Application (core PR)
 
-**Goal:** Editing a rental transaction no longer destroys its prices, and item-scoped coupons discount the right line.
+**Goal:** Item-scoped coupons discount the right line — including rental tickets — on both create and update.
 
-### 3.1 Preserve rental-item prices (PRD FR-2 / D7)
-In `transaction_usecase.go`, both `CreateTransaction` (~:51-73) and `UpdateTransactionById` (~:126-149): for items with `RentalId != nil`, take `base` from the item's **stored** price (`item.Price * item.Amount`, or the persisted subtotal on update) instead of `variant.Price`. Non-rental items keep `base = variant.Price * item.Amount`.
+### 3.1 Rental-price preservation — ✅ DONE on main (#131)
+`UpdateTransactionById` already preserves the stored `Price`/`Subtotal`/`DiscountAmount`/`RentalId`/`Note` of rental items and ships a regression test. **No work here** — but note its shape: rental items hit an early `if existingItem.RentalId != nil { … continue }` branch (`transaction_usecase.go`, ~:137-152) that copies stored values and skips the variant recompute. Phase 3.2 hooks coupons *into* that branch. (`CreateTransaction` never receives rental items, so it needed no preservation fix.)
 
 ### 3.2 Apply item-scoped coupons
-Refactor the coupon loops (`:75-98`, `:151-174`):
+Update the coupon loop (`transaction.TransactionCoupons`) in **both** `CreateTransaction` and `UpdateTransactionById` (~:178-202):
 - For each `TransactionCoupon`:
   - If `TransactionItemId == nil` → transaction-scope: subtract from `Total` exactly as today.
-  - If set → load coupon, call `CalculateItemDiscount(itemBase, coupon)`, add to that item's `DiscountAmount`, recompute that item's `Subtotal = base − discount`. Enforce ≤1 item-coupon per line (D4).
-- Compute `Total = Σ item.Subtotal` first, then apply transaction-scope coupons. Snapshot `{type, amount, transaction_item_id}` into the `transaction_coupons` rows.
+  - If set → locate the target item in `transaction.TransactionItems`, derive its `base`, call `CalculateItemDiscount(base, coupon)`, set that item's `DiscountAmount = discount` and `Subtotal = base − discount`, adjust the running `Total` by the delta. Enforce ≤1 item-coupon per line (D4); reject a non-`item` coupon carrying a `TransactionItemId` (D5, 400).
+- **Base derivation (matches #131):** rental item → `base = existingItem.Price * existingItem.Amount` (full duration-based price; recompute from `Price` each save so discounts never compound). Non-rental → `base = variant.Price * item.Amount`.
+- **Rental-branch hook:** in `UpdateTransactionById`, when a rental item has an attached item-coupon, recompute its `DiscountAmount`/`Subtotal` from `Price` instead of blindly copying the stored `Subtotal`. A rental ticket with no item-coupon stays byte-for-byte as #131 leaves it.
+- Snapshot `{type, amount, transaction_item_id}` into the `transaction_coupons` rows (the current loop drops `transaction_item_id` — add it).
 
 ### 3.3 Tests
-`transaction_usecase_test.go`:
-- **Regression:** edit + re-save a rental transaction → line prices and total unchanged (guards FR-2).
-- FREE 1 HOUR on a 30K item → subtotal 15K (FR-4 #1).
+Extend `transaction_usecase_test.go` (keep #131's rental-regression test):
+- FREE 1 HOUR on a 30K **rental** item → DiscountAmount 15K, subtotal 15K, `RentalId` intact (rental-branch hook).
+- Re-save the same transaction twice → discount stays 15K, does not compound (base-from-`Price`).
 - FREE 2 HOUR on a 15K item → subtotal 0 (FR-4 #4, clamp).
 - STUDENT on a 30K item → 17,500 (FR-4 #5).
 - Multi-item: 3 items, STUDENT on the middle → only it discounted (FR-5).
-- Item coupon with a `transaction` scope → 400 (D5).
+- `transaction`-scope coupon carrying a `TransactionItemId` → 400 (D5).
+- Item-coupon on a new transaction via `CreateTransaction` (non-rental path).
 
-**Exit criteria:** Backend reproduces every FR-4/FR-5 case; rental transactions survive an edit.
+**Exit criteria:** Backend reproduces every FR-4/FR-5 case; a coupon on a rental ticket re-prices it without breaking #131's preservation guarantee.
 
 ---
 
@@ -220,7 +223,7 @@ Run the project codegen (`libs/api-contract/package.json` / `openapitools.json`)
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| Editing a rental transaction zeroes its prices (current bug) | High if unaddressed | High | Phase 3.1 preserves stored prices for `RentalId != nil` items; Phase 3.3 regression test asserts unchanged totals. Hard prerequisite, done before any UI ships. |
+| Editing a rental transaction zeroes its prices (was a live bug) | — | High | **Resolved on main (#131):** rental items keep stored price/subtotal on update, covered by a regression test. Phase 3.2's coupon hook must preserve this guarantee for the no-coupon case. |
 | Fixed 15K/30K over-discounts all-day or capped rentals (D1) | Medium | Low | Documented; staff only apply FREE 1/2 HOUR to standard hourly rentals. Open Question #1 confirms with owner. Duration note shown on the line. |
 | Income/budget math regresses | Low | High | Discount always lands on `DiscountAmount`; `Subtotal = base − discount`; `Total = Σ subtotals`. Regression test on the no-coupon path. |
 | A `transaction` coupon attached to a line (or vice versa) | Low | Medium | Calculator rejects wrong scope (Phase 2.2); UI offers only the matching scope per surface (D5). |
@@ -235,7 +238,7 @@ Run the project codegen (`libs/api-contract/package.json` / `openapitools.json`)
 |---|---|---|
 | 1 Schema + seed | 0.5 day | 2 |
 | 2 Domain + calculator | 0.5 day | 3 |
-| 3 Rental-safe update + item application (core) | 1.5 days | 4 |
+| 3 Item-coupon application (core; rental-safe update already done #131) | 1 day | 4 |
 | 4 Data layer | 0.5 day | 5 |
 | 5 Contract + codegen | 0.5 day | 6, 7 |
 | 6 Coupon admin UI | 0.5 day | 7 |
@@ -243,4 +246,4 @@ Run the project codegen (`libs/api-contract/package.json` / `openapitools.json`)
 | 8 Mobile parity | 1 day | 9 |
 | 9 Docs + release | 0.5 day | — |
 
-**Total:** ~7 working days, single engineer. Each phase is one reviewable PR.
+**Total:** ~6.5 working days, single engineer (the rental-safe update prerequisite already shipped in #131). Each phase is one reviewable PR.

--- a/docs/prd-rental-coupons.md
+++ b/docs/prd-rental-coupons.md
@@ -1,0 +1,295 @@
+# PRD: Rental Coupons — Time-Aware & Per-Ticket Discounts
+
+## Problem Statement
+
+The cafe wants to run three new coupons for board-game **rentals**:
+
+| Coupon | Rule |
+|---|---|
+| **FREE 1 HOUR** | Customer plays at least **2 hours** → bill **1 hour less**. |
+| **FREE 2 HOUR** | No minimum play time → bill **2 hours less**. |
+| **STUDENT DISCOUNT** | **40% off a single ticket** only. One checkout can contain several tickets; only the student's ticket is discounted, not the whole bill. |
+
+The current coupon system cannot express any of these:
+
+1. **No play-time context.** Coupons are only applied inside `CreateTransaction` / `UpdateTransactionById` (`apps/api/domain/transaction_usecase.go:75-98`), i.e. the manual transaction-create screen. The **rental checkout** path (`apps/api/domain/rental_usecase.go:83-155`) builds its transaction directly and **never applies any coupon**. Yet rental duration — the thing "FREE 1 HOUR" depends on — only exists at checkout, computed from `checkout_at − checkin_at`. So a time-conditional coupon is impossible today.
+
+2. **No per-ticket scope.** A coupon discounts the **whole transaction total** — `transaction.Total -= couponDiscountAmount` (`transaction_usecase.go:90`). A checkout of three rental tickets gets one transaction-wide discount. "40% off **his** ticket only" cannot be modeled when only some of the tickets qualify.
+
+3. **No "free duration" discount type.** The only types are `fixed` (subtract rupiah) and `percentage` (subtract a % of total) — see `apps/api/domain/coupon_entity.go:7-10`. "Bill one hour less" is neither: in a tiered pricing model the price of an hour is not a fixed number, so it must be expressed as *reduce the billable minutes, then re-price*.
+
+4. **No eligibility rule.** Nothing stores or checks a minimum play time. "FREE 1 HOUR requires ≥ 2 hours" has nowhere to live.
+
+This PRD extends the coupon model so coupons can be **scoped to a single rental ticket**, **conditioned on play time**, and can express **free duration**, and makes them selectable **at the rental checkout screen** where duration is finally known.
+
+---
+
+## Context: Existing System
+
+- **Backend**: Go REST API, MySQL + GORM, Clean Architecture (`domain → data → presentation`). Migrations under `apps/api/migrations/` via `golang-migrate` (next free number is **000012**).
+- **Frontend**: Next.js web (`apps/web/`) + React Native mobile (`apps/mobile/`) sharing a Tamagui UI library (`libs/ui/`). React Query for server state, Zod + React Hook Form for forms.
+- **API contract**: OpenAPI at `libs/api-contract/src/api.yaml`, codegen consumed by both frontends.
+
+### Coupon domain today
+
+- **Entity** (`apps/api/domain/coupon_entity.go`):
+  ```go
+  type CouponType string
+  const ( Fixed CouponType = "fixed"; Percentage CouponType = "percentage" )
+  type Coupon struct { Id; Code; Type; Amount int64; CreatedAt; DeletedAt }
+  ```
+- **Schema** (`apps/api/migrations/000001_initial_schema.up.sql:65-74`):
+  ```
+  coupons(id, code, type, amount, created_at, deleted_at)   UNIQUE(code)
+  ```
+- **Junction** (same file, `transaction_coupons`): snapshots `(transaction_id, coupon_id, type, amount)` — the coupon's type/amount at apply time, so later coupon edits don't rewrite history.
+- **Application math** (`transaction_usecase.go:82-90`): `fixed` subtracts `amount`; `percentage` subtracts `RoundToNearest500(total * amount / 100)`.
+- **Frontend**: `libs/ui/src/domain/entities/Coupon.ts` (`CouponType = 'fixed' | 'percentage'`), coupon picker `CouponList.tsx` (a bottom sheet) used inside the **transaction** create screen only.
+
+### Rental domain today
+
+- **One rental row = one person = one "ticket."** A group of three players is three rental rows (design rule from `trd-board-game-rental-pricing.md`).
+- **Check-in** snapshots the variant's pricing tiers onto `rentals.pricing_tiers` (JSON). Billing reads only the snapshot.
+- **Check-out** (`rental_usecase.go:83-155`): for each `rentalId`, compute `duration = now − checkin_at`, price via `CalculatePrice(snapshot, duration)` (`apps/api/domain/pricing_calculator.go`), and emit **one `TransactionItem`** per rental (`Amount=1`, `Price`, `Subtotal=Price`, `RentalId`, `Note="<duration>"`). The items become one `Transaction`. **No coupon is ever consulted.**
+- **Checkout request** today carries only a list of rental IDs; the transaction is created server-side. The frontend usecase is `libs/ui/src/domain/usecases/rentalCheckout.ts`, screen rendered by `apps/web/src/pages/rentals/checkout.tsx`.
+- **`TransactionItem.DiscountAmount`** already exists (`transaction_entity.go:14`, column `transaction_items.discount_amount`) and already flows into `Subtotal = Price − DiscountAmount` for manual transactions. **Per-ticket discounts have a home in the data model already** — they just aren't produced by the rental flow.
+
+### The pricing calculator (the lever for "free duration")
+
+```go
+// pricing_calculator.go
+func CalculatePrice(tiers []PricingTier, duration time.Duration) (PricingResult, *Error) {
+    durationMinutes := ceil(duration.Minutes())
+    for _, tier := range tiers { if tier.UpToMinutes >= durationMinutes { return tier.Price } }
+    return tiers[last].Price // cap
+}
+```
+
+"Bill one hour less" = call this with `duration − 60min`. That is the whole trick, and it reuses the audited calculator unchanged.
+
+---
+
+## Proposed Solution
+
+Add three orthogonal capabilities to coupons, then surface coupon selection on the rental checkout screen.
+
+### 1. Coupon **scope** — where the discount lands
+
+A new `scope` field:
+
+| Scope | Meaning | Applies to |
+|---|---|---|
+| `transaction` | Whole-bill discount (today's behavior). | Manual transaction create screen, unchanged. |
+| `rental_item` | Discount one rental **ticket** (one `TransactionItem`). | Rental checkout screen. |
+
+`scope` defaults to `transaction`, so every existing coupon keeps behaving exactly as it does now.
+
+### 2. A new coupon **type** — `free_duration`
+
+`type` extends from `{fixed, percentage}` to `{fixed, percentage, free_duration}`. For `free_duration`, `amount` is **minutes of free play** (FREE 1 HOUR = `60`, FREE 2 HOUR = `120`). It only makes sense with `scope = rental_item`.
+
+### 3. Coupon **eligibility** — `min_play_minutes`
+
+A new `min_play_minutes` integer (default `0`). A `rental_item` coupon may be applied to a ticket only if the ticket's **actual** played minutes ≥ `min_play_minutes`. FREE 1 HOUR sets `120`; FREE 2 HOUR and STUDENT DISCOUNT set `0`.
+
+### 4. The three coupons, expressed in the model
+
+| Coupon | `type` | `amount` | `scope` | `min_play_minutes` |
+|---|---|---:|---|---:|
+| FREE 1 HOUR | `free_duration` | 60 | `rental_item` | 120 |
+| FREE 2 HOUR | `free_duration` | 120 | `rental_item` | 0 |
+| STUDENT DISCOUNT | `percentage` | 40 | `rental_item` | 0 |
+
+### 5. Apply coupons **at checkout**, per ticket
+
+`POST /rentals/checkout` is extended so each rental in the request may carry an **optional `couponId`**. At checkout the server, per rental, computes duration, validates the coupon's scope + eligibility against the actual play time, computes the discount, writes it to that ticket's `TransactionItem.DiscountAmount`, and records a `transaction_coupons` row linked to that specific item.
+
+### 6. Checkout screen gets a per-ticket coupon picker
+
+The rental checkout screen lists each ticket with its duration and computed subtotal. Each ticket gets an "Apply coupon" affordance offering only `rental_item` coupons; ineligible coupons (e.g. FREE 1 HOUR on a 40-minute ticket) are disabled with the reason shown. Selecting one updates that ticket's subtotal and the grand total live.
+
+The existing **transaction** create screen and its whole-bill coupon picker are **untouched**.
+
+---
+
+## Confirmed Product Decisions
+
+| # | Decision | Choice | Rationale |
+|---|---|---|---|
+| D1 | "Free X hours" semantics | **Reduce billable minutes by `amount`, then re-price through `CalculatePrice`.** Not "subtract the rupiah value of X hours." | In a tiered model the marginal hour has no single price. Reducing duration and re-pricing is the faithful, unambiguous meaning and reuses the audited calculator. Worked examples in FR-3. |
+| D2 | Free duration ≥ actual play time | **Ticket is fully free (subtotal = 0).** Billable minutes clamp at 0. | FREE 2 HOUR on a 1-hour rental = nothing to pay. Note: `CalculatePrice(…, 0)` would otherwise return the smallest tier, so the usecase must short-circuit `billable ≤ 0 → price 0`. |
+| D3 | Discount representation | Store the **rupiah discount** on `TransactionItem.DiscountAmount`; `Subtotal = base price − discount`. Record the coupon link + snapshot in `transaction_coupons` (now with a nullable `transaction_item_id`). | Keeps `transaction.Total` = Σ subtotals, so the existing income/budget math in `PayTransaction` flows unchanged. The free-duration discount is materialized as money at checkout time, when duration is known. |
+| D4 | Coupons per ticket | **At most one coupon per rental ticket** in v1 (no stacking). | Keeps math and UI simple; covers all three target coupons. Stacking is a future PRD. |
+| D5 | Scope enforcement | A `rental_item` coupon **cannot** be selected on the manual transaction screen; a `transaction` coupon cannot be selected per-ticket at checkout. | Each scope is offered only where it makes sense; the server validates scope on both paths. |
+| D6 | Eligibility failure | Server **rejects checkout with 400** if a chosen coupon fails its `min_play_minutes` check; the UI **disables** the coupon up front so this is unreachable through normal use. | Defense in depth — the UI prevents it, the server guarantees it. |
+| D7 | Same coupon on multiple tickets | **Allowed.** Two students in one checkout each apply STUDENT DISCOUNT to their own ticket. | Coupons are reusable rules, not single-use codes, in the current system. No usage-limit concept is introduced here. |
+| D8 | Percentage rounding for tickets | Reuse `RoundToNearest500` for `rental_item` percentage discounts, same as transaction-scope today. | Consistency with existing IDR rounding behavior. |
+| D9 | Backward compatibility | New columns are additive with defaults (`scope='transaction'`, `min_play_minutes=0`); `transaction_coupons.transaction_item_id` is nullable (null = whole-transaction). The OpenAPI changes are additive; the checkout request's `couponId` is optional. | No existing coupon, transaction, or consumer needs changing. |
+
+---
+
+## Feature Requirements
+
+### FR-1: Extended Coupon Model
+
+`coupons` gains:
+- `scope VARCHAR(50) NOT NULL DEFAULT 'transaction'` — `transaction` | `rental_item`.
+- `min_play_minutes INT NOT NULL DEFAULT 0`.
+- `type` value set extends to include `free_duration` (no DDL change — already `VARCHAR(50)`).
+
+Validation in the coupon create/update usecase:
+- `type = free_duration` ⇒ `scope` must be `rental_item` and `amount > 0` (minutes).
+- `type = percentage` ⇒ `0 < amount ≤ 100`.
+- `type = fixed` ⇒ `amount > 0`.
+- `min_play_minutes ≥ 0`; only meaningful for `rental_item` scope (ignored for `transaction`).
+
+### FR-2: Seed the Three Coupons
+
+A migration seeds exactly these rows (idempotent on `code`):
+
+| code | type | amount | scope | min_play_minutes |
+|---|---|---:|---|---:|
+| `FREE 1 HOUR` | `free_duration` | 60 | `rental_item` | 120 |
+| `FREE 2 HOUR` | `free_duration` | 120 | `rental_item` | 0 |
+| `STUDENT DISCOUNT` | `percentage` | 40 | `rental_item` | 0 |
+
+(The owner can later also create/edit these via the admin UI — FR-6.)
+
+### FR-3: Per-Ticket Discount Calculator (Acceptance Tests)
+
+A pure function computes a ticket's discount from `(snapshotTiers, actualDuration, coupon)`:
+
+```
+base       = CalculatePrice(tiers, actualDuration).Price
+actualMin  = ceil(actualDuration.minutes)
+
+if coupon == nil:                      discount = 0
+elif coupon.scope != rental_item:      ERROR (wrong scope)
+elif actualMin < coupon.minPlayMinutes: ERROR (not eligible)
+else switch coupon.type:
+  free_duration:
+      billableMin = max(0, actualMin - coupon.amount)
+      discounted  = billableMin <= 0 ? 0 : CalculatePrice(tiers, billableMin*time.Minute).Price
+      discount    = base - discounted
+  percentage:
+      discount    = RoundToNearest500(base * coupon.amount / 100)
+  fixed:
+      discount    = min(coupon.amount, base)     // never negative subtotal
+
+subtotal = base - discount
+```
+
+Worked examples against the seeded Hourly tier set (60→15K, 90→20K, 120→30K, 150→35K, 180→45K, …):
+
+| # | Coupon | Played | Base | Billed minutes | Subtotal | Discount |
+|---|---|---|---:|---|---:|---:|
+| 1 | FREE 1 HOUR | 2h 0m (120m) | 30,000 | 60m → 15K | 15,000 | 15,000 |
+| 2 | FREE 1 HOUR | 3h 0m (180m) | 45,000 | 120m → 30K | 30,000 | 15,000 |
+| 3 | FREE 1 HOUR | 1h 30m (90m) | 20,000 | — | — | **rejected** (90 < 120) |
+| 4 | FREE 2 HOUR | 3h 0m (180m) | 45,000 | 60m → 15K | 15,000 | 30,000 |
+| 5 | FREE 2 HOUR | 1h 0m (60m) | 15,000 | 0m → free (D2) | 0 | 15,000 |
+| 6 | STUDENT DISCOUNT | 2h 0m (120m) | 30,000 | n/a | 17,500 | 12,500 (`round500(30000×40/100)`) |
+| 7 | (none) | 2h 0m | 30,000 | n/a | 30,000 | 0 |
+
+### FR-4: Checkout Applies Per-Ticket Coupons
+
+`POST /rentals/checkout` request shape extends from a list of IDs to a list of `{ rentalId, couponId? }`. Per rental the server:
+1. Loads the rental, guards against double-checkout (unchanged).
+2. Computes `duration` and `base` (unchanged).
+3. If `couponId` present: loads the coupon, runs the FR-3 calculator. On scope/eligibility error → **400**, whole checkout rolls back (it already runs in one DB transaction).
+4. Emits the `TransactionItem` with `DiscountAmount = discount`, `Subtotal = base − discount`.
+5. Records a `transaction_coupons` row `{ transaction_id, coupon_id, transaction_item_id, type, amount }` (snapshotting type+amount) for each applied coupon.
+
+`transaction.Total` remains Σ of item subtotals, so `PayTransaction` income/budget math is untouched.
+
+### FR-5: Multi-Ticket Checkout Behavior
+
+A checkout of 3 tickets where ticket B has STUDENT DISCOUNT and tickets A, C have none:
+- A and C: full price.
+- B: 40% off B's subtotal only.
+- Grand total = A + (0.6×B rounded) + C.
+
+This is the requirement's "not all tickets can use STUDENT DISCOUNT" case, working by construction because the discount is per-`TransactionItem`.
+
+### FR-6: Coupon Admin UI
+
+The coupon create/edit form (`libs/ui/src/presentation/...` coupon form + `apps/web/src/pages/coupons/...`) gains:
+- A **scope** selector (`transaction` / `rental_item`).
+- The **type** selector gains `free_duration` (shown/relevant only when scope is `rental_item`).
+- A **min play minutes** numeric input (shown only for `rental_item`).
+- Amount field label adapts: "Amount (Rp)" for fixed, "Percent (%)" for percentage, "Free minutes" for free_duration.
+- Zod mirrors the FR-1 validation.
+
+### FR-7: Checkout Screen UI
+
+The rental checkout screen (`apps/web/src/pages/rentals/checkout.tsx` → its `libs/ui` screen) renders, per ticket:
+- Player name • variant • duration • **base price**.
+- An "Apply coupon" control listing only `rental_item` coupons. Coupons failing the ticket's eligibility (actual minutes < `min_play_minutes`) are **disabled** with a hint ("needs ≥ 2h play").
+- On selection: show the discount and the new subtotal for that ticket; update the **grand total** live.
+- Allow clearing the coupon. At most one coupon per ticket (D4).
+
+The submitted checkout payload carries each ticket's optional `couponId`.
+
+### FR-8: Mobile Parity
+
+React Native checkout screen (`apps/mobile/`) offers the same per-ticket coupon picker. Coupon **admin** editing may remain web-only for v1 (consistent with how rental pricing tier editing was scoped). Most primitives are shared through `libs/ui`.
+
+---
+
+## Data Model Changes
+
+### Altered: `coupons`
+```sql
+ALTER TABLE coupons
+  ADD COLUMN scope            VARCHAR(50) NOT NULL DEFAULT 'transaction',
+  ADD COLUMN min_play_minutes INT         NOT NULL DEFAULT 0;
+```
+`type` stays `VARCHAR(50)` — `free_duration` needs no DDL.
+
+### Altered: `transaction_coupons`
+```sql
+ALTER TABLE transaction_coupons
+  ADD COLUMN transaction_item_id BIGINT NULL,
+  ADD KEY idx_tc_transaction_item_id (transaction_item_id),
+  ADD CONSTRAINT fk_tc_transaction_item
+      FOREIGN KEY (transaction_item_id) REFERENCES transaction_items(id);
+```
+`null` ⇒ whole-transaction coupon (today's rows). Non-null ⇒ the discounted ticket.
+
+### Unchanged
+`transaction_items.discount_amount` already exists and is the storage for per-ticket discounts. No change to `transactions`, `rentals`, `pricing_tiers`, or `variants`.
+
+### Seed
+The three coupons of FR-2, inserted idempotently keyed on `code`.
+
+---
+
+## API Changes
+
+| Method | Path | Change |
+|---|---|---|
+| `POST /coupons`, `PUT /coupons/{id}` | Request/response gain `scope` and `min_play_minutes`; `type` enum gains `free_duration`. Additive. |
+| `GET /coupons`, `GET /coupons/{id}` | Response gains `scope`, `min_play_minutes`. Additive. |
+| `POST /rentals/checkout` | Request changes from `{ rentalIds: number[] }` to `{ rentals: [{ rentalId: number, couponId?: number }] }`. The transaction response gains per-item `discountAmount` (already present in the transaction schema). |
+| `GET /transactions/{id}` | `transaction_coupons` entries gain optional `transactionItemId`. Additive. |
+
+OpenAPI edits live in `libs/api-contract/src/api.yaml`; codegen regenerates the TS clients. The only **non-additive** change is the checkout request body — coordinated in one phase across backend + contract + both frontends.
+
+---
+
+## Out of Scope
+
+- **Coupon stacking** (more than one coupon per ticket, or per-ticket + whole-bill together). D4.
+- **Usage limits / single-use codes / expiry dates.** Coupons remain reusable rules.
+- **Auto-applying** coupons (e.g. auto-grant FREE 1 HOUR when ≥ 2h). Staff selects manually.
+- **Per-ticket coupons on the manual transaction screen** (non-rental product items). The `rental_item` scope is built generically but only surfaced at rental checkout in v1.
+- **Discounts on purchase (non-rental) items.** Unchanged.
+- **Time-of-day / weekday-weekend coupon conditions.** Only `min_play_minutes` is introduced.
+
+---
+
+## Open Questions
+
+1. **FREE 2 HOUR on a sub-2-hour rental → fully free (D2).** Confirm the cafe wants "2 free hours" to be able to zero out a short rental, rather than capping the free benefit at the played time only (which would also yield 0 here, but differs for "free duration as rupiah-credit" interpretations — already excluded by D1).
+2. **Does STUDENT DISCOUNT apply to the food/drink items in the same checkout, or rentals only?** This PRD scopes it to rental tickets (the requirement says "ticket"). If students should also get % off snacks, that needs the `rental_item` scope generalized to all transaction items — a follow-up.
+3. **Should the seeded coupon codes be exactly `FREE 1 HOUR` / `FREE 2 HOUR` / `STUDENT DISCOUNT`** (with spaces), or slugs (`FREE_1_HOUR`)? Codes are unique and user-facing; confirm the preferred display form.

--- a/docs/prd-rental-coupons.md
+++ b/docs/prd-rental-coupons.md
@@ -126,6 +126,8 @@ For a rental: staff checks out as today → opens the resulting transaction → 
 | D8 | Reusability / limits | Coupons stay reusable rules; no usage limits, single-use codes, or expiry introduced here. Two students in one checkout each attach STUDENT DISCOUNT to their own ticket. | Matches today's coupon semantics. |
 | D9 | Percentage rounding | Reuse `RoundToNearest500` for item-scoped percentage discounts, same as transaction scope today. | Consistency with existing IDR rounding. |
 | D10 | Backward compatibility | `coupons.scope` defaults to `'transaction'`; `transaction_coupons.transaction_item_id` is nullable (null = whole-transaction). OpenAPI changes are additive. | No existing coupon, transaction, or consumer changes. |
+| D11 | STUDENT DISCOUNT eligibility | **Board-game rentals only, staff-enforced.** No system restriction on which line type can take an `item` coupon. | The item-scope mechanism is intentionally generic; limiting STUDENT to rental tickets is a usage rule staff apply, keeping the model simple and reusable for future per-item discounts. |
+| D12 | Coupon code format | **Free text**, unique (existing `UNIQUE(code)`). No slug/normalization rule. | Owner enters human-readable codes directly; no added validation. |
 
 ---
 
@@ -246,9 +248,10 @@ Rental checkout (`POST /rentals/checkout`) is **unchanged**. OpenAPI edits in `l
 
 ## Resolved
 
-- **All-day / capped rentals + FREE 1 HOUR** (was Open Q): the owner confirms this is **staff-controlled** — staff don't apply FREE 1/2 HOUR to all-day or capped rentals, and the 2-hour minimum is enforced by staff judgment. The system stays simple and does not block either case. (See D1, D6.)
+- **All-day / capped rentals + FREE 1 HOUR**: the owner confirms this is **staff-controlled** — staff don't apply FREE 1/2 HOUR to all-day or capped rentals, and the 2-hour minimum is enforced by staff judgment. The system stays simple and does not block either case. (See D1, D6.)
+- **STUDENT DISCOUNT eligibility**: applies to **board-game rentals only**, enforced by **staff judgment** — staff attach it only to a rental ticket, not to food/drink lines. The item-scope mechanism is generic (any line item *could* take it), so no system restriction is added; this is a usage rule, not a constraint. (See D5, D11.)
+- **Coupon codes are free text.** No slug/format rule. Codes remain unique (existing `UNIQUE(code)` constraint) and user-entered as-is (e.g. `FREE 1 HOUR`, `STUDENT DISCOUNT`). (See D12.)
 
 ## Open Questions
 
-1. **STUDENT DISCOUNT on food/drinks in the same transaction.** Scoped to rental tickets here. If students should also get % off snacks, the item-scope generalizes to any line item — confirm whether that's wanted now or later.
-2. **Exact coupon code strings** — `FREE 1 HOUR` / `FREE 2 HOUR` / `STUDENT DISCOUNT` with spaces, or slugs? Codes are unique and user-facing.
+_None outstanding. The PRD is ready to build against._

--- a/docs/prd-rental-coupons.md
+++ b/docs/prd-rental-coupons.md
@@ -51,16 +51,13 @@ The transaction stays the single source of truth for money. No second applicatio
 
 Rental checkout (`apps/api/domain/rental_usecase.go:83-155`) computes each ticket's price from the tier snapshot and creates a plain transaction. **This PRD changes nothing here.** Coupons are added afterward by editing the resulting transaction.
 
-### ⚠️ The blocker for "edit the transaction afterward"
+### ✅ The blocker for "edit the transaction afterward" — RESOLVED on main (#131)
 
-The transaction **update** path recomputes every item's price from the variant:
+The transaction **update** path used to recompute every item's price from the variant (`variants.price = 0` for rentals), so saving a rental transaction zeroed its prices. **This is now fixed on `main` by [#131](../../pull/131)** (`fix: preserve rental item pricing on transaction update`): `UpdateTransactionById` indexes the existing items and, for any item with `RentalId != nil`, **preserves the checkout-calculated `Price`, `Subtotal`, `DiscountAmount`, `RentalId`, and `Note`** instead of re-deriving them, then `continue`s past the variant recompute.
 
-```go
-// transaction_usecase.go:132 (UpdateTransactionById), mirror at :57 (CreateTransaction)
-subTotal := (variant.Price * item.Amount) - item.DiscountAmount
-```
-
-For **rental** items, `variants.price` is **0** (rental price lives on the item, from the tier snapshot). So saving a rental transaction through the current update path **zeroes out the rental prices**. Attaching a coupon requires saving the transaction — so this path must first be made **rental-aware**: items with `RentalId != nil` keep their stored price instead of re-deriving it from the variant. This is FR-2 and a hard prerequisite.
+Two consequences for this feature:
+- **The prerequisite is done.** FR-2 / D7 below are satisfied upstream; this PRD builds on them.
+- **A rental line is now treated as immutable on update.** It copies the stored `Subtotal`/`DiscountAmount` and skips the recompute branch. So to *attach a coupon to a rental ticket*, the item-coupon logic (FR-3) must **extend that rental branch**: compute the discount against the stored full `Price` (the pre-discount base, since at checkout `Subtotal == Price` and `DiscountAmount == 0`) and write the new `DiscountAmount`/`Subtotal` — recomputing from `Price` each save so the discount never compounds across edits.
 
 ---
 
@@ -122,7 +119,7 @@ For a rental: staff checks out as today → opens the resulting transaction → 
 | D4 | Coupons per item | **At most one `item` coupon per line item** in v1 (no stacking). | Keeps math and UI simple; covers all three target coupons. |
 | D5 | Scope enforcement | An `item` coupon can only be attached to a line item; a `transaction` coupon only to the whole bill. The server validates scope on both paths. | Each scope is offered only where it makes sense. |
 | D6 | 2-hour minimum for FREE 1 HOUR | **Staff discretion. Confirmed by the owner.** Not auto-enforced. | After checkout, the transaction item carries duration only as a display note (`"2 hour(s)"`), not structured minutes — there's nothing reliable to gate on. The duration note is shown on the line so staff can judge. Auto-enforcement is a future enhancement (carry played-minutes onto the item). |
-| D7 | Rental-item price preservation | The transaction **create/update** path must keep the stored price of items with `RentalId != nil` instead of recomputing from `variants.price` (which is 0 for rentals). | Hard prerequisite for editing rental transactions; the current path silently zeroes rental prices. (FR-2) |
+| D7 | Rental-item price preservation | **Done on main (#131).** `UpdateTransactionById` preserves the stored `Price`/`Subtotal`/`DiscountAmount`/`RentalId`/`Note` of items with `RentalId != nil` instead of recomputing from `variants.price` (0 for rentals). The item-coupon work (FR-3) extends this same branch. | Was a hard prerequisite for editing rental transactions; the old path silently zeroed rental prices. |
 | D8 | Reusability / limits | Coupons stay reusable rules; no usage limits, single-use codes, or expiry introduced here. Two students in one checkout each attach STUDENT DISCOUNT to their own ticket. | Matches today's coupon semantics. |
 | D9 | Percentage rounding | Reuse `RoundToNearest500` for item-scoped percentage discounts, same as transaction scope today. | Consistency with existing IDR rounding. |
 | D10 | Backward compatibility | `coupons.scope` defaults to `'transaction'`; `transaction_coupons.transaction_item_id` is nullable (null = whole-transaction). OpenAPI changes are additive. | No existing coupon, transaction, or consumer changes. |
@@ -141,15 +138,17 @@ Coupon create/update validation:
 - `scope ∈ {transaction, item}`.
 - `percentage` ⇒ `0 < amount ≤ 100`; `fixed` ⇒ `amount > 0`.
 
-### FR-2: Rental-Safe Transaction Update (Prerequisite)
+### FR-2: Rental-Safe Transaction Update — ✅ DONE (#131)
 
-`CreateTransaction` and `UpdateTransactionById` (`transaction_usecase.go`) must, for any item with `RentalId != nil`, use the item's **stored** price as `base` rather than `variant.Price`. Non-rental items keep today's `base = variant.Price × amount`. A regression test must assert that editing and re-saving a rental transaction leaves its line prices and total unchanged.
+`UpdateTransactionById` (`transaction_usecase.go`) preserves the stored `Price`/`Subtotal`/`DiscountAmount`/`RentalId`/`Note` of any item with `RentalId != nil` instead of re-deriving from `variant.Price`, with a regression test asserting an edit+resave leaves rental line prices and total unchanged. (`CreateTransaction` never receives rental items — rentals enter only via `CheckoutRentals` → `repository.CreateTransaction`, not the create usecase — so no change was needed there.) **No further work; FR-3 builds on this.**
 
 ### FR-3: Item-Scoped Coupon Application
 
 `transaction_coupons` gains a nullable `transaction_item_id`. When a coupon row carries one:
 - The coupon must be `item`-scoped (else 400).
 - Its discount is computed per §3 against that item's `base` and written to `item.DiscountAmount`; `item.Subtotal = base − discount`.
+- **Base derivation:** for a **rental** item (`RentalId != nil`) `base` is the stored full `Price × Amount` (pre-discount; the discount is recomputed from `Price` each save so it never compounds). For a non-rental item `base = variant.Price × Amount`, matching the existing line math.
+- **Integration with #131:** the rental branch of `UpdateTransactionById` currently copies the stored `Subtotal`/`DiscountAmount` and `continue`s. Item-coupon application must hook into that branch so a coupon attached to a rental ticket actually re-prices its `DiscountAmount`/`Subtotal` (and the running `Total`), while a rental ticket with *no* item-coupon stays exactly as #131 leaves it. Item-scope must also be applied in `CreateTransaction`'s coupon loop for new (non-rental) transactions.
 
 Transaction-scope coupons (no `transaction_item_id`) behave exactly as today, subtracting from `Total` after item subtotals are summed.
 

--- a/docs/prd-rental-coupons.md
+++ b/docs/prd-rental-coupons.md
@@ -116,12 +116,12 @@ For a rental: staff checks out as today → opens the resulting transaction → 
 
 | # | Decision | Choice | Rationale |
 |---|---|---|---|
-| D1 | "Free N hours" model | **Fixed rupiah** (15K / 30K), item-scoped, clamped to the ticket price. **Not** duration re-pricing. | The hourly table adds 15K/hour, so a fixed amount is *exact* for standard 2–6h hourly rentals and keeps the model to two coupon types. **Trade-off:** it over-discounts on all-day passes (a flat day rate where a "free hour" is really worth 0) and past the tier cap (where a removed hour saves < 15K). Accepted because FREE 1/2 HOUR are intended for standard hourly rentals; staff simply don't apply them to all-day passes. |
+| D1 | "Free N hours" model | **Fixed rupiah** (15K / 30K), item-scoped, clamped to the ticket price. **Not** duration re-pricing. | The hourly table adds 15K/hour, so a fixed amount is *exact* for standard 2–6h hourly rentals and keeps the model to two coupon types. **Trade-off:** it over-discounts on all-day passes (a flat day rate where a "free hour" is really worth 0) and past the tier cap (where a removed hour saves < 15K). **Confirmed by the owner:** this is a staff-controlled rule — staff do not apply FREE 1/2 HOUR to all-day or capped rentals. The system does not block it. |
 | D2 | Where coupons attach | **On the transaction edit screen, after checkout.** Rental checkout is unchanged. | Reuses the existing coupon UI and the transaction as the single coupon authority. No checkout-endpoint change, no second application path. |
 | D3 | Fixed > item price | **Clamp to the item subtotal** (discount never exceeds base; subtotal floors at 0). | FREE 2 HOUR (30K) on a 1-hour ticket (15K) → ticket is free, not negative. Gives "short rental fully covered" for free. |
 | D4 | Coupons per item | **At most one `item` coupon per line item** in v1 (no stacking). | Keeps math and UI simple; covers all three target coupons. |
 | D5 | Scope enforcement | An `item` coupon can only be attached to a line item; a `transaction` coupon only to the whole bill. The server validates scope on both paths. | Each scope is offered only where it makes sense. |
-| D6 | 2-hour minimum for FREE 1 HOUR | **Staff discretion** in v1. Not auto-enforced. | After checkout, the transaction item carries duration only as a display note (`"2 hour(s)"`), not structured minutes — there's nothing reliable to gate on. The duration note is shown on the line so staff can judge. Auto-enforcement is a future enhancement (carry played-minutes onto the item). |
+| D6 | 2-hour minimum for FREE 1 HOUR | **Staff discretion. Confirmed by the owner.** Not auto-enforced. | After checkout, the transaction item carries duration only as a display note (`"2 hour(s)"`), not structured minutes — there's nothing reliable to gate on. The duration note is shown on the line so staff can judge. Auto-enforcement is a future enhancement (carry played-minutes onto the item). |
 | D7 | Rental-item price preservation | The transaction **create/update** path must keep the stored price of items with `RentalId != nil` instead of recomputing from `variants.price` (which is 0 for rentals). | Hard prerequisite for editing rental transactions; the current path silently zeroes rental prices. (FR-2) |
 | D8 | Reusability / limits | Coupons stay reusable rules; no usage limits, single-use codes, or expiry introduced here. Two students in one checkout each attach STUDENT DISCOUNT to their own ticket. | Matches today's coupon semantics. |
 | D9 | Percentage rounding | Reuse `RoundToNearest500` for item-scoped percentage discounts, same as transaction scope today. | Consistency with existing IDR rounding. |
@@ -244,8 +244,11 @@ Rental checkout (`POST /rentals/checkout`) is **unchanged**. OpenAPI edits in `l
 
 ---
 
+## Resolved
+
+- **All-day / capped rentals + FREE 1 HOUR** (was Open Q): the owner confirms this is **staff-controlled** — staff don't apply FREE 1/2 HOUR to all-day or capped rentals, and the 2-hour minimum is enforced by staff judgment. The system stays simple and does not block either case. (See D1, D6.)
+
 ## Open Questions
 
-1. **All-day / capped rentals + FREE 1 HOUR.** D1 accepts that a fixed 15K over-discounts these. Confirm staff will only apply FREE 1/2 HOUR to standard hourly rentals — if not, we'd need the duration-aware model after all.
-2. **STUDENT DISCOUNT on food/drinks in the same transaction.** Scoped to rental tickets here. If students should also get % off snacks, the item-scope generalizes to any line item — confirm whether that's wanted now or later.
-3. **Exact coupon code strings** — `FREE 1 HOUR` / `FREE 2 HOUR` / `STUDENT DISCOUNT` with spaces, or slugs? Codes are unique and user-facing.
+1. **STUDENT DISCOUNT on food/drinks in the same transaction.** Scoped to rental tickets here. If students should also get % off snacks, the item-scope generalizes to any line item — confirm whether that's wanted now or later.
+2. **Exact coupon code strings** — `FREE 1 HOUR` / `FREE 2 HOUR` / `STUDENT DISCOUNT` with spaces, or slugs? Codes are unique and user-facing.

--- a/docs/prd-rental-coupons.md
+++ b/docs/prd-rental-coupons.md
@@ -1,114 +1,114 @@
-# PRD: Rental Coupons — Time-Aware & Per-Ticket Discounts
+# PRD: Per-Item Coupons — Per-Ticket Discounts on Transactions
 
 ## Problem Statement
 
-The cafe wants to run three new coupons for board-game **rentals**:
+The cafe wants three new discounts for board-game **rentals**:
 
 | Coupon | Rule |
 |---|---|
-| **FREE 1 HOUR** | Customer plays at least **2 hours** → bill **1 hour less**. |
-| **FREE 2 HOUR** | No minimum play time → bill **2 hours less**. |
-| **STUDENT DISCOUNT** | **40% off a single ticket** only. One checkout can contain several tickets; only the student's ticket is discounted, not the whole bill. |
+| **FREE 1 HOUR** | Customer who plays ≥ 2 hours gets one hour's worth (Rp 15,000) off their ticket. |
+| **FREE 2 HOUR** | Two hours' worth (Rp 30,000) off a ticket, no minimum. |
+| **STUDENT DISCOUNT** | **40% off a single ticket** only. One checkout can contain several tickets; only the student's ticket is discounted. |
 
-The current coupon system cannot express any of these:
+The current coupon system can't express these because **a coupon only discounts the whole transaction total**. Applying logic lives in `apps/api/domain/transaction_usecase.go:75-98` / `151-174`:
 
-1. **No play-time context.** Coupons are only applied inside `CreateTransaction` / `UpdateTransactionById` (`apps/api/domain/transaction_usecase.go:75-98`), i.e. the manual transaction-create screen. The **rental checkout** path (`apps/api/domain/rental_usecase.go:83-155`) builds its transaction directly and **never applies any coupon**. Yet rental duration — the thing "FREE 1 HOUR" depends on — only exists at checkout, computed from `checkout_at − checkin_at`. So a time-conditional coupon is impossible today.
+```go
+transaction.Total -= float32(couponDiscountAmount)   // whole-bill only
+```
 
-2. **No per-ticket scope.** A coupon discounts the **whole transaction total** — `transaction.Total -= couponDiscountAmount` (`transaction_usecase.go:90`). A checkout of three rental tickets gets one transaction-wide discount. "40% off **his** ticket only" cannot be modeled when only some of the tickets qualify.
+A checkout of three rental tickets becomes one transaction with three line items (`TransactionItem`s). There is no way to land a discount on **one** of those items. "40% off *his* ticket only," when only some tickets qualify, is impossible.
 
-3. **No "free duration" discount type.** The only types are `fixed` (subtract rupiah) and `percentage` (subtract a % of total) — see `apps/api/domain/coupon_entity.go:7-10`. "Bill one hour less" is neither: in a tiered pricing model the price of an hour is not a fixed number, so it must be expressed as *reduce the billable minutes, then re-price*.
+### Why this is now an *item-scoped coupon* problem (not a checkout problem)
 
-4. **No eligibility rule.** Nothing stores or checks a minimum play time. "FREE 1 HOUR requires ≥ 2 hours" has nowhere to live.
+An earlier draft of this PRD modeled "free hours" as a special `free_duration` coupon applied during rental checkout (re-pricing the ticket at a reduced duration). We are **not** doing that. Two decisions (below) collapse the whole feature into a single, simpler idea:
 
-This PRD extends the coupon model so coupons can be **scoped to a single rental ticket**, **conditioned on play time**, and can express **free duration**, and makes them selectable **at the rental checkout screen** where duration is finally known.
+1. **"Free N hours" is just a fixed-rupiah discount.** The cafe's hourly tier table adds Rp 15,000 per hour, so "1 free hour" = Rp 15,000 off and "2 free hours" = Rp 30,000 off. No duration math, no new coupon type. (See D1 for the edge cases this trades away.)
+2. **Coupons are attached on the transaction, per item.** The student case is *already* a per-item discount; the free-hour cases become per-item `fixed` discounts. So the entire feature is: **let a coupon target one `TransactionItem` instead of the whole transaction.**
+
+The transaction stays the single source of truth for money. No second application path, no rental-specific coupon type, no duration leaking into the coupon layer.
 
 ---
 
 ## Context: Existing System
 
-- **Backend**: Go REST API, MySQL + GORM, Clean Architecture (`domain → data → presentation`). Migrations under `apps/api/migrations/` via `golang-migrate` (next free number is **000012**).
-- **Frontend**: Next.js web (`apps/web/`) + React Native mobile (`apps/mobile/`) sharing a Tamagui UI library (`libs/ui/`). React Query for server state, Zod + React Hook Form for forms.
+- **Backend**: Go REST API, MySQL + GORM, Clean Architecture (`domain → data → presentation`). Migrations under `apps/api/migrations/` (next free number **000012**).
+- **Frontend**: Next.js web (`apps/web/`) + React Native (`apps/mobile/`) sharing a Tamagui UI library (`libs/ui/`). React Query + Zod + React Hook Form.
 - **API contract**: OpenAPI at `libs/api-contract/src/api.yaml`, codegen consumed by both frontends.
 
 ### Coupon domain today
 
-- **Entity** (`apps/api/domain/coupon_entity.go`):
-  ```go
-  type CouponType string
-  const ( Fixed CouponType = "fixed"; Percentage CouponType = "percentage" )
-  type Coupon struct { Id; Code; Type; Amount int64; CreatedAt; DeletedAt }
-  ```
-- **Schema** (`apps/api/migrations/000001_initial_schema.up.sql:65-74`):
-  ```
-  coupons(id, code, type, amount, created_at, deleted_at)   UNIQUE(code)
-  ```
-- **Junction** (same file, `transaction_coupons`): snapshots `(transaction_id, coupon_id, type, amount)` — the coupon's type/amount at apply time, so later coupon edits don't rewrite history.
-- **Application math** (`transaction_usecase.go:82-90`): `fixed` subtracts `amount`; `percentage` subtracts `RoundToNearest500(total * amount / 100)`.
-- **Frontend**: `libs/ui/src/domain/entities/Coupon.ts` (`CouponType = 'fixed' | 'percentage'`), coupon picker `CouponList.tsx` (a bottom sheet) used inside the **transaction** create screen only.
+- **Entity** (`apps/api/domain/coupon_entity.go`): `Coupon { Id, Code, Type CouponType (fixed|percentage), Amount int64, ... }`.
+- **Schema** (`apps/api/migrations/000001_initial_schema.up.sql:65-74`): `coupons(id, code, type, amount, created_at, deleted_at)`, `UNIQUE(code)`.
+- **Junction** (same file): `transaction_coupons(id, transaction_id, coupon_id, type, amount)` — snapshots the coupon's type/amount at apply time so later edits don't rewrite history.
+- **Application math** (`transaction_usecase.go:82-90`): `fixed` subtracts `amount`; `percentage` subtracts `RoundToNearest500(total * amount / 100)`. Both subtract from `transaction.Total`.
+- **Frontend**: `libs/ui/src/domain/entities/Coupon.ts`; a coupon picker bottom-sheet `CouponList.tsx`, used in the transaction create/edit screens.
 
-### Rental domain today
+### Transaction items already support a discount
 
-- **One rental row = one person = one "ticket."** A group of three players is three rental rows (design rule from `trd-board-game-rental-pricing.md`).
-- **Check-in** snapshots the variant's pricing tiers onto `rentals.pricing_tiers` (JSON). Billing reads only the snapshot.
-- **Check-out** (`rental_usecase.go:83-155`): for each `rentalId`, compute `duration = now − checkin_at`, price via `CalculatePrice(snapshot, duration)` (`apps/api/domain/pricing_calculator.go`), and emit **one `TransactionItem`** per rental (`Amount=1`, `Price`, `Subtotal=Price`, `RentalId`, `Note="<duration>"`). The items become one `Transaction`. **No coupon is ever consulted.**
-- **Checkout request** today carries only a list of rental IDs; the transaction is created server-side. The frontend usecase is `libs/ui/src/domain/usecases/rentalCheckout.ts`, screen rendered by `apps/web/src/pages/rentals/checkout.tsx`.
-- **`TransactionItem.DiscountAmount`** already exists (`transaction_entity.go:14`, column `transaction_items.discount_amount`) and already flows into `Subtotal = Price − DiscountAmount` for manual transactions. **Per-ticket discounts have a home in the data model already** — they just aren't produced by the rental flow.
+`TransactionItem.DiscountAmount` exists (`apps/api/domain/transaction_entity.go:14`; column `transaction_items.discount_amount`) and already flows into `Subtotal = (price × amount) − DiscountAmount`. **Per-item discounts have a home in the data model already** — there is just no coupon that targets it.
 
-### The pricing calculator (the lever for "free duration")
+### The rental flow stays untouched
+
+Rental checkout (`apps/api/domain/rental_usecase.go:83-155`) computes each ticket's price from the tier snapshot and creates a plain transaction. **This PRD changes nothing here.** Coupons are added afterward by editing the resulting transaction.
+
+### ⚠️ The blocker for "edit the transaction afterward"
+
+The transaction **update** path recomputes every item's price from the variant:
 
 ```go
-// pricing_calculator.go
-func CalculatePrice(tiers []PricingTier, duration time.Duration) (PricingResult, *Error) {
-    durationMinutes := ceil(duration.Minutes())
-    for _, tier := range tiers { if tier.UpToMinutes >= durationMinutes { return tier.Price } }
-    return tiers[last].Price // cap
-}
+// transaction_usecase.go:132 (UpdateTransactionById), mirror at :57 (CreateTransaction)
+subTotal := (variant.Price * item.Amount) - item.DiscountAmount
 ```
 
-"Bill one hour less" = call this with `duration − 60min`. That is the whole trick, and it reuses the audited calculator unchanged.
+For **rental** items, `variants.price` is **0** (rental price lives on the item, from the tier snapshot). So saving a rental transaction through the current update path **zeroes out the rental prices**. Attaching a coupon requires saving the transaction — so this path must first be made **rental-aware**: items with `RentalId != nil` keep their stored price instead of re-deriving it from the variant. This is FR-2 and a hard prerequisite.
 
 ---
 
 ## Proposed Solution
 
-Add three orthogonal capabilities to coupons, then surface coupon selection on the rental checkout screen.
+One new dimension on coupons, plus a ticket link on the junction, plus a rental-safe update path, plus per-item coupon UI on the transaction edit screen.
 
-### 1. Coupon **scope** — where the discount lands
+### 1. Coupon **scope**
 
-A new `scope` field:
+A new `scope` field on `coupons`:
 
-| Scope | Meaning | Applies to |
-|---|---|---|
-| `transaction` | Whole-bill discount (today's behavior). | Manual transaction create screen, unchanged. |
-| `rental_item` | Discount one rental **ticket** (one `TransactionItem`). | Rental checkout screen. |
+| Scope | Meaning |
+|---|---|
+| `transaction` | Whole-bill discount (today's behavior; the default). |
+| `item` | Discount one `TransactionItem` (one rental ticket). |
 
-`scope` defaults to `transaction`, so every existing coupon keeps behaving exactly as it does now.
+`scope` defaults to `transaction`, so every existing coupon is unchanged.
 
-### 2. A new coupon **type** — `free_duration`
+### 2. The three coupons, in the model
 
-`type` extends from `{fixed, percentage}` to `{fixed, percentage, free_duration}`. For `free_duration`, `amount` is **minutes of free play** (FREE 1 HOUR = `60`, FREE 2 HOUR = `120`). It only makes sense with `scope = rental_item`.
+| Coupon | `type` | `amount` | `scope` |
+|---|---|---:|---|
+| FREE 1 HOUR | `fixed` | 15,000 | `item` |
+| FREE 2 HOUR | `fixed` | 30,000 | `item` |
+| STUDENT DISCOUNT | `percentage` | 40 | `item` |
 
-### 3. Coupon **eligibility** — `min_play_minutes`
+No new `type`. `fixed` and `percentage` are all we need.
 
-A new `min_play_minutes` integer (default `0`). A `rental_item` coupon may be applied to a ticket only if the ticket's **actual** played minutes ≥ `min_play_minutes`. FREE 1 HOUR sets `120`; FREE 2 HOUR and STUDENT DISCOUNT set `0`.
+### 3. Per-item application math
 
-### 4. The three coupons, expressed in the model
+When a coupon is attached to a specific item, its discount is computed against **that item's pre-discount subtotal** (`base = price × amount`) and stored on that item:
 
-| Coupon | `type` | `amount` | `scope` | `min_play_minutes` |
-|---|---|---:|---|---:|
-| FREE 1 HOUR | `free_duration` | 60 | `rental_item` | 120 |
-| FREE 2 HOUR | `free_duration` | 120 | `rental_item` | 0 |
-| STUDENT DISCOUNT | `percentage` | 40 | `rental_item` | 0 |
+```
+fixed:      discount = min(amount, base)                    // never negative
+percentage: discount = RoundToNearest500(base × amount / 100)
 
-### 5. Apply coupons **at checkout**, per ticket
+item.DiscountAmount = discount
+item.Subtotal       = base − discount
+transaction.Total   = Σ item.Subtotal  − (transaction-scope coupon discounts)
+```
 
-`POST /rentals/checkout` is extended so each rental in the request may carry an **optional `couponId`**. At checkout the server, per rental, computes duration, validates the coupon's scope + eligibility against the actual play time, computes the discount, writes it to that ticket's `TransactionItem.DiscountAmount`, and records a `transaction_coupons` row linked to that specific item.
+Because the discount lands on `Subtotal` and `Total` is the sum of subtotals, the existing income/budget math in `PayTransaction` is untouched.
 
-### 6. Checkout screen gets a per-ticket coupon picker
+### 4. Attach coupons on the transaction edit screen
 
-The rental checkout screen lists each ticket with its duration and computed subtotal. Each ticket gets an "Apply coupon" affordance offering only `rental_item` coupons; ineligible coupons (e.g. FREE 1 HOUR on a 40-minute ticket) are disabled with the reason shown. Selecting one updates that ticket's subtotal and the grand total live.
+The transaction edit screen already has a whole-bill coupon picker. It gains a **per-item** coupon picker: each line item can have at most one `item`-scoped coupon attached, showing the resulting discount and new subtotal, with the grand total updating live. The whole-bill picker continues to offer only `transaction`-scoped coupons.
 
-The existing **transaction** create screen and its whole-bill coupon picker are **untouched**.
+For a rental: staff checks out as today → opens the resulting transaction → attaches FREE 1 HOUR / STUDENT DISCOUNT to the relevant ticket(s) → saves.
 
 ---
 
@@ -116,15 +116,16 @@ The existing **transaction** create screen and its whole-bill coupon picker are 
 
 | # | Decision | Choice | Rationale |
 |---|---|---|---|
-| D1 | "Free X hours" semantics | **Reduce billable minutes by `amount`, then re-price through `CalculatePrice`.** Not "subtract the rupiah value of X hours." | In a tiered model the marginal hour has no single price. Reducing duration and re-pricing is the faithful, unambiguous meaning and reuses the audited calculator. Worked examples in FR-3. |
-| D2 | Free duration ≥ actual play time | **Ticket is fully free (subtotal = 0).** Billable minutes clamp at 0. | FREE 2 HOUR on a 1-hour rental = nothing to pay. Note: `CalculatePrice(…, 0)` would otherwise return the smallest tier, so the usecase must short-circuit `billable ≤ 0 → price 0`. |
-| D3 | Discount representation | Store the **rupiah discount** on `TransactionItem.DiscountAmount`; `Subtotal = base price − discount`. Record the coupon link + snapshot in `transaction_coupons` (now with a nullable `transaction_item_id`). | Keeps `transaction.Total` = Σ subtotals, so the existing income/budget math in `PayTransaction` flows unchanged. The free-duration discount is materialized as money at checkout time, when duration is known. |
-| D4 | Coupons per ticket | **At most one coupon per rental ticket** in v1 (no stacking). | Keeps math and UI simple; covers all three target coupons. Stacking is a future PRD. |
-| D5 | Scope enforcement | A `rental_item` coupon **cannot** be selected on the manual transaction screen; a `transaction` coupon cannot be selected per-ticket at checkout. | Each scope is offered only where it makes sense; the server validates scope on both paths. |
-| D6 | Eligibility failure | Server **rejects checkout with 400** if a chosen coupon fails its `min_play_minutes` check; the UI **disables** the coupon up front so this is unreachable through normal use. | Defense in depth — the UI prevents it, the server guarantees it. |
-| D7 | Same coupon on multiple tickets | **Allowed.** Two students in one checkout each apply STUDENT DISCOUNT to their own ticket. | Coupons are reusable rules, not single-use codes, in the current system. No usage-limit concept is introduced here. |
-| D8 | Percentage rounding for tickets | Reuse `RoundToNearest500` for `rental_item` percentage discounts, same as transaction-scope today. | Consistency with existing IDR rounding behavior. |
-| D9 | Backward compatibility | New columns are additive with defaults (`scope='transaction'`, `min_play_minutes=0`); `transaction_coupons.transaction_item_id` is nullable (null = whole-transaction). The OpenAPI changes are additive; the checkout request's `couponId` is optional. | No existing coupon, transaction, or consumer needs changing. |
+| D1 | "Free N hours" model | **Fixed rupiah** (15K / 30K), item-scoped, clamped to the ticket price. **Not** duration re-pricing. | The hourly table adds 15K/hour, so a fixed amount is *exact* for standard 2–6h hourly rentals and keeps the model to two coupon types. **Trade-off:** it over-discounts on all-day passes (a flat day rate where a "free hour" is really worth 0) and past the tier cap (where a removed hour saves < 15K). Accepted because FREE 1/2 HOUR are intended for standard hourly rentals; staff simply don't apply them to all-day passes. |
+| D2 | Where coupons attach | **On the transaction edit screen, after checkout.** Rental checkout is unchanged. | Reuses the existing coupon UI and the transaction as the single coupon authority. No checkout-endpoint change, no second application path. |
+| D3 | Fixed > item price | **Clamp to the item subtotal** (discount never exceeds base; subtotal floors at 0). | FREE 2 HOUR (30K) on a 1-hour ticket (15K) → ticket is free, not negative. Gives "short rental fully covered" for free. |
+| D4 | Coupons per item | **At most one `item` coupon per line item** in v1 (no stacking). | Keeps math and UI simple; covers all three target coupons. |
+| D5 | Scope enforcement | An `item` coupon can only be attached to a line item; a `transaction` coupon only to the whole bill. The server validates scope on both paths. | Each scope is offered only where it makes sense. |
+| D6 | 2-hour minimum for FREE 1 HOUR | **Staff discretion** in v1. Not auto-enforced. | After checkout, the transaction item carries duration only as a display note (`"2 hour(s)"`), not structured minutes — there's nothing reliable to gate on. The duration note is shown on the line so staff can judge. Auto-enforcement is a future enhancement (carry played-minutes onto the item). |
+| D7 | Rental-item price preservation | The transaction **create/update** path must keep the stored price of items with `RentalId != nil` instead of recomputing from `variants.price` (which is 0 for rentals). | Hard prerequisite for editing rental transactions; the current path silently zeroes rental prices. (FR-2) |
+| D8 | Reusability / limits | Coupons stay reusable rules; no usage limits, single-use codes, or expiry introduced here. Two students in one checkout each attach STUDENT DISCOUNT to their own ticket. | Matches today's coupon semantics. |
+| D9 | Percentage rounding | Reuse `RoundToNearest500` for item-scoped percentage discounts, same as transaction scope today. | Consistency with existing IDR rounding. |
+| D10 | Backward compatibility | `coupons.scope` defaults to `'transaction'`; `transaction_coupons.transaction_item_id` is nullable (null = whole-transaction). OpenAPI changes are additive. | No existing coupon, transaction, or consumer changes. |
 
 ---
 
@@ -132,107 +133,58 @@ The existing **transaction** create screen and its whole-bill coupon picker are 
 
 ### FR-1: Extended Coupon Model
 
-`coupons` gains:
-- `scope VARCHAR(50) NOT NULL DEFAULT 'transaction'` — `transaction` | `rental_item`.
-- `min_play_minutes INT NOT NULL DEFAULT 0`.
-- `type` value set extends to include `free_duration` (no DDL change — already `VARCHAR(50)`).
+`coupons` gains `scope VARCHAR(50) NOT NULL DEFAULT 'transaction'` (`transaction` | `item`). Type set is unchanged (`fixed`, `percentage`).
 
-Validation in the coupon create/update usecase:
-- `type = free_duration` ⇒ `scope` must be `rental_item` and `amount > 0` (minutes).
-- `type = percentage` ⇒ `0 < amount ≤ 100`.
-- `type = fixed` ⇒ `amount > 0`.
-- `min_play_minutes ≥ 0`; only meaningful for `rental_item` scope (ignored for `transaction`).
+Coupon create/update validation:
+- `scope ∈ {transaction, item}`.
+- `percentage` ⇒ `0 < amount ≤ 100`; `fixed` ⇒ `amount > 0`.
 
-### FR-2: Seed the Three Coupons
+### FR-2: Rental-Safe Transaction Update (Prerequisite)
 
-A migration seeds exactly these rows (idempotent on `code`):
+`CreateTransaction` and `UpdateTransactionById` (`transaction_usecase.go`) must, for any item with `RentalId != nil`, use the item's **stored** price as `base` rather than `variant.Price`. Non-rental items keep today's `base = variant.Price × amount`. A regression test must assert that editing and re-saving a rental transaction leaves its line prices and total unchanged.
 
-| code | type | amount | scope | min_play_minutes |
-|---|---|---:|---|---:|
-| `FREE 1 HOUR` | `free_duration` | 60 | `rental_item` | 120 |
-| `FREE 2 HOUR` | `free_duration` | 120 | `rental_item` | 0 |
-| `STUDENT DISCOUNT` | `percentage` | 40 | `rental_item` | 0 |
+### FR-3: Item-Scoped Coupon Application
 
-(The owner can later also create/edit these via the admin UI — FR-6.)
+`transaction_coupons` gains a nullable `transaction_item_id`. When a coupon row carries one:
+- The coupon must be `item`-scoped (else 400).
+- Its discount is computed per §3 against that item's `base` and written to `item.DiscountAmount`; `item.Subtotal = base − discount`.
 
-### FR-3: Per-Ticket Discount Calculator (Acceptance Tests)
+Transaction-scope coupons (no `transaction_item_id`) behave exactly as today, subtracting from `Total` after item subtotals are summed.
 
-A pure function computes a ticket's discount from `(snapshotTiers, actualDuration, coupon)`:
+### FR-4: Discount Calculator (Acceptance Tests)
 
-```
-base       = CalculatePrice(tiers, actualDuration).Price
-actualMin  = ceil(actualDuration.minutes)
+A pure function computes one item's discount from `(base, coupon)`:
 
-if coupon == nil:                      discount = 0
-elif coupon.scope != rental_item:      ERROR (wrong scope)
-elif actualMin < coupon.minPlayMinutes: ERROR (not eligible)
-else switch coupon.type:
-  free_duration:
-      billableMin = max(0, actualMin - coupon.amount)
-      discounted  = billableMin <= 0 ? 0 : CalculatePrice(tiers, billableMin*time.Minute).Price
-      discount    = base - discounted
-  percentage:
-      discount    = RoundToNearest500(base * coupon.amount / 100)
-  fixed:
-      discount    = min(coupon.amount, base)     // never negative subtotal
+| # | Coupon | Item base | Discount | Subtotal |
+|---|---|---:|---:|---:|
+| 1 | FREE 1 HOUR (`fixed 15000`) | 30,000 | 15,000 | 15,000 |
+| 2 | FREE 1 HOUR (`fixed 15000`) | 45,000 | 15,000 | 30,000 |
+| 3 | FREE 2 HOUR (`fixed 30000`) | 45,000 | 30,000 | 15,000 |
+| 4 | FREE 2 HOUR (`fixed 30000`) | 15,000 | 15,000 (clamped, D3) | 0 |
+| 5 | STUDENT (`percentage 40`) | 30,000 | 12,500 (`round500(30000×40/100)`) | 17,500 |
+| 6 | STUDENT (`percentage 40`) | 20,000 | 8,000 | 12,000 |
+| 7 | (none) | 30,000 | 0 | 30,000 |
 
-subtotal = base - discount
-```
+### FR-5: Multi-Ticket Behavior
 
-Worked examples against the seeded Hourly tier set (60→15K, 90→20K, 120→30K, 150→35K, 180→45K, …):
-
-| # | Coupon | Played | Base | Billed minutes | Subtotal | Discount |
-|---|---|---|---:|---|---:|---:|
-| 1 | FREE 1 HOUR | 2h 0m (120m) | 30,000 | 60m → 15K | 15,000 | 15,000 |
-| 2 | FREE 1 HOUR | 3h 0m (180m) | 45,000 | 120m → 30K | 30,000 | 15,000 |
-| 3 | FREE 1 HOUR | 1h 30m (90m) | 20,000 | — | — | **rejected** (90 < 120) |
-| 4 | FREE 2 HOUR | 3h 0m (180m) | 45,000 | 60m → 15K | 15,000 | 30,000 |
-| 5 | FREE 2 HOUR | 1h 0m (60m) | 15,000 | 0m → free (D2) | 0 | 15,000 |
-| 6 | STUDENT DISCOUNT | 2h 0m (120m) | 30,000 | n/a | 17,500 | 12,500 (`round500(30000×40/100)`) |
-| 7 | (none) | 2h 0m | 30,000 | n/a | 30,000 | 0 |
-
-### FR-4: Checkout Applies Per-Ticket Coupons
-
-`POST /rentals/checkout` request shape extends from a list of IDs to a list of `{ rentalId, couponId? }`. Per rental the server:
-1. Loads the rental, guards against double-checkout (unchanged).
-2. Computes `duration` and `base` (unchanged).
-3. If `couponId` present: loads the coupon, runs the FR-3 calculator. On scope/eligibility error → **400**, whole checkout rolls back (it already runs in one DB transaction).
-4. Emits the `TransactionItem` with `DiscountAmount = discount`, `Subtotal = base − discount`.
-5. Records a `transaction_coupons` row `{ transaction_id, coupon_id, transaction_item_id, type, amount }` (snapshotting type+amount) for each applied coupon.
-
-`transaction.Total` remains Σ of item subtotals, so `PayTransaction` income/budget math is untouched.
-
-### FR-5: Multi-Ticket Checkout Behavior
-
-A checkout of 3 tickets where ticket B has STUDENT DISCOUNT and tickets A, C have none:
-- A and C: full price.
-- B: 40% off B's subtotal only.
-- Grand total = A + (0.6×B rounded) + C.
-
-This is the requirement's "not all tickets can use STUDENT DISCOUNT" case, working by construction because the discount is per-`TransactionItem`.
+A transaction with three rental tickets where only ticket B has STUDENT DISCOUNT: A and C keep full price; B is 40%-off; `Total = A + round(0.6×B) + C`. Works by construction because the discount is per-`TransactionItem`. This is the requirement's "not all tickets can use STUDENT DISCOUNT" case.
 
 ### FR-6: Coupon Admin UI
 
-The coupon create/edit form (`libs/ui/src/presentation/...` coupon form + `apps/web/src/pages/coupons/...`) gains:
-- A **scope** selector (`transaction` / `rental_item`).
-- The **type** selector gains `free_duration` (shown/relevant only when scope is `rental_item`).
-- A **min play minutes** numeric input (shown only for `rental_item`).
-- Amount field label adapts: "Amount (Rp)" for fixed, "Percent (%)" for percentage, "Free minutes" for free_duration.
-- Zod mirrors the FR-1 validation.
+The coupon create/edit form gains a **scope** selector (`transaction` / `item`). The amount label adapts ("Amount (Rp)" for fixed, "Percent (%)" for percentage). Zod mirrors FR-1. The owner can thereby create FREE 1 HOUR, FREE 2 HOUR, STUDENT DISCOUNT.
 
-### FR-7: Checkout Screen UI
+### FR-7: Transaction Edit Screen — Per-Item Coupon Picker
 
-The rental checkout screen (`apps/web/src/pages/rentals/checkout.tsx` → its `libs/ui` screen) renders, per ticket:
-- Player name • variant • duration • **base price**.
-- An "Apply coupon" control listing only `rental_item` coupons. Coupons failing the ticket's eligibility (actual minutes < `min_play_minutes`) are **disabled** with a hint ("needs ≥ 2h play").
-- On selection: show the discount and the new subtotal for that ticket; update the **grand total** live.
-- Allow clearing the coupon. At most one coupon per ticket (D4).
-
-The submitted checkout payload carries each ticket's optional `couponId`.
+On the transaction create/edit screen:
+- Each line item gains an "Apply coupon" control listing only `item`-scoped coupons.
+- Selecting one shows the discount and the new subtotal for that line; the grand total updates live. At most one item-coupon per line (D4); allow clearing.
+- The existing whole-bill picker is filtered to `transaction`-scoped coupons.
+- For rental items, the duration note (e.g. "2 hour(s)") is shown next to the line so staff can apply the 2-hour-minimum rule by eye (D6).
+- The submitted form carries each line's optional attached `couponId`.
 
 ### FR-8: Mobile Parity
 
-React Native checkout screen (`apps/mobile/`) offers the same per-ticket coupon picker. Coupon **admin** editing may remain web-only for v1 (consistent with how rental pricing tier editing was scoped). Most primitives are shared through `libs/ui`.
+The React Native transaction edit screen offers the same per-item coupon picker, reusing shared `libs/ui` primitives. Coupon **admin** editing may stay web-only for v1.
 
 ---
 
@@ -241,10 +193,8 @@ React Native checkout screen (`apps/mobile/`) offers the same per-ticket coupon 
 ### Altered: `coupons`
 ```sql
 ALTER TABLE coupons
-  ADD COLUMN scope            VARCHAR(50) NOT NULL DEFAULT 'transaction',
-  ADD COLUMN min_play_minutes INT         NOT NULL DEFAULT 0;
+  ADD COLUMN scope VARCHAR(50) NOT NULL DEFAULT 'transaction';
 ```
-`type` stays `VARCHAR(50)` — `free_duration` needs no DDL.
 
 ### Altered: `transaction_coupons`
 ```sql
@@ -257,39 +207,45 @@ ALTER TABLE transaction_coupons
 `null` ⇒ whole-transaction coupon (today's rows). Non-null ⇒ the discounted ticket.
 
 ### Unchanged
-`transaction_items.discount_amount` already exists and is the storage for per-ticket discounts. No change to `transactions`, `rentals`, `pricing_tiers`, or `variants`.
+`transaction_items.discount_amount` already stores per-item discounts. No change to `transactions`, `rentals`, `pricing_tiers`, or `variants`.
 
-### Seed
-The three coupons of FR-2, inserted idempotently keyed on `code`.
+### Seed (FR-2 of the plan)
+```sql
+INSERT INTO coupons (code, type, amount, scope) VALUES
+  ('FREE 1 HOUR',      'fixed',      15000, 'item'),
+  ('FREE 2 HOUR',      'fixed',      30000, 'item'),
+  ('STUDENT DISCOUNT', 'percentage',    40, 'item');
+```
+Idempotent on `code`.
 
 ---
 
-## API Changes
+## API Changes (all additive)
 
 | Method | Path | Change |
 |---|---|---|
-| `POST /coupons`, `PUT /coupons/{id}` | Request/response gain `scope` and `min_play_minutes`; `type` enum gains `free_duration`. Additive. |
-| `GET /coupons`, `GET /coupons/{id}` | Response gains `scope`, `min_play_minutes`. Additive. |
-| `POST /rentals/checkout` | Request changes from `{ rentalIds: number[] }` to `{ rentals: [{ rentalId: number, couponId?: number }] }`. The transaction response gains per-item `discountAmount` (already present in the transaction schema). |
-| `GET /transactions/{id}` | `transaction_coupons` entries gain optional `transactionItemId`. Additive. |
+| `POST /coupons`, `PUT /coupons/{id}` | Request/response gain `scope`. |
+| `GET /coupons`, `GET /coupons/{id}` | Response gains `scope`. |
+| `POST /transactions`, `PUT /transactions/{id}` | Each transaction-coupon entry may carry an optional `transactionItemId`. Rental-item prices are preserved server-side (FR-2). |
+| `GET /transactions/{id}` | `transaction_coupons` entries gain optional `transactionItemId`. |
 
-OpenAPI edits live in `libs/api-contract/src/api.yaml`; codegen regenerates the TS clients. The only **non-additive** change is the checkout request body — coordinated in one phase across backend + contract + both frontends.
+Rental checkout (`POST /rentals/checkout`) is **unchanged**. OpenAPI edits in `libs/api-contract/src/api.yaml`; codegen regenerates TS clients. No breaking changes.
 
 ---
 
 ## Out of Scope
 
-- **Coupon stacking** (more than one coupon per ticket, or per-ticket + whole-bill together). D4.
-- **Usage limits / single-use codes / expiry dates.** Coupons remain reusable rules.
-- **Auto-applying** coupons (e.g. auto-grant FREE 1 HOUR when ≥ 2h). Staff selects manually.
-- **Per-ticket coupons on the manual transaction screen** (non-rental product items). The `rental_item` scope is built generically but only surfaced at rental checkout in v1.
-- **Discounts on purchase (non-rental) items.** Unchanged.
-- **Time-of-day / weekday-weekend coupon conditions.** Only `min_play_minutes` is introduced.
+- **Coupon stacking** (more than one coupon per item, or per-item + whole-bill on the same line). D4.
+- **Duration-accurate free-hour pricing** (re-pricing through the tier table for all-day/capped rentals). Explicitly traded away in D1.
+- **Auto-enforcing the 2-hour minimum.** Staff discretion in v1 (D6); a follow-up could carry structured played-minutes onto items.
+- **Auto-applying coupons** at checkout. Staff attach manually on the transaction.
+- **Usage limits / single-use codes / expiry.** Coupons remain reusable rules.
+- **Discounts on purchase (non-rental) items** beyond what item-scope already allows — the feature is generic but targeted at rental tickets in v1.
 
 ---
 
 ## Open Questions
 
-1. **FREE 2 HOUR on a sub-2-hour rental → fully free (D2).** Confirm the cafe wants "2 free hours" to be able to zero out a short rental, rather than capping the free benefit at the played time only (which would also yield 0 here, but differs for "free duration as rupiah-credit" interpretations — already excluded by D1).
-2. **Does STUDENT DISCOUNT apply to the food/drink items in the same checkout, or rentals only?** This PRD scopes it to rental tickets (the requirement says "ticket"). If students should also get % off snacks, that needs the `rental_item` scope generalized to all transaction items — a follow-up.
-3. **Should the seeded coupon codes be exactly `FREE 1 HOUR` / `FREE 2 HOUR` / `STUDENT DISCOUNT`** (with spaces), or slugs (`FREE_1_HOUR`)? Codes are unique and user-facing; confirm the preferred display form.
+1. **All-day / capped rentals + FREE 1 HOUR.** D1 accepts that a fixed 15K over-discounts these. Confirm staff will only apply FREE 1/2 HOUR to standard hourly rentals — if not, we'd need the duration-aware model after all.
+2. **STUDENT DISCOUNT on food/drinks in the same transaction.** Scoped to rental tickets here. If students should also get % off snacks, the item-scope generalizes to any line item — confirm whether that's wanted now or later.
+3. **Exact coupon code strings** — `FREE 1 HOUR` / `FREE 2 HOUR` / `STUDENT DISCOUNT` with spaces, or slugs? Codes are unique and user-facing.

--- a/docs/prd-rental-coupons.md
+++ b/docs/prd-rental-coupons.md
@@ -10,7 +10,7 @@ The cafe wants three new discounts for board-game **rentals**:
 | **FREE 2 HOUR** | Two hours' worth (Rp 30,000) off a ticket, no minimum. |
 | **STUDENT DISCOUNT** | **40% off a single ticket** only. One checkout can contain several tickets; only the student's ticket is discounted. |
 
-The current coupon system can't express these because **a coupon only discounts the whole transaction total**. Applying logic lives in `apps/api/domain/transaction_usecase.go:75-98` / `151-174`:
+The current coupon system can't express these because **a coupon only discounts the whole transaction total**. Applying logic lives in `apps/api/domain/transaction_usecase.go`:
 
 ```go
 transaction.Total -= float32(couponDiscountAmount)   // whole-bill only
@@ -18,14 +18,18 @@ transaction.Total -= float32(couponDiscountAmount)   // whole-bill only
 
 A checkout of three rental tickets becomes one transaction with three line items (`TransactionItem`s). There is no way to land a discount on **one** of those items. "40% off *his* ticket only," when only some tickets qualify, is impossible.
 
-### Why this is now an *item-scoped coupon* problem (not a checkout problem)
+### The whole feature, in one sentence
 
-An earlier draft of this PRD modeled "free hours" as a special `free_duration` coupon applied during rental checkout (re-pricing the ticket at a reduced duration). We are **not** doing that. Two decisions (below) collapse the whole feature into a single, simpler idea:
+An earlier draft modeled "free hours" as a special `free_duration` coupon applied during rental checkout. We are **not** doing that. Two decisions collapse the feature into one idea:
 
-1. **"Free N hours" is just a fixed-rupiah discount.** The cafe's hourly tier table adds Rp 15,000 per hour, so "1 free hour" = Rp 15,000 off and "2 free hours" = Rp 30,000 off. No duration math, no new coupon type. (See D1 for the edge cases this trades away.)
-2. **Coupons are attached on the transaction, per item.** The student case is *already* a per-item discount; the free-hour cases become per-item `fixed` discounts. So the entire feature is: **let a coupon target one `TransactionItem` instead of the whole transaction.**
+1. **"Free N hours" is just a fixed-rupiah discount.** The hourly tier table adds Rp 15,000 per hour, so "1 free hour" = Rp 15,000 off, "2 free hours" = Rp 30,000 off. No duration math, no new coupon type. (D1 covers the edge cases this trades away.)
+2. **A coupon can be attached to one `TransactionItem`, not just the whole transaction.** The student case is *already* a per-item discount; the free-hour cases become per-item `fixed` discounts.
 
-The transaction stays the single source of truth for money. No second application path, no rental-specific coupon type, no duration leaking into the coupon layer.
+So the entire feature is: **let an existing coupon target one line item instead of the whole bill.** No new coupon attribute, no new coupon type, no second application path. The transaction stays the single source of truth for money.
+
+### Why there is **no coupon "scope"** (a deliberate non-decision)
+
+A coupon is just a `{type, amount}` rule. *Where* it applies — whole bill or one line — is decided when staff **attach** it (by setting `transaction_item_id` or not), not by a property on the coupon. The math is identical either way: `fixed` subtracts its amount; `percentage` subtracts a rounded % of whatever base it lands on (the bill total, or the line subtotal). So the same coupon can legitimately be used either place, and **staff choose the placement.** We considered a `scope` flag to restrict this and rejected it — see D5.
 
 ---
 
@@ -37,10 +41,10 @@ The transaction stays the single source of truth for money. No second applicatio
 
 ### Coupon domain today
 
-- **Entity** (`apps/api/domain/coupon_entity.go`): `Coupon { Id, Code, Type CouponType (fixed|percentage), Amount int64, ... }`.
-- **Schema** (`apps/api/migrations/000001_initial_schema.up.sql:65-74`): `coupons(id, code, type, amount, created_at, deleted_at)`, `UNIQUE(code)`.
-- **Junction** (same file): `transaction_coupons(id, transaction_id, coupon_id, type, amount)` — snapshots the coupon's type/amount at apply time so later edits don't rewrite history.
-- **Application math** (`transaction_usecase.go:82-90`): `fixed` subtracts `amount`; `percentage` subtracts `RoundToNearest500(total * amount / 100)`. Both subtract from `transaction.Total`.
+- **Entity** (`apps/api/domain/coupon_entity.go`): `Coupon { Id, Code, Type CouponType (fixed|percentage), Amount int64, ... }`. **This entity does not change.**
+- **Schema** (`apps/api/migrations/000001_initial_schema.up.sql:65-74`): `coupons(id, code, type, amount, created_at, deleted_at)`, `UNIQUE(code)`. **Unchanged.**
+- **Junction** (same file): `transaction_coupons(id, transaction_id, coupon_id, type, amount)` — snapshots the coupon's type/amount at apply time so later edits don't rewrite history. **Gains one nullable column** (`transaction_item_id`).
+- **Application math** (`transaction_usecase.go`): `fixed` subtracts `amount`; `percentage` subtracts `RoundToNearest500(total * amount / 100)`. Both subtract from `transaction.Total`.
 - **Frontend**: `libs/ui/src/domain/entities/Coupon.ts`; a coupon picker bottom-sheet `CouponList.tsx`, used in the transaction create/edit screens.
 
 ### Transaction items already support a discount
@@ -63,47 +67,40 @@ Two consequences for this feature:
 
 ## Proposed Solution
 
-One new dimension on coupons, plus a ticket link on the junction, plus a rental-safe update path, plus per-item coupon UI on the transaction edit screen.
+Three pieces, no coupon-model change:
 
-### 1. Coupon **scope**
+1. **Link** — `transaction_coupons` gains a nullable `transaction_item_id`. Null = whole-bill coupon (today's behavior). Non-null = the line item the coupon discounts.
+2. **Apply** — when a coupon row carries a `transaction_item_id`, its discount is computed against that line's base and folded into the line's `DiscountAmount`/`Subtotal`. Otherwise it subtracts from `Total` as today.
+3. **UI** — the transaction edit screen gains a per-line "Apply coupon" control alongside the existing whole-bill picker.
 
-A new `scope` field on `coupons`:
+### The three coupons, in the model
 
-| Scope | Meaning |
-|---|---|
-| `transaction` | Whole-bill discount (today's behavior; the default). |
-| `item` | Discount one `TransactionItem` (one rental ticket). |
+| Coupon | `type` | `amount` |
+|---|---|---:|
+| FREE 1 HOUR | `fixed` | 15,000 |
+| FREE 2 HOUR | `fixed` | 30,000 |
+| STUDENT DISCOUNT | `percentage` | 40 |
 
-`scope` defaults to `transaction`, so every existing coupon is unchanged.
+Plain `fixed`/`percentage` coupons — creatable in the existing coupon admin with **no UI change**. They become "per-item" only by how staff attach them.
 
-### 2. The three coupons, in the model
+### Application math
 
-| Coupon | `type` | `amount` | `scope` |
-|---|---|---:|---|
-| FREE 1 HOUR | `fixed` | 15,000 | `item` |
-| FREE 2 HOUR | `fixed` | 30,000 | `item` |
-| STUDENT DISCOUNT | `percentage` | 40 | `item` |
-
-No new `type`. `fixed` and `percentage` are all we need.
-
-### 3. Per-item application math
-
-When a coupon is attached to a specific item, its discount is computed against **that item's pre-discount subtotal** (`base = price × amount`) and stored on that item:
+When a coupon is attached to a line item, its discount is computed against **that line's pre-discount subtotal** (`base = price × amount`) and stored on the line:
 
 ```
-fixed:      discount = min(amount, base)                    // never negative
+fixed:      discount = min(amount, base)                    // clamp, never negative (D3)
 percentage: discount = RoundToNearest500(base × amount / 100)
 
 item.DiscountAmount = discount
 item.Subtotal       = base − discount
-transaction.Total   = Σ item.Subtotal  − (transaction-scope coupon discounts)
+transaction.Total   = Σ item.Subtotal  − (whole-bill coupon discounts)
 ```
 
-Because the discount lands on `Subtotal` and `Total` is the sum of subtotals, the existing income/budget math in `PayTransaction` is untouched.
+The same `fixed`/`percentage` formula already runs for whole-bill coupons against `Total`; the only new thing is running it against a line base. A single shared helper `ApplyCouponToBase(base, coupon)` should serve both paths (and applying the clamp to the bill path too is a small bonus fix). Because the discount lands on `Subtotal` and `Total` is the sum of subtotals, the existing income/budget math in `PayTransaction` is untouched.
 
-### 4. Attach coupons on the transaction edit screen
+### Attach coupons on the transaction edit screen
 
-The transaction edit screen already has a whole-bill coupon picker. It gains a **per-item** coupon picker: each line item can have at most one `item`-scoped coupon attached, showing the resulting discount and new subtotal, with the grand total updating live. The whole-bill picker continues to offer only `transaction`-scoped coupons.
+The transaction edit screen already has a whole-bill coupon picker. It gains a **per-line** "Apply coupon" control: each line item can have at most one coupon attached (D4), showing the resulting discount and new subtotal, with the grand total updating live. Both pickers offer **all** coupons — staff pick the right one for the placement (D5).
 
 For a rental: staff checks out as today → opens the resulting transaction → attaches FREE 1 HOUR / STUDENT DISCOUNT to the relevant ticket(s) → saves.
 
@@ -113,50 +110,45 @@ For a rental: staff checks out as today → opens the resulting transaction → 
 
 | # | Decision | Choice | Rationale |
 |---|---|---|---|
-| D1 | "Free N hours" model | **Fixed rupiah** (15K / 30K), item-scoped, clamped to the ticket price. **Not** duration re-pricing. | The hourly table adds 15K/hour, so a fixed amount is *exact* for standard 2–6h hourly rentals and keeps the model to two coupon types. **Trade-off:** it over-discounts on all-day passes (a flat day rate where a "free hour" is really worth 0) and past the tier cap (where a removed hour saves < 15K). **Confirmed by the owner:** this is a staff-controlled rule — staff do not apply FREE 1/2 HOUR to all-day or capped rentals. The system does not block it. |
+| D1 | "Free N hours" model | **Fixed rupiah** (15K / 30K), applied to a line, clamped to the ticket price. **Not** duration re-pricing. | The hourly table adds 15K/hour, so a fixed amount is *exact* for standard 2–6h hourly rentals and keeps the model to two coupon types. **Trade-off:** it over-discounts on all-day passes (flat day rate where a "free hour" is worth 0) and past the tier cap. **Confirmed by the owner:** staff-controlled — staff don't apply FREE 1/2 HOUR to all-day or capped rentals. The system does not block it. |
 | D2 | Where coupons attach | **On the transaction edit screen, after checkout.** Rental checkout is unchanged. | Reuses the existing coupon UI and the transaction as the single coupon authority. No checkout-endpoint change, no second application path. |
-| D3 | Fixed > item price | **Clamp to the item subtotal** (discount never exceeds base; subtotal floors at 0). | FREE 2 HOUR (30K) on a 1-hour ticket (15K) → ticket is free, not negative. Gives "short rental fully covered" for free. |
-| D4 | Coupons per item | **At most one `item` coupon per line item** in v1 (no stacking). | Keeps math and UI simple; covers all three target coupons. |
-| D5 | Scope enforcement | An `item` coupon can only be attached to a line item; a `transaction` coupon only to the whole bill. The server validates scope on both paths. | Each scope is offered only where it makes sense. |
-| D6 | 2-hour minimum for FREE 1 HOUR | **Staff discretion. Confirmed by the owner.** Not auto-enforced. | After checkout, the transaction item carries duration only as a display note (`"2 hour(s)"`), not structured minutes — there's nothing reliable to gate on. The duration note is shown on the line so staff can judge. Auto-enforcement is a future enhancement (carry played-minutes onto the item). |
+| D3 | Fixed > base | **Clamp to the base** the coupon is applied against (discount never exceeds base; subtotal/total floors at 0). | FREE 2 HOUR (30K) on a 1-hour ticket (15K) → ticket is free, not negative. Applies to both line and whole-bill placement. |
+| D4 | Coupons per line | **At most one coupon per line item** in v1 (no stacking). | Keeps math and UI simple; covers all three target coupons. |
+| D5 | **No coupon "scope"** | **Any coupon can be attached either to the whole bill or to a line item; staff choose the placement.** No `scope` flag, no server restriction, no picker filtering. | The math is well-defined for both placements regardless of any flag, so `scope` would be pure guardrail + UI filter. The owner is happy to let staff decide placement (consistent with D6/D11). Removing it deletes a column, a migration, the coupon-admin form change, and a validation rule — with no correctness or data-integrity cost. The only trade-off: the server won't stop a "wrong" placement (e.g. FREE 2 HOUR on the whole bill) — that's now staff judgment. |
+| D6 | 2-hour minimum for FREE 1 HOUR | **Staff discretion. Confirmed by the owner.** Not auto-enforced. | After checkout, the line carries duration only as a display note (`"2 hour(s)"`), not structured minutes — nothing reliable to gate on. The note is shown on the line so staff can judge. Auto-enforcement is a future enhancement. |
 | D7 | Rental-item price preservation | **Done on main (#131).** `UpdateTransactionById` preserves the stored `Price`/`Subtotal`/`DiscountAmount`/`RentalId`/`Note` of items with `RentalId != nil` instead of recomputing from `variants.price` (0 for rentals). The item-coupon work (FR-3) extends this same branch. | Was a hard prerequisite for editing rental transactions; the old path silently zeroed rental prices. |
-| D8 | Reusability / limits | Coupons stay reusable rules; no usage limits, single-use codes, or expiry introduced here. Two students in one checkout each attach STUDENT DISCOUNT to their own ticket. | Matches today's coupon semantics. |
-| D9 | Percentage rounding | Reuse `RoundToNearest500` for item-scoped percentage discounts, same as transaction scope today. | Consistency with existing IDR rounding. |
-| D10 | Backward compatibility | `coupons.scope` defaults to `'transaction'`; `transaction_coupons.transaction_item_id` is nullable (null = whole-transaction). OpenAPI changes are additive. | No existing coupon, transaction, or consumer changes. |
-| D11 | STUDENT DISCOUNT eligibility | **Board-game rentals only, staff-enforced.** No system restriction on which line type can take an `item` coupon. | The item-scope mechanism is intentionally generic; limiting STUDENT to rental tickets is a usage rule staff apply, keeping the model simple and reusable for future per-item discounts. |
+| D8 | Reusability / limits | Coupons stay reusable rules; no usage limits, single-use codes, or expiry. Two students in one checkout each attach STUDENT DISCOUNT to their own ticket. | Matches today's coupon semantics. |
+| D9 | Percentage rounding | Reuse `RoundToNearest500` for line discounts, same as the bill path today. | Consistency with existing IDR rounding. |
+| D10 | Backward compatibility | Coupons table is **unchanged**. `transaction_coupons.transaction_item_id` is nullable (null = whole-transaction, today's rows). OpenAPI changes are additive. | No existing coupon, transaction, or consumer changes. |
+| D11 | STUDENT DISCOUNT eligibility | **Board-game rentals only, staff-enforced.** No system restriction on which line a coupon can target. | The mechanism is generic; limiting STUDENT to rental tickets is a usage rule staff apply, keeping the model simple and reusable for future per-item discounts. |
 | D12 | Coupon code format | **Free text**, unique (existing `UNIQUE(code)`). No slug/normalization rule. | Owner enters human-readable codes directly; no added validation. |
 
 ---
 
 ## Feature Requirements
 
-### FR-1: Extended Coupon Model
+### FR-1: Coupon Model — Unchanged
 
-`coupons` gains `scope VARCHAR(50) NOT NULL DEFAULT 'transaction'` (`transaction` | `item`). Type set is unchanged (`fixed`, `percentage`).
-
-Coupon create/update validation:
-- `scope ∈ {transaction, item}`.
-- `percentage` ⇒ `0 < amount ≤ 100`; `fixed` ⇒ `amount > 0`.
+No change to the `coupons` table, the `Coupon` entity, coupon validation, the coupon admin UI, or the coupon API. FREE 1 HOUR / FREE 2 HOUR / STUDENT DISCOUNT are ordinary `fixed`/`percentage` coupons the current admin already creates. (Existing validation stays: `percentage` ⇒ `0 < amount ≤ 100`; `fixed` ⇒ `amount > 0`.)
 
 ### FR-2: Rental-Safe Transaction Update — ✅ DONE (#131)
 
-`UpdateTransactionById` (`transaction_usecase.go`) preserves the stored `Price`/`Subtotal`/`DiscountAmount`/`RentalId`/`Note` of any item with `RentalId != nil` instead of re-deriving from `variant.Price`, with a regression test asserting an edit+resave leaves rental line prices and total unchanged. (`CreateTransaction` never receives rental items — rentals enter only via `CheckoutRentals` → `repository.CreateTransaction`, not the create usecase — so no change was needed there.) **No further work; FR-3 builds on this.**
+`UpdateTransactionById` preserves the stored `Price`/`Subtotal`/`DiscountAmount`/`RentalId`/`Note` of any item with `RentalId != nil` instead of re-deriving from `variant.Price`, with a regression test asserting an edit+resave leaves rental line prices and total unchanged. (`CreateTransaction` never receives rental items — they enter only via `CheckoutRentals` → `repository.CreateTransaction` — so no change was needed there.) **No further work; FR-3 builds on this.**
 
-### FR-3: Item-Scoped Coupon Application
+### FR-3: Item-Linked Coupon Application
 
 `transaction_coupons` gains a nullable `transaction_item_id`. When a coupon row carries one:
-- The coupon must be `item`-scoped (else 400).
-- Its discount is computed per §3 against that item's `base` and written to `item.DiscountAmount`; `item.Subtotal = base − discount`.
-- **Base derivation:** for a **rental** item (`RentalId != nil`) `base` is the stored full `Price × Amount` (pre-discount; the discount is recomputed from `Price` each save so it never compounds). For a non-rental item `base = variant.Price × Amount`, matching the existing line math.
-- **Integration with #131:** the rental branch of `UpdateTransactionById` currently copies the stored `Subtotal`/`DiscountAmount` and `continue`s. Item-coupon application must hook into that branch so a coupon attached to a rental ticket actually re-prices its `DiscountAmount`/`Subtotal` (and the running `Total`), while a rental ticket with *no* item-coupon stays exactly as #131 leaves it. Item-scope must also be applied in `CreateTransaction`'s coupon loop for new (non-rental) transactions.
+- Its discount is computed (per the application math) against that line's `base` and written to `item.DiscountAmount`; `item.Subtotal = base − discount`. No scope check — any coupon may target any line (D5).
+- **Base derivation:** for a **rental** item (`RentalId != nil`) `base` is the stored full `Price × Amount` (pre-discount; recomputed from `Price` each save so it never compounds). For a non-rental item `base = variant.Price × Amount`, matching the existing line math.
+- **Integration with #131:** the rental branch of `UpdateTransactionById` currently copies the stored `Subtotal`/`DiscountAmount` and `continue`s. Item-coupon application must hook into that branch so a coupon attached to a rental ticket actually re-prices its `DiscountAmount`/`Subtotal` (and the running `Total`), while a rental ticket with *no* attached coupon stays exactly as #131 leaves it. The same item-linked logic also applies in `CreateTransaction`'s coupon loop for new (non-rental) transactions.
 
-Transaction-scope coupons (no `transaction_item_id`) behave exactly as today, subtracting from `Total` after item subtotals are summed.
+Whole-bill coupons (no `transaction_item_id`) behave exactly as today, subtracting from `Total` after item subtotals are summed.
 
 ### FR-4: Discount Calculator (Acceptance Tests)
 
-A pure function computes one item's discount from `(base, coupon)`:
+The shared `ApplyCouponToBase(base, coupon)` helper computes the discount:
 
-| # | Coupon | Item base | Discount | Subtotal |
+| # | Coupon | Base | Discount | Subtotal |
 |---|---|---:|---:|---:|
 | 1 | FREE 1 HOUR (`fixed 15000`) | 30,000 | 15,000 | 15,000 |
 | 2 | FREE 1 HOUR (`fixed 15000`) | 45,000 | 15,000 | 30,000 |
@@ -168,34 +160,24 @@ A pure function computes one item's discount from `(base, coupon)`:
 
 ### FR-5: Multi-Ticket Behavior
 
-A transaction with three rental tickets where only ticket B has STUDENT DISCOUNT: A and C keep full price; B is 40%-off; `Total = A + round(0.6×B) + C`. Works by construction because the discount is per-`TransactionItem`. This is the requirement's "not all tickets can use STUDENT DISCOUNT" case.
+A transaction with three rental tickets where only ticket B has STUDENT DISCOUNT attached: A and C keep full price; B is 40%-off; `Total = A + round(0.6×B) + C`. Works by construction because the discount is per-`TransactionItem`. This is the requirement's "not all tickets can use STUDENT DISCOUNT" case.
 
-### FR-6: Coupon Admin UI
-
-The coupon create/edit form gains a **scope** selector (`transaction` / `item`). The amount label adapts ("Amount (Rp)" for fixed, "Percent (%)" for percentage). Zod mirrors FR-1. The owner can thereby create FREE 1 HOUR, FREE 2 HOUR, STUDENT DISCOUNT.
-
-### FR-7: Transaction Edit Screen — Per-Item Coupon Picker
+### FR-6: Transaction Edit Screen — Per-Line Coupon Picker
 
 On the transaction create/edit screen:
-- Each line item gains an "Apply coupon" control listing only `item`-scoped coupons.
-- Selecting one shows the discount and the new subtotal for that line; the grand total updates live. At most one item-coupon per line (D4); allow clearing.
-- The existing whole-bill picker is filtered to `transaction`-scoped coupons.
+- Each line item gains an "Apply coupon" control listing **all** coupons (no filtering — D5).
+- Selecting one shows the discount and the new subtotal for that line; the grand total updates live. At most one coupon per line (D4); allow clearing.
+- The existing whole-bill picker is unchanged and continues to offer all coupons.
 - For rental items, the duration note (e.g. "2 hour(s)") is shown next to the line so staff can apply the 2-hour-minimum rule by eye (D6).
-- The submitted form carries each line's optional attached `couponId`.
+- The submitted form carries each line's optional attached `couponId`, mapped to `transactionCoupons[].transactionItemId` on save.
 
-### FR-8: Mobile Parity
+### FR-7: Mobile Parity
 
-The React Native transaction edit screen offers the same per-item coupon picker, reusing shared `libs/ui` primitives. Coupon **admin** editing may stay web-only for v1.
+The React Native transaction edit screen offers the same per-line coupon picker, reusing shared `libs/ui` primitives.
 
 ---
 
 ## Data Model Changes
-
-### Altered: `coupons`
-```sql
-ALTER TABLE coupons
-  ADD COLUMN scope VARCHAR(50) NOT NULL DEFAULT 'transaction';
-```
 
 ### Altered: `transaction_coupons`
 ```sql
@@ -205,19 +187,19 @@ ALTER TABLE transaction_coupons
   ADD CONSTRAINT fk_tc_transaction_item
       FOREIGN KEY (transaction_item_id) REFERENCES transaction_items(id);
 ```
-`null` ⇒ whole-transaction coupon (today's rows). Non-null ⇒ the discounted ticket.
+`null` ⇒ whole-transaction coupon (today's rows). Non-null ⇒ the discounted line item.
 
 ### Unchanged
-`transaction_items.discount_amount` already stores per-item discounts. No change to `transactions`, `rentals`, `pricing_tiers`, or `variants`.
+`coupons` and `transaction_items` are untouched (the latter already stores per-item discounts). No change to `transactions`, `rentals`, `pricing_tiers`, or `variants`.
 
-### Seed (FR-2 of the plan)
+### Seed
 ```sql
-INSERT INTO coupons (code, type, amount, scope) VALUES
-  ('FREE 1 HOUR',      'fixed',      15000, 'item'),
-  ('FREE 2 HOUR',      'fixed',      30000, 'item'),
-  ('STUDENT DISCOUNT', 'percentage',    40, 'item');
+INSERT INTO coupons (code, type, amount) VALUES
+  ('FREE 1 HOUR',      'fixed',      15000),
+  ('FREE 2 HOUR',      'fixed',      30000),
+  ('STUDENT DISCOUNT', 'percentage',    40);
 ```
-Idempotent on `code`.
+Idempotent on `code`. (Could equally be created by the owner in the existing admin UI; seeding just guarantees they exist.)
 
 ---
 
@@ -225,31 +207,30 @@ Idempotent on `code`.
 
 | Method | Path | Change |
 |---|---|---|
-| `POST /coupons`, `PUT /coupons/{id}` | Request/response gain `scope`. |
-| `GET /coupons`, `GET /coupons/{id}` | Response gains `scope`. |
 | `POST /transactions`, `PUT /transactions/{id}` | Each transaction-coupon entry may carry an optional `transactionItemId`. Rental-item prices are preserved server-side (FR-2). |
 | `GET /transactions/{id}` | `transaction_coupons` entries gain optional `transactionItemId`. |
 
-Rental checkout (`POST /rentals/checkout`) is **unchanged**. OpenAPI edits in `libs/api-contract/src/api.yaml`; codegen regenerates TS clients. No breaking changes.
+**Coupon endpoints are unchanged.** Rental checkout (`POST /rentals/checkout`) is unchanged. OpenAPI edits in `libs/api-contract/src/api.yaml`; codegen regenerates TS clients. No breaking changes.
 
 ---
 
 ## Out of Scope
 
-- **Coupon stacking** (more than one coupon per item, or per-item + whole-bill on the same line). D4.
-- **Duration-accurate free-hour pricing** (re-pricing through the tier table for all-day/capped rentals). Explicitly traded away in D1.
+- **Coupon stacking** (more than one coupon per line, or per-line + whole-bill on the same line). D4.
+- **Coupon "scope" / placement restrictions.** Deliberately rejected — D5.
+- **Duration-accurate free-hour pricing** (re-pricing through the tier table for all-day/capped rentals). Traded away in D1.
 - **Auto-enforcing the 2-hour minimum.** Staff discretion in v1 (D6); a follow-up could carry structured played-minutes onto items.
 - **Auto-applying coupons** at checkout. Staff attach manually on the transaction.
 - **Usage limits / single-use codes / expiry.** Coupons remain reusable rules.
-- **Discounts on purchase (non-rental) items** beyond what item-scope already allows — the feature is generic but targeted at rental tickets in v1.
 
 ---
 
 ## Resolved
 
-- **All-day / capped rentals + FREE 1 HOUR**: the owner confirms this is **staff-controlled** — staff don't apply FREE 1/2 HOUR to all-day or capped rentals, and the 2-hour minimum is enforced by staff judgment. The system stays simple and does not block either case. (See D1, D6.)
-- **STUDENT DISCOUNT eligibility**: applies to **board-game rentals only**, enforced by **staff judgment** — staff attach it only to a rental ticket, not to food/drink lines. The item-scope mechanism is generic (any line item *could* take it), so no system restriction is added; this is a usage rule, not a constraint. (See D5, D11.)
-- **Coupon codes are free text.** No slug/format rule. Codes remain unique (existing `UNIQUE(code)` constraint) and user-entered as-is (e.g. `FREE 1 HOUR`, `STUDENT DISCOUNT`). (See D12.)
+- **All-day / capped rentals + FREE 1 HOUR**: staff-controlled — staff don't apply FREE 1/2 HOUR to all-day or capped rentals; the 2-hour minimum is staff judgment. (D1, D6.)
+- **STUDENT DISCOUNT eligibility**: board-game rentals only, by staff judgment — no system restriction. (D11.)
+- **Coupon "scope"**: dropped. Any coupon applies at either level; staff choose placement. (D5.)
+- **Coupon codes**: free text, unique. (D12.)
 
 ## Open Questions
 


### PR DESCRIPTION
## Summary

Add comprehensive product requirements document (PRD) and implementation plan for rental coupon feature, enabling time-aware, per-ticket discounts at rental checkout.

## Changes

- **`docs/prd-rental-coupons.md`** (295 lines): Complete PRD defining the rental coupon feature
  - Problem statement: current coupon system cannot express play-time conditions, per-ticket scope, or free-duration discounts
  - Proposed solution: extend coupon model with `scope` (transaction/rental_item), new `free_duration` type, and `min_play_minutes` eligibility gate
  - Three target coupons: FREE 1 HOUR (60 min free, ≥2h minimum), FREE 2 HOUR (120 min free), STUDENT DISCOUNT (40% off)
  - 9 confirmed product decisions (D1–D9) covering semantics, scope enforcement, eligibility, and backward compatibility
  - 8 feature requirements (FR-1 through FR-8) with acceptance test cases, data model changes, and API contract updates
  - Risk register and open questions

- **`docs/plan-rental-coupons.md`** (306 lines): Detailed 9-phase implementation plan
  - Phase 1: Database schema + seed (migration 000012)
  - Phase 2: Domain layer (coupon entity extension, pure per-ticket discount calculator with exhaustive unit tests)
  - Phase 3: Data layer (GORM models, transformers)
  - Phase 4: Rental checkout usecase + handler (core behavioral change, applies discounts per ticket)
  - Phase 5: API contract + codegen (OpenAPI updates, TS client regeneration)
  - Phase 6: Coupon admin UI (create/edit form for all coupon types)
  - Phase 7: Web checkout screen (per-ticket coupon picker with live totals)
  - Phase 8: Mobile parity (React Native checkout)
  - Phase 9: Documentation + release
  - Each phase is independently shippable; estimated 8 working days total
  - Risk register covering checkout request shape changes, math drift, income/budget regression, scope enforcement, and eligibility validation

## Key Design Principles

- **Discount materialization**: Discounts land on `TransactionItem.DiscountAmount` (already exists), keeping `transaction.Total = Σ subtotals` and preserving existing income/budget math
- **Free-duration semantics**: "Free X hours" = reduce billable minutes by amount, then re-price through existing `CalculatePrice` (reuses audited calculator)
- **Backward compatibility**: All new columns are additive with defaults; existing coupons and transactions remain unchanged
- **Scope enforcement**: `rental_item` coupons only at checkout; `transaction` coupons only on manual transaction screen
- **Per-ticket limit**: At most one coupon per rental ticket in v1 (no stacking)

## Notes

These documents serve as the specification and roadmap for the feature implementation. The PRD is the source of truth for product requirements; the implementation plan breaks the work into 9 reviewable phases with clear exit criteria and dependencies.

https://claude.ai/code/session_01WNMQZ6KhxqxKUaMbwnfJfU