### PR TITLE
Implement per-item coupon application for transactions

### DIFF
--- a/apps/api/domain/transaction_usecase.go
+++ b/apps/api/domain/transaction_usecase.go
@@ -1,7 +1,6 @@
 package domain
 
 import (
-	"apps/api/utils"
 	"context"
 	"time"
 )
@@ -58,6 +57,7 @@ func (usecase TransactionUsecase) CreateTransaction(ctx context.Context, transac
 			transaction.Total += subTotal
 
 			transactionItem := TransactionItem{
+				Id:             item.Id,
 				TransactionId:  createdTransaction.Id,
 				VariantId:      item.VariantId,
 				Amount:         item.Amount,
@@ -72,29 +72,9 @@ func (usecase TransactionUsecase) CreateTransaction(ctx context.Context, transac
 			transaction.TransactionItems[index] = transactionItem
 		}
 
-		// Calculate total with coupon
-		for index, transactionCoupon := range transaction.TransactionCoupons {
-			couponItem, err := usecase.couponRepository.GetCouponById(ctxWithTx, transactionCoupon.CouponId)
-			if err != nil {
-				return err
-			}
-
-			couponDiscountAmount := 0
-			switch couponItem.Type {
-			case Fixed:
-				couponDiscountAmount = int(couponItem.Amount)
-			case Percentage:
-				couponDiscountAmount = utils.RoundToNearest500(int(transaction.Total) * int(couponItem.Amount) / 100)
-			}
-
-			transaction.Total -= float32(couponDiscountAmount)
-
-			transaction.TransactionCoupons[index] = TransactionCoupon{
-				CouponId:      transactionCoupon.CouponId,
-				Type:          couponItem.Type,
-				Amount:        couponItem.Amount,
-				TransactionId: createdTransaction.Id,
-			}
+		// Apply whole-bill and item-linked coupons
+		if err := usecase.applyTransactionCoupons(ctxWithTx, &transaction, createdTransaction.Id); err != nil {
+			return err
 		}
 
 		// Create transaction
@@ -176,29 +156,9 @@ func (usecase TransactionUsecase) UpdateTransactionById(ctx context.Context, tra
 			transaction.TransactionItems[index] = transactionItem
 		}
 
-		for index, transactionCoupon := range transaction.TransactionCoupons {
-			couponItem, err := usecase.couponRepository.GetCouponById(ctxWithTx, transactionCoupon.CouponId)
-			if err != nil {
-				return err
-			}
-
-			couponDiscountAmount := 0
-			switch couponItem.Type {
-			case Fixed:
-				couponDiscountAmount = int(couponItem.Amount)
-			case Percentage:
-				couponDiscountAmount = utils.RoundToNearest500(int(transaction.Total) * int(couponItem.Amount) / 100)
-			}
-
-			transaction.Total -= float32(couponDiscountAmount)
-
-			transaction.TransactionCoupons[index] = TransactionCoupon{
-				CouponId:      transactionCoupon.CouponId,
-				Type:          couponItem.Type,
-				Amount:        couponItem.Amount,
-				TransactionId: id,
-				Id:            transactionCoupon.Id,
-			}
+		// Apply whole-bill and item-linked coupons
+		if err := usecase.applyTransactionCoupons(ctxWithTx, &transaction, id); err != nil {
+			return err
 		}
 
 		ut, err := usecase.transactionRepository.UpdateTransactionById(ctxWithTx, transaction, id)
@@ -375,6 +335,84 @@ func (usecase TransactionUsecase) UnpayTransaction(ctx context.Context, id int64
 
 func (usecase TransactionUsecase) GetTransactionStatistics(ctx context.Context, groupBy string) ([]TransactionStatistic, *Error) {
 	return usecase.transactionRepository.GetTransactionStatistics(ctx, groupBy)
+}
+
+// applyTransactionCoupons resolves each TransactionCoupon against the coupon
+// repository and applies its discount via ApplyCouponToBase.
+//
+// A coupon with TransactionItemId set discounts that line: the discount is
+// computed against the line's pre-discount base (Price * Amount, which #131
+// keeps stable across edits for rental items) and written to the item's
+// DiscountAmount/Subtotal, with transaction.Total adjusted by the resulting
+// delta. Item-linked coupons are applied first so that a whole-bill coupon
+// (TransactionItemId == nil) is computed against the item-adjusted Total, per
+// the PRD's Total = Σ item.Subtotal − whole-bill discounts.
+//
+// Every TransactionCoupon is rewritten with a {type, amount, transactionItemId}
+// snapshot of the coupon at apply time.
+func (usecase TransactionUsecase) applyTransactionCoupons(ctx context.Context, transaction *Transaction, transactionId int64) *Error {
+	itemIndexById := map[int64]int{}
+	for index, item := range transaction.TransactionItems {
+		itemIndexById[item.Id] = index
+	}
+
+	usedItemIds := map[int64]bool{}
+	wholeBillCoupons := []Coupon{}
+
+	for index, transactionCoupon := range transaction.TransactionCoupons {
+		coupon, err := usecase.couponRepository.GetCouponById(ctx, transactionCoupon.CouponId)
+		if err != nil {
+			return err
+		}
+
+		if transactionCoupon.TransactionItemId == nil {
+			wholeBillCoupons = append(wholeBillCoupons, coupon)
+		} else {
+			itemId := *transactionCoupon.TransactionItemId
+
+			if usedItemIds[itemId] {
+				return &Error{Type: BadRequest, Message: "only one coupon allowed per transaction item"}
+			}
+			usedItemIds[itemId] = true
+
+			itemIndex, ok := itemIndexById[itemId]
+			if !ok {
+				return &Error{Type: BadRequest, Message: "transaction item not found for coupon"}
+			}
+
+			item := &transaction.TransactionItems[itemIndex]
+			base := item.Price * item.Amount
+
+			discount, err := ApplyCouponToBase(base, coupon)
+			if err != nil {
+				return err
+			}
+
+			newSubtotal := base - discount
+			transaction.Total += newSubtotal - item.Subtotal
+			item.DiscountAmount = discount
+			item.Subtotal = newSubtotal
+		}
+
+		transaction.TransactionCoupons[index] = TransactionCoupon{
+			Id:                transactionCoupon.Id,
+			TransactionId:     transactionId,
+			CouponId:          transactionCoupon.CouponId,
+			Type:              coupon.Type,
+			Amount:            coupon.Amount,
+			TransactionItemId: transactionCoupon.TransactionItemId,
+		}
+	}
+
+	for _, coupon := range wholeBillCoupons {
+		discount, err := ApplyCouponToBase(transaction.Total, coupon)
+		if err != nil {
+			return err
+		}
+		transaction.Total -= discount
+	}
+
+	return nil
 }
 
 // snapshotVariantValues copies the currently selected option / option-value

--- a/apps/api/domain/transaction_usecase_test.go
+++ b/apps/api/domain/transaction_usecase_test.go
@@ -13,6 +13,28 @@ import (
 
 func int64Ptr(v int64) *int64 { return &v }
 
+// setupUpdateTransactionMocks wires the mocks shared by item-coupon update
+// tests: BeginTransaction passthrough, GetTransactionById returning the
+// existing transaction, and UpdateTransactionById echoing back whatever the
+// usecase saved (so callers can assert on the resulting items/coupons/total).
+func setupUpdateTransactionMocks(ctrl *gomock.Controller, id int64, existing domain.Transaction) (*mock.MockTransactionRepository, *mock.MockVariantRepository, *mock.MockCouponRepository, *mock.MockWalletRepository, *mock.MockBudgetRepository) {
+	txRepo := mock.NewMockTransactionRepository(ctrl)
+	variantRepo := mock.NewMockVariantRepository(ctrl)
+	couponRepo := mock.NewMockCouponRepository(ctrl)
+	walletRepo := mock.NewMockWalletRepository(ctrl)
+	budgetRepo := mock.NewMockBudgetRepository(ctrl)
+
+	txRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
+	txRepo.EXPECT().GetTransactionById(gomock.Any(), id).Return(existing, nil)
+	txRepo.EXPECT().UpdateTransactionById(gomock.Any(), gomock.Any(), id).DoAndReturn(
+		func(ctx context.Context, tx domain.Transaction, id int64) (domain.Transaction, *domain.Error) {
+			return tx, nil
+		}).AnyTimes()
+
+	return txRepo, variantRepo, couponRepo, walletRepo, budgetRepo
+}
+
 func TestTransactionUsecase_GetTransactionList(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -486,6 +508,294 @@ func TestTransactionUsecase_UpdateTransactionById(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestTransactionUsecase_UpdateTransactionById_ItemCoupons covers the
+// per-item coupon application (Phase 3 of the rental-coupons plan): a coupon
+// with TransactionItemId set discounts that line's DiscountAmount/Subtotal
+// (recomputed from Price so it never compounds across edits) and adjusts the
+// running Total, while a whole-bill coupon (TransactionItemId == nil)
+// continues to subtract from Total as before.
+func TestTransactionUsecase_UpdateTransactionById_ItemCoupons(t *testing.T) {
+	t.Run("FREE 1 HOUR on a 30K rental item discounts the line (FR-4 #1)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		rentalId := int64(100)
+		txRepo, variantRepo, couponRepo, walletRepo, budgetRepo := setupUpdateTransactionMocks(ctrl, 1, domain.Transaction{
+			Id: 1, PaidAt: nil,
+			TransactionItems: []domain.TransactionItem{
+				{Id: 10, VariantId: 1, Amount: 1, Price: 30000, Subtotal: 30000, RentalId: &rentalId, Note: "2 hour(s)"},
+			},
+		})
+		couponRepo.EXPECT().GetCouponById(gomock.Any(), int64(50)).Return(domain.Coupon{Id: 50, Type: domain.Fixed, Amount: 15000}, nil)
+
+		usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
+		updated, err := usecase.UpdateTransactionById(context.Background(), domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 10, VariantId: 1, Amount: 1, DiscountAmount: 0, Note: "2 hour(s)"},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{
+				{CouponId: 50, TransactionItemId: int64Ptr(10)},
+			},
+		}, 1)
+
+		assert.Nil(t, err)
+		assert.Equal(t, float32(15000), updated.Total)
+		assert.Equal(t, float32(15000), updated.TransactionItems[0].DiscountAmount)
+		assert.Equal(t, float32(15000), updated.TransactionItems[0].Subtotal)
+		assert.Equal(t, &rentalId, updated.TransactionItems[0].RentalId)
+		assert.Equal(t, []domain.TransactionCoupon{
+			{CouponId: 50, Type: domain.Fixed, Amount: 15000, TransactionId: 1, TransactionItemId: int64Ptr(10)},
+		}, updated.TransactionCoupons)
+	})
+
+	t.Run("re-saving the same rental coupon does not compound the discount", func(t *testing.T) {
+		rentalId := int64(101)
+		coupon := domain.Coupon{Id: 50, Type: domain.Fixed, Amount: 15000}
+		input := domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 11, VariantId: 1, Amount: 1, DiscountAmount: 0, Note: "2 hour(s)"},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{
+				{CouponId: 50, TransactionItemId: int64Ptr(11)},
+			},
+		}
+
+		// First save: rental item still carries its checkout-time price/subtotal.
+		ctrl1 := gomock.NewController(t)
+		txRepo1, variantRepo1, couponRepo1, walletRepo1, budgetRepo1 := setupUpdateTransactionMocks(ctrl1, 1, domain.Transaction{
+			Id: 1, PaidAt: nil,
+			TransactionItems: []domain.TransactionItem{
+				{Id: 11, VariantId: 1, Amount: 1, Price: 30000, Subtotal: 30000, RentalId: &rentalId, Note: "2 hour(s)"},
+			},
+		})
+		couponRepo1.EXPECT().GetCouponById(gomock.Any(), int64(50)).Return(coupon, nil)
+		usecase1 := domain.NewTransactionUsecase(txRepo1, variantRepo1, couponRepo1, walletRepo1, budgetRepo1)
+		firstSave, err := usecase1.UpdateTransactionById(context.Background(), input, 1)
+
+		assert.Nil(t, err)
+		assert.Equal(t, float32(15000), firstSave.Total)
+		assert.Equal(t, float32(15000), firstSave.TransactionItems[0].DiscountAmount)
+		assert.Equal(t, float32(15000), firstSave.TransactionItems[0].Subtotal)
+
+		// Second save: the stored item now reflects the first save's discount;
+		// re-deriving the base from the unchanged Price must not compound it.
+		ctrl2 := gomock.NewController(t)
+		txRepo2, variantRepo2, couponRepo2, walletRepo2, budgetRepo2 := setupUpdateTransactionMocks(ctrl2, 1, domain.Transaction{
+			Id: 1, PaidAt: nil,
+			TransactionItems: []domain.TransactionItem{
+				{Id: 11, VariantId: 1, Amount: 1, Price: 30000, Subtotal: 15000, DiscountAmount: 15000, RentalId: &rentalId, Note: "2 hour(s)"},
+			},
+		})
+		couponRepo2.EXPECT().GetCouponById(gomock.Any(), int64(50)).Return(coupon, nil)
+		usecase2 := domain.NewTransactionUsecase(txRepo2, variantRepo2, couponRepo2, walletRepo2, budgetRepo2)
+		secondSave, err := usecase2.UpdateTransactionById(context.Background(), input, 1)
+
+		assert.Nil(t, err)
+		assert.Equal(t, float32(15000), secondSave.Total)
+		assert.Equal(t, float32(15000), secondSave.TransactionItems[0].DiscountAmount)
+		assert.Equal(t, float32(15000), secondSave.TransactionItems[0].Subtotal)
+	})
+
+	t.Run("FREE 2 HOUR on a 15K rental item clamps to the base (FR-4 #4)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		rentalId := int64(102)
+		txRepo, variantRepo, couponRepo, walletRepo, budgetRepo := setupUpdateTransactionMocks(ctrl, 1, domain.Transaction{
+			Id: 1, PaidAt: nil,
+			TransactionItems: []domain.TransactionItem{
+				{Id: 12, VariantId: 1, Amount: 1, Price: 15000, Subtotal: 15000, RentalId: &rentalId, Note: "1 hour(s)"},
+			},
+		})
+		couponRepo.EXPECT().GetCouponById(gomock.Any(), int64(51)).Return(domain.Coupon{Id: 51, Type: domain.Fixed, Amount: 30000}, nil)
+
+		usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
+		updated, err := usecase.UpdateTransactionById(context.Background(), domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 12, VariantId: 1, Amount: 1, DiscountAmount: 0, Note: "1 hour(s)"},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{
+				{CouponId: 51, TransactionItemId: int64Ptr(12)},
+			},
+		}, 1)
+
+		assert.Nil(t, err)
+		assert.Equal(t, float32(0), updated.Total)
+		assert.Equal(t, float32(15000), updated.TransactionItems[0].DiscountAmount)
+		assert.Equal(t, float32(0), updated.TransactionItems[0].Subtotal)
+	})
+
+	t.Run("STUDENT DISCOUNT 40% on a 30K item (FR-4 #5)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txRepo, variantRepo, couponRepo, walletRepo, budgetRepo := setupUpdateTransactionMocks(ctrl, 1, domain.Transaction{Id: 1, PaidAt: nil})
+		variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(2)).Return(domain.Variant{Id: 2, Price: 30000}, nil)
+		couponRepo.EXPECT().GetCouponById(gomock.Any(), int64(52)).Return(domain.Coupon{Id: 52, Type: domain.Percentage, Amount: 40}, nil)
+
+		usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
+		updated, err := usecase.UpdateTransactionById(context.Background(), domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 30, VariantId: 2, Amount: 1, DiscountAmount: 0},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{
+				{CouponId: 52, TransactionItemId: int64Ptr(30)},
+			},
+		}, 1)
+
+		assert.Nil(t, err)
+		// 30000 * 40% = 12000 (already a multiple of 500, see coupon_calculator_test.go row5).
+		assert.Equal(t, float32(18000), updated.Total)
+		assert.Equal(t, float32(12000), updated.TransactionItems[0].DiscountAmount)
+		assert.Equal(t, float32(18000), updated.TransactionItems[0].Subtotal)
+	})
+
+	t.Run("multi-item: STUDENT on the middle ticket only discounts that ticket (FR-5)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txRepo, variantRepo, couponRepo, walletRepo, budgetRepo := setupUpdateTransactionMocks(ctrl, 1, domain.Transaction{Id: 1, PaidAt: nil})
+		variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(1)).Return(domain.Variant{Id: 1, Price: 20000}, nil)
+		variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(2)).Return(domain.Variant{Id: 2, Price: 30000}, nil)
+		variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(3)).Return(domain.Variant{Id: 3, Price: 25000}, nil)
+		couponRepo.EXPECT().GetCouponById(gomock.Any(), int64(52)).Return(domain.Coupon{Id: 52, Type: domain.Percentage, Amount: 40}, nil)
+
+		usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
+		updated, err := usecase.UpdateTransactionById(context.Background(), domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 40, VariantId: 1, Amount: 1, DiscountAmount: 0},
+				{Id: 41, VariantId: 2, Amount: 1, DiscountAmount: 0},
+				{Id: 42, VariantId: 3, Amount: 1, DiscountAmount: 0},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{
+				{CouponId: 52, TransactionItemId: int64Ptr(41)},
+			},
+		}, 1)
+
+		assert.Nil(t, err)
+		assert.Equal(t, float32(63000), updated.Total) // 20000 + 18000 + 25000
+		assert.Equal(t, float32(0), updated.TransactionItems[0].DiscountAmount)
+		assert.Equal(t, float32(20000), updated.TransactionItems[0].Subtotal)
+		assert.Equal(t, float32(12000), updated.TransactionItems[1].DiscountAmount)
+		assert.Equal(t, float32(18000), updated.TransactionItems[1].Subtotal)
+		assert.Equal(t, float32(0), updated.TransactionItems[2].DiscountAmount)
+		assert.Equal(t, float32(25000), updated.TransactionItems[2].Subtotal)
+	})
+
+	t.Run("whole-bill coupon still subtracts from Total", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txRepo, variantRepo, couponRepo, walletRepo, budgetRepo := setupUpdateTransactionMocks(ctrl, 1, domain.Transaction{Id: 1, PaidAt: nil})
+		variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(1)).Return(domain.Variant{Id: 1, Price: 20000}, nil)
+		couponRepo.EXPECT().GetCouponById(gomock.Any(), int64(60)).Return(domain.Coupon{Id: 60, Type: domain.Fixed, Amount: 5000}, nil)
+
+		usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
+		updated, err := usecase.UpdateTransactionById(context.Background(), domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 50, VariantId: 1, Amount: 1, DiscountAmount: 0},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{
+				{CouponId: 60},
+			},
+		}, 1)
+
+		assert.Nil(t, err)
+		assert.Equal(t, float32(15000), updated.Total)
+		assert.Equal(t, []domain.TransactionCoupon{
+			{CouponId: 60, Type: domain.Fixed, Amount: 5000, TransactionId: 1, TransactionItemId: nil},
+		}, updated.TransactionCoupons)
+	})
+
+	t.Run("rejects more than one coupon on the same line (D4)", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txRepo, variantRepo, couponRepo, walletRepo, budgetRepo := setupUpdateTransactionMocks(ctrl, 1, domain.Transaction{Id: 1, PaidAt: nil})
+		variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(1)).Return(domain.Variant{Id: 1, Price: 30000}, nil)
+		couponRepo.EXPECT().GetCouponById(gomock.Any(), int64(50)).Return(domain.Coupon{Id: 50, Type: domain.Fixed, Amount: 15000}, nil)
+		couponRepo.EXPECT().GetCouponById(gomock.Any(), int64(60)).Return(domain.Coupon{Id: 60, Type: domain.Percentage, Amount: 40}, nil)
+
+		usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
+		_, err := usecase.UpdateTransactionById(context.Background(), domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 60, VariantId: 1, Amount: 1, DiscountAmount: 0},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{
+				{CouponId: 50, TransactionItemId: int64Ptr(60)},
+				{CouponId: 60, TransactionItemId: int64Ptr(60)},
+			},
+		}, 1)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, domain.BadRequest, err.Type)
+	})
+
+	t.Run("rejects a coupon targeting an unknown transaction item", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txRepo, variantRepo, couponRepo, walletRepo, budgetRepo := setupUpdateTransactionMocks(ctrl, 1, domain.Transaction{Id: 1, PaidAt: nil})
+		variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(1)).Return(domain.Variant{Id: 1, Price: 30000}, nil)
+		couponRepo.EXPECT().GetCouponById(gomock.Any(), int64(50)).Return(domain.Coupon{Id: 50, Type: domain.Fixed, Amount: 15000}, nil)
+
+		usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
+		_, err := usecase.UpdateTransactionById(context.Background(), domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 70, VariantId: 1, Amount: 1, DiscountAmount: 0},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{
+				{CouponId: 50, TransactionItemId: int64Ptr(999)},
+			},
+		}, 1)
+
+		assert.NotNil(t, err)
+		assert.Equal(t, domain.BadRequest, err.Type)
+	})
+}
+
+// TestTransactionUsecase_CreateTransaction_ItemCoupon covers the same
+// item-linked coupon math on the create path (non-rental, FR-3).
+func TestTransactionUsecase_CreateTransaction_ItemCoupon(t *testing.T) {
+	t.Run("item-linked coupon discounts a single line on a new transaction", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		txRepo := mock.NewMockTransactionRepository(ctrl)
+		variantRepo := mock.NewMockVariantRepository(ctrl)
+		couponRepo := mock.NewMockCouponRepository(ctrl)
+		walletRepo := mock.NewMockWalletRepository(ctrl)
+		budgetRepo := mock.NewMockBudgetRepository(ctrl)
+
+		txRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
+		variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(1)).Return(domain.Variant{Id: 1, Price: 20000}, nil)
+		couponRepo.EXPECT().GetCouponById(gomock.Any(), int64(50)).Return(domain.Coupon{Id: 50, Type: domain.Fixed, Amount: 15000}, nil)
+		txRepo.EXPECT().CreateTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
+			func(ctx context.Context, tx domain.Transaction) (domain.Transaction, *domain.Error) {
+				return tx, nil
+			})
+
+		usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
+		created, err := usecase.CreateTransaction(context.Background(), domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 1, VariantId: 1, Amount: 1, DiscountAmount: 0},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{
+				{CouponId: 50, TransactionItemId: int64Ptr(1)},
+			},
+		})
+
+		assert.Nil(t, err)
+		assert.Equal(t, float32(5000), created.Total)
+		assert.Equal(t, float32(15000), created.TransactionItems[0].DiscountAmount)
+		assert.Equal(t, float32(5000), created.TransactionItems[0].Subtotal)
+		assert.Equal(t, []domain.TransactionCoupon{
+			{CouponId: 50, Type: domain.Fixed, Amount: 15000, TransactionId: 0, TransactionItemId: int64Ptr(1)},
+		}, created.TransactionCoupons)
+	})
 }
 
 func TestTransactionUsecase_GetTransactionStatistics(t *testing.T) {


### PR DESCRIPTION
## Summary
This PR implements Phase 3 of the rental-coupons plan by adding support for per-item coupon application. Coupons can now be linked to specific transaction items via `TransactionItemId`, allowing line-item discounts while maintaining backward compatibility with whole-bill coupons.

## Key Changes

- **New `applyTransactionCoupons` method**: Extracted and refactored coupon application logic into a dedicated method that handles both item-linked and whole-bill coupons. Item-linked coupons are applied first so whole-bill coupons are computed against the item-adjusted total.

- **Item-linked coupon logic**: 
  - Coupons with `TransactionItemId` set now discount that specific line item
  - Discount is computed against the line's pre-discount base (`Price * Amount`), ensuring discounts don't compound across edits
  - Updates the item's `DiscountAmount` and `Subtotal`, with transaction `Total` adjusted by the delta
  - Enforces one coupon per transaction item (validation added)

- **Whole-bill coupon backward compatibility**: Coupons without `TransactionItemId` continue to subtract from the transaction total as before

- **Refactored coupon application**: Both `CreateTransaction` and `UpdateTransactionById` now use the shared `applyTransactionCoupons` method, eliminating code duplication

- **Test coverage**: Added comprehensive test suite (`TestTransactionUsecase_UpdateTransactionById_ItemCoupons` and `TestTransactionUsecase_CreateTransaction_ItemCoupon`) covering:
  - Fixed and percentage-based item discounts
  - Discount clamping to item base
  - Multi-item transactions with selective discounting
  - Discount non-compounding on re-saves
  - Validation of coupon constraints

- **Helper function**: Added `setupUpdateTransactionMocks` to reduce test boilerplate for update transaction tests

## Implementation Details

- Item base is always recomputed from `Price * Amount` to prevent discount compounding when rental items are re-saved
- Coupon snapshots (type, amount, item ID) are stored in `TransactionCoupon` records at apply time
- Validation ensures coupons target valid transaction items and no duplicate coupons per item
- Removed unused import of `utils` package from transaction_usecase.go

https://claude.ai/code/session_01L6haEisTK7B9yjeCYL6rfT