### PR TITLE
Add coupon calculator domain logic with comprehensive tests

### DIFF
--- a/apps/api/domain/coupon_calculator.go
+++ b/apps/api/domain/coupon_calculator.go
@@ -1,0 +1,17 @@
+package domain
+
+import "apps/api/utils"
+
+func ApplyCouponToBase(base float32, coupon Coupon) (float32, *Error) {
+	switch coupon.Type {
+	case Fixed:
+		d := float32(coupon.Amount)
+		if d > base {
+			d = base
+		}
+		return d, nil
+	case Percentage:
+		return float32(utils.RoundToNearest500(int(base) * int(coupon.Amount) / 100)), nil
+	}
+	return 0, &Error{Type: BadRequest, Message: "unsupported coupon type"}
+}

--- a/apps/api/domain/coupon_calculator_test.go
+++ b/apps/api/domain/coupon_calculator_test.go
@@ -1,0 +1,100 @@
+package domain_test
+
+import (
+	"apps/api/domain"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestApplyCouponToBase(t *testing.T) {
+	tests := []struct {
+		name             string
+		base             float32
+		coupon           domain.Coupon
+		expectedDiscount float32
+		expectError      bool
+	}{
+		// FR-4 row 1: FREE 1 HOUR (fixed 15000), base 30000 → discount 15000, subtotal 15000
+		{
+			name:             "row1: FREE 1 HOUR on 30000 base",
+			base:             30000,
+			coupon:           domain.Coupon{Type: domain.Fixed, Amount: 15000},
+			expectedDiscount: 15000,
+		},
+		// FR-4 row 2: FREE 1 HOUR (fixed 15000), base 45000 → discount 15000, subtotal 30000
+		{
+			name:             "row2: FREE 1 HOUR on 45000 base",
+			base:             45000,
+			coupon:           domain.Coupon{Type: domain.Fixed, Amount: 15000},
+			expectedDiscount: 15000,
+		},
+		// FR-4 row 3: FREE 2 HOUR (fixed 30000), base 45000 → discount 30000, subtotal 15000
+		{
+			name:             "row3: FREE 2 HOUR on 45000 base",
+			base:             45000,
+			coupon:           domain.Coupon{Type: domain.Fixed, Amount: 30000},
+			expectedDiscount: 30000,
+		},
+		// FR-4 row 4: FREE 2 HOUR (fixed 30000), base 15000 → clamped to 15000 (D3), subtotal 0
+		{
+			name:             "row4: FREE 2 HOUR on 15000 base, clamped to base",
+			base:             15000,
+			coupon:           domain.Coupon{Type: domain.Fixed, Amount: 30000},
+			expectedDiscount: 15000,
+		},
+		// FR-4 row 5: STUDENT (percentage 40), base 30000 → 30000*40/100 = 12000, subtotal 18000
+		{
+			name:             "row5: STUDENT 40% on 30000 base",
+			base:             30000,
+			coupon:           domain.Coupon{Type: domain.Percentage, Amount: 40},
+			expectedDiscount: 12000,
+		},
+		// FR-4 row 6: STUDENT (percentage 40), base 20000 → 20000*40/100 = 8000, subtotal 12000
+		{
+			name:             "row6: STUDENT 40% on 20000 base",
+			base:             20000,
+			coupon:           domain.Coupon{Type: domain.Percentage, Amount: 40},
+			expectedDiscount: 8000,
+		},
+		// FR-4 row 7: (none) — no coupon applied; ApplyCouponToBase is not called in this path,
+		// the item subtotal equals base unchanged. Verified at the usecase level, not here.
+
+		// fixed exactly equal to base → discount = base, subtotal 0
+		{
+			name:             "fixed exactly equal to base",
+			base:             30000,
+			coupon:           domain.Coupon{Type: domain.Fixed, Amount: 30000},
+			expectedDiscount: 30000,
+		},
+		// percentage rounding boundary: 12250*40/100 = 4900, rounds up to nearest 500 → 5000
+		{
+			name:             "percentage rounding boundary: 4900 rounds up to 5000",
+			base:             12250,
+			coupon:           domain.Coupon{Type: domain.Percentage, Amount: 40},
+			expectedDiscount: 5000,
+		},
+		// unsupported coupon type → error
+		{
+			name:        "unsupported coupon type returns BadRequest error",
+			base:        30000,
+			coupon:      domain.Coupon{Type: "unknown"},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			discount, err := domain.ApplyCouponToBase(tt.base, tt.coupon)
+
+			if tt.expectError {
+				assert.NotNil(t, err)
+				assert.Equal(t, domain.BadRequest, err.Type)
+				assert.Equal(t, float32(0), discount)
+			} else {
+				assert.Nil(t, err)
+				assert.Equal(t, tt.expectedDiscount, discount)
+			}
+		})
+	}
+}

--- a/apps/api/domain/transaction_entity.go
+++ b/apps/api/domain/transaction_entity.go
@@ -27,12 +27,13 @@ type TransactionItemValue struct {
 }
 
 type TransactionCoupon struct {
-	Id            int64
-	TransactionId int64
-	CouponId      int64
-	Coupon        Coupon
-	Type          CouponType
-	Amount        int64
+	Id                  int64
+	TransactionId       int64
+	CouponId            int64
+	Coupon              Coupon
+	Type                CouponType
+	Amount              int64
+	TransactionItemId   *int64
 }
 
 type Transaction struct {


### PR DESCRIPTION
## Summary
This PR introduces coupon calculation logic to the domain layer, enabling the application to apply both fixed and percentage-based discounts to transaction items. It includes a new `ApplyCouponToBase` function with full test coverage and updates the transaction entity to support item-level coupon associations.

## Key Changes
- **New `coupon_calculator.go`**: Implements `ApplyCouponToBase` function that:
  - Handles fixed-amount coupons by applying the discount amount (clamped to base price)
  - Handles percentage-based coupons by calculating the discount and rounding to nearest 500
  - Returns a `BadRequest` error for unsupported coupon types
  
- **New `coupon_calculator_test.go`**: Comprehensive test suite covering:
  - Fixed coupon scenarios (FR-4 rows 1-4): various base amounts with clamping behavior
  - Percentage coupon scenarios (FR-4 rows 5-6): discount calculations with rounding
  - Edge cases: discount equal to base, rounding boundaries
  - Error handling for unsupported coupon types

- **Updated `transaction_entity.go`**: 
  - Added `TransactionItemId` field to `TransactionCoupon` struct to establish the relationship between coupons and specific transaction items

## Implementation Details
- Fixed coupons are clamped to the base price (cannot exceed the item subtotal)
- Percentage discounts use `utils.RoundToNearest500` for consistent rounding behavior
- The function returns `(0, error)` for invalid coupon types, following the domain error pattern
- All test cases are mapped to functional requirements (FR-4) for traceability

https://claude.ai/code/session_01Diirp216RnN2dejdo67npD