### PR TITLE
Add item-level coupon support to transaction coupons

### DIFF
--- a/apps/api/migrations/000012_item_coupons.down.sql
+++ b/apps/api/migrations/000012_item_coupons.down.sql
@@ -1,0 +1,6 @@
+DELETE FROM coupons WHERE code IN ('FREE 1 HOUR','FREE 2 HOUR','STUDENT DISCOUNT');
+
+ALTER TABLE transaction_coupons
+  DROP FOREIGN KEY fk_tc_transaction_item,
+  DROP KEY idx_tc_transaction_item_id,
+  DROP COLUMN transaction_item_id;

--- a/apps/api/migrations/000012_item_coupons.up.sql
+++ b/apps/api/migrations/000012_item_coupons.up.sql
@@ -1,0 +1,13 @@
+ALTER TABLE transaction_coupons
+  ADD COLUMN transaction_item_id BIGINT NULL,
+  ADD KEY idx_tc_transaction_item_id (transaction_item_id),
+  ADD CONSTRAINT fk_tc_transaction_item
+      FOREIGN KEY (transaction_item_id) REFERENCES transaction_items(id);
+
+INSERT INTO coupons (code, type, amount)
+SELECT * FROM (
+  SELECT 'FREE 1 HOUR'      AS code, 'fixed'      AS type, 15000 AS amount UNION ALL
+  SELECT 'FREE 2 HOUR',           'fixed',            30000 UNION ALL
+  SELECT 'STUDENT DISCOUNT',      'percentage',          40
+) seed
+WHERE NOT EXISTS (SELECT 1 FROM coupons c WHERE c.code = seed.code);


### PR DESCRIPTION
## Summary
This migration adds support for applying coupons at the individual transaction item level, rather than only at the transaction level. It also seeds the database with three new coupon codes for promotional use.

## Key Changes
- **Schema Update**: Added `transaction_item_id` column to `transaction_coupons` table with a foreign key constraint to `transaction_items(id)`, allowing coupons to be linked to specific items within a transaction
- **Index Addition**: Created an index on `transaction_item_id` for efficient querying of item-level coupons
- **Seed Data**: Inserted three new coupon codes:
  - `FREE 1 HOUR`: Fixed amount coupon worth 15,000 units
  - `FREE 2 HOUR`: Fixed amount coupon worth 30,000 units
  - `STUDENT DISCOUNT`: Percentage-based coupon for 40% off
  - Seed operation includes idempotent check to prevent duplicate inserts

## Implementation Details
- The `transaction_item_id` column is nullable, maintaining backward compatibility with existing transaction-level coupons
- Down migration properly cleans up the seeded coupons and removes the schema changes

https://claude.ai/code/session_018o14uShgkp9yM5paUbFqNx