### PR TITLE
Add ticket mapping to rentals during check-in (FR-3)

### DIFF
--- a/apps/api/data/mysql/rental_entity.go
+++ b/apps/api/data/mysql/rental_entity.go
@@ -44,6 +44,8 @@ type Rental struct {
 	PricingTiers PricingTiersJSON
 	CreatedAt    time.Time
 	DeletedAt    *time.Time
+	TicketId     *int64
+	TicketName   *string
 }
 
 // toPricingTierList unmarshals the JSON snapshot into a slice of PricingTier.

--- a/apps/api/data/mysql/rental_transformer.go
+++ b/apps/api/data/mysql/rental_transformer.go
@@ -14,6 +14,8 @@ func ToRentalDB(domainRental domain.Rental) Rental {
 		PricingTiers: pricingTierListToJSON(ToPricingTierListDB(domainRental.PricingTiers)),
 		CreatedAt:    domainRental.CreatedAt,
 		DeletedAt:    domainRental.DeletedAt,
+		TicketId:     domainRental.TicketId,
+		TicketName:   domainRental.TicketName,
 	}
 }
 
@@ -29,6 +31,8 @@ func ToRentalDomain(dbRental Rental) domain.Rental {
 		PricingTiers: ToPricingTierListDomain(dbRental.PricingTiers.toPricingTierList()),
 		CreatedAt:    dbRental.CreatedAt,
 		DeletedAt:    dbRental.DeletedAt,
+		TicketId:     dbRental.TicketId,
+		TicketName:   dbRental.TicketName,
 	}
 }
 

--- a/apps/api/domain/rental_entity.go
+++ b/apps/api/domain/rental_entity.go
@@ -15,6 +15,8 @@ type Rental struct {
 	CreatedAt    time.Time
 	DeletedAt    *time.Time
 	PricingTiers []PricingTier
+	TicketId     *int64
+	TicketName   *string
 }
 
 type CheckoutStatus int

--- a/apps/api/domain/rental_usecase.go
+++ b/apps/api/domain/rental_usecase.go
@@ -11,13 +11,15 @@ type RentalUsecase struct {
 	rentalRepository      RentalRepository
 	variantRepository     VariantRepository
 	transactionRepository TransactionRepository
+	ticketRepository      TicketRepository
 }
 
-func NewRentalUsecase(rentalRepository RentalRepository, variantRepository VariantRepository, transactionRepository TransactionRepository) RentalUsecase {
+func NewRentalUsecase(rentalRepository RentalRepository, variantRepository VariantRepository, transactionRepository TransactionRepository, ticketRepository TicketRepository) RentalUsecase {
 	return RentalUsecase{
 		rentalRepository:      rentalRepository,
 		variantRepository:     variantRepository,
 		transactionRepository: transactionRepository,
+		ticketRepository:      ticketRepository,
 	}
 }
 
@@ -68,6 +70,11 @@ func (usecase RentalUsecase) CheckinRentals(ctx context.Context, rentalRequests 
 			}
 			rentalRequests[index].PricingTiers = variant.PricingTiers
 			rentalRequests[index].CreatedAt = time.Now()
+
+			if ticket, ticketErr := usecase.ticketRepository.GetTicketByCode(ctxWithTx, rentalRequests[index].Code); ticketErr == nil && ticket.Id > 0 {
+				rentalRequests[index].TicketId = &ticket.Id
+				rentalRequests[index].TicketName = &ticket.Name
+			}
 		}
 		cr, err := usecase.rentalRepository.CheckinRentals(ctxWithTx, rentalRequests)
 		if err != nil {

--- a/apps/api/domain/rental_usecase_test.go
+++ b/apps/api/domain/rental_usecase_test.go
@@ -11,6 +11,14 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
+func ptrInt64(v int64) *int64 {
+	return &v
+}
+
+func ptrString(v string) *string {
+	return &v
+}
+
 func TestRentalUsecase_GetRentalList(t *testing.T) {
 	tests := []struct {
 		name          string
@@ -45,9 +53,10 @@ func TestRentalUsecase_GetRentalList(t *testing.T) {
 			rentalRepo := mock.NewMockRentalRepository(ctrl)
 			variantRepo := mock.NewMockVariantRepository(ctrl)
 			txRepo := mock.NewMockTransactionRepository(ctrl)
+			ticketRepo := mock.NewMockTicketRepository(ctrl)
 			tt.setupMock(rentalRepo)
 
-			usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo)
+			usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo, ticketRepo)
 			rentals, _, err := usecase.GetRentalList(context.Background(), "", domain.CreatedAt, domain.Ascending, 0, 10, domain.CheckoutStatusAll)
 
 			if tt.expectedError != nil {
@@ -109,9 +118,10 @@ func TestRentalUsecase_DeleteRentalById(t *testing.T) {
 			rentalRepo := mock.NewMockRentalRepository(ctrl)
 			variantRepo := mock.NewMockVariantRepository(ctrl)
 			txRepo := mock.NewMockTransactionRepository(ctrl)
+			ticketRepo := mock.NewMockTicketRepository(ctrl)
 			tt.setupMock(rentalRepo)
 
-			usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo)
+			usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo, ticketRepo)
 			err := usecase.DeleteRentalById(context.Background(), tt.id)
 
 			if tt.expectedError != nil {
@@ -126,21 +136,25 @@ func TestRentalUsecase_DeleteRentalById(t *testing.T) {
 
 func TestRentalUsecase_CheckinRentals(t *testing.T) {
 	tests := []struct {
-		name              string
-		input             []domain.Rental
-		setupMock         func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository)
-		expectedLen       int
-		expectedTierCount int
-		expectedError     *domain.Error
+		name               string
+		input              []domain.Rental
+		setupMock          func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, ticketRepo *mock.MockTicketRepository)
+		expectedLen        int
+		expectedTierCount  int
+		expectedTicketId   *int64
+		expectedTicketName *string
+		expectedError      *domain.Error
 	}{
 		{
 			name:  "success — tiers snapshot copied from variant",
 			input: []domain.Rental{{Code: "A1", VariantId: 10}},
-			setupMock: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository) {
+			setupMock: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(10)).
 					Return(domain.Variant{Id: 10, PricingTiers: hourlyTiers}, nil)
+				ticketRepo.EXPECT().GetTicketByCode(gomock.Any(), "A1").
+					Return(domain.Ticket{}, &domain.Error{Type: domain.NotFound})
 				rentalRepo.EXPECT().CheckinRentals(gomock.Any(), gomock.Any()).
 					DoAndReturn(func(_ context.Context, rentals []domain.Rental) ([]domain.Rental, *domain.Error) {
 						return rentals, nil
@@ -150,9 +164,29 @@ func TestRentalUsecase_CheckinRentals(t *testing.T) {
 			expectedTierCount: 15,
 		},
 		{
+			name:  "success — registered ticket resolved and snapshotted (FR-3)",
+			input: []domain.Rental{{Code: "0xA3F19C82", VariantId: 10}},
+			setupMock: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, ticketRepo *mock.MockTicketRepository) {
+				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
+					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
+				variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(10)).
+					Return(domain.Variant{Id: 10, PricingTiers: hourlyTiers}, nil)
+				ticketRepo.EXPECT().GetTicketByCode(gomock.Any(), "0xA3F19C82").
+					Return(domain.Ticket{Id: 7, Code: "0xA3F19C82", Name: "Ticket 01"}, nil)
+				rentalRepo.EXPECT().CheckinRentals(gomock.Any(), gomock.Any()).
+					DoAndReturn(func(_ context.Context, rentals []domain.Rental) ([]domain.Rental, *domain.Error) {
+						return rentals, nil
+					})
+			},
+			expectedLen:        1,
+			expectedTierCount:  15,
+			expectedTicketId:   ptrInt64(7),
+			expectedTicketName: ptrString("Ticket 01"),
+		},
+		{
 			name:  "error — rental variant has no pricing tiers",
 			input: []domain.Rental{{Code: "A1", VariantId: 10}},
-			setupMock: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository) {
+			setupMock: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(10)).
@@ -163,7 +197,7 @@ func TestRentalUsecase_CheckinRentals(t *testing.T) {
 		{
 			name:  "error — variant not found",
 			input: []domain.Rental{{Code: "A1", VariantId: 99}},
-			setupMock: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository) {
+			setupMock: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(99)).
@@ -174,11 +208,13 @@ func TestRentalUsecase_CheckinRentals(t *testing.T) {
 		{
 			name:  "error — repository error on insert",
 			input: []domain.Rental{{Code: "A1", VariantId: 10}},
-			setupMock: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository) {
+			setupMock: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(10)).
 					Return(domain.Variant{Id: 10, PricingTiers: hourlyTiers}, nil)
+				ticketRepo.EXPECT().GetTicketByCode(gomock.Any(), "A1").
+					Return(domain.Ticket{}, &domain.Error{Type: domain.NotFound})
 				rentalRepo.EXPECT().CheckinRentals(gomock.Any(), gomock.Any()).
 					Return(nil, &domain.Error{Type: domain.InternalServerError})
 			},
@@ -194,9 +230,10 @@ func TestRentalUsecase_CheckinRentals(t *testing.T) {
 			rentalRepo := mock.NewMockRentalRepository(ctrl)
 			variantRepo := mock.NewMockVariantRepository(ctrl)
 			txRepo := mock.NewMockTransactionRepository(ctrl)
-			tt.setupMock(rentalRepo, variantRepo)
+			ticketRepo := mock.NewMockTicketRepository(ctrl)
+			tt.setupMock(rentalRepo, variantRepo, ticketRepo)
 
-			usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo)
+			usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo, ticketRepo)
 			rentals, err := usecase.CheckinRentals(context.Background(), tt.input)
 
 			if tt.expectedError != nil {
@@ -208,6 +245,8 @@ func TestRentalUsecase_CheckinRentals(t *testing.T) {
 				if tt.expectedTierCount > 0 {
 					assert.Len(t, rentals[0].PricingTiers, tt.expectedTierCount)
 				}
+				assert.Equal(t, tt.expectedTicketId, rentals[0].TicketId)
+				assert.Equal(t, tt.expectedTicketName, rentals[0].TicketName)
 			}
 		})
 	}
@@ -366,9 +405,10 @@ func TestRentalUsecase_CheckoutRentals(t *testing.T) {
 			rentalRepo := mock.NewMockRentalRepository(ctrl)
 			variantRepo := mock.NewMockVariantRepository(ctrl)
 			txRepo := mock.NewMockTransactionRepository(ctrl)
+			ticketRepo := mock.NewMockTicketRepository(ctrl)
 			tt.setupMock(rentalRepo, txRepo, checkinAt)
 
-			usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo)
+			usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo, ticketRepo)
 			tx, err := usecase.CheckoutRentals(context.Background(), tt.rentalIds)
 
 			if tt.expectedError != nil {

--- a/apps/api/main.go
+++ b/apps/api/main.go
@@ -76,7 +76,7 @@ func main() {
 	budgetUsecase := domain.NewBudgetUsecase(budgetRepository)
 	authUsecase := domain.NewAuthUsecase(authRepository)
 	calculationUsecase := domain.NewCalculationUsecase(calculationRepository, walletRepository)
-	rentalUsecase := domain.NewRentalUsecase(rentalRepository, variantRepository, transactionRepository)
+	rentalUsecase := domain.NewRentalUsecase(rentalRepository, variantRepository, transactionRepository, ticketRepository)
 	checklistTemplateUsecase := domain.NewChecklistTemplateUsecase(checklistTemplateRepository)
 	checklistSessionUsecase := domain.NewChecklistSessionUsecase(checklistSessionRepository, checklistTemplateRepository)
 	stockCheckUsecase := domain.NewStockCheckUsecase(stockCheckRepository, materialRepository)

--- a/apps/api/migrations/000014_add_rental_ticket.down.sql
+++ b/apps/api/migrations/000014_add_rental_ticket.down.sql
@@ -1,0 +1,5 @@
+ALTER TABLE `rentals`
+  DROP FOREIGN KEY `fk_rentals_ticket`,
+  DROP KEY `idx_rentals_ticket_id`,
+  DROP COLUMN `ticket_name`,
+  DROP COLUMN `ticket_id`;

--- a/apps/api/migrations/000014_add_rental_ticket.up.sql
+++ b/apps/api/migrations/000014_add_rental_ticket.up.sql
@@ -1,0 +1,6 @@
+ALTER TABLE `rentals`
+  ADD COLUMN `ticket_id`   BIGINT       NULL,
+  ADD COLUMN `ticket_name` VARCHAR(255) NULL,
+  ADD KEY `idx_rentals_ticket_id` (`ticket_id`),
+  ADD CONSTRAINT `fk_rentals_ticket`
+      FOREIGN KEY (`ticket_id`) REFERENCES `tickets` (`id`);

--- a/apps/api/presentation/restapi/rental_handler_test.go
+++ b/apps/api/presentation/restapi/rental_handler_test.go
@@ -16,13 +16,14 @@ import (
 	"go.uber.org/mock/gomock"
 )
 
-func newRentalHandler(t *testing.T, setupMocks func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository)) (restapi.RentalHandler, *gomock.Controller) {
+func newRentalHandler(t *testing.T, setupMocks func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository)) (restapi.RentalHandler, *gomock.Controller) {
 	ctrl := gomock.NewController(t)
 	rentalRepo := mock.NewMockRentalRepository(ctrl)
 	variantRepo := mock.NewMockVariantRepository(ctrl)
 	txRepo := mock.NewMockTransactionRepository(ctrl)
-	setupMocks(rentalRepo, variantRepo, txRepo)
-	usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo)
+	ticketRepo := mock.NewMockTicketRepository(ctrl)
+	setupMocks(rentalRepo, variantRepo, txRepo, ticketRepo)
+	usecase := domain.NewRentalUsecase(rentalRepo, variantRepo, txRepo, ticketRepo)
 	return restapi.NewRentalHandler(usecase), ctrl
 }
 
@@ -30,13 +31,13 @@ func TestRentalHandler_GetRentalList(t *testing.T) {
 	tests := []struct {
 		name           string
 		url            string
-		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository)
+		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository)
 		expectedStatus int
 	}{
 		{
 			name: "success",
 			url:  "/rentals",
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().GetRentalList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]domain.Rental{{Id: 1}}, nil)
 				rentalRepo.EXPECT().GetRentalListTotal(gomock.Any(), gomock.Any(), gomock.Any()).Return(int64(1), nil)
 			},
@@ -45,14 +46,14 @@ func TestRentalHandler_GetRentalList(t *testing.T) {
 		{
 			name: "invalid skip param",
 			url:  "/rentals?skip=abc",
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name: "repo error",
 			url:  "/rentals",
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().GetRentalList(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &domain.Error{Type: domain.InternalServerError, Message: "db error"})
 			},
 			expectedStatus: http.StatusInternalServerError,
@@ -75,13 +76,13 @@ func TestRentalHandler_GetRentalById(t *testing.T) {
 	tests := []struct {
 		name           string
 		rentalId       string
-		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository)
+		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository)
 		expectedStatus int
 	}{
 		{
 			name:     "success",
 			rentalId: "1",
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().GetRentalById(gomock.Any(), int64(1)).Return(domain.Rental{Id: 1, Name: "John"}, nil)
 			},
 			expectedStatus: http.StatusOK,
@@ -89,7 +90,7 @@ func TestRentalHandler_GetRentalById(t *testing.T) {
 		{
 			name:     "not found",
 			rentalId: "99",
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().GetRentalById(gomock.Any(), int64(99)).Return(domain.Rental{}, &domain.Error{Type: domain.NotFound, Message: "not found"})
 			},
 			expectedStatus: http.StatusNotFound,
@@ -97,7 +98,7 @@ func TestRentalHandler_GetRentalById(t *testing.T) {
 		{
 			name:     "invalid id",
 			rentalId: "abc",
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
@@ -121,16 +122,17 @@ func TestRentalHandler_CheckinRentals(t *testing.T) {
 	tests := []struct {
 		name           string
 		body           string
-		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository)
+		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository)
 		expectedStatus int
 	}{
 		{
 			name: "success",
 			body: `[{"code": "R001", "name": "John", "variantId": 1, "checkinAt": "` + checkinAt + `"}]`,
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(1)).Return(domain.Variant{Id: 1, PricingTiers: []domain.PricingTier{{UpToMinutes: 60, Price: 15000}}}, nil)
+				ticketRepo.EXPECT().GetTicketByCode(gomock.Any(), "R001").Return(domain.Ticket{}, &domain.Error{Type: domain.NotFound})
 				rentalRepo.EXPECT().CheckinRentals(gomock.Any(), gomock.Any()).Return([]domain.Rental{{Id: 1, Name: "John"}}, nil)
 			},
 			expectedStatus: http.StatusOK,
@@ -138,17 +140,18 @@ func TestRentalHandler_CheckinRentals(t *testing.T) {
 		{
 			name: "invalid JSON body",
 			body: `{invalid`,
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name: "repo error",
 			body: `[{"code": "R001", "name": "John", "variantId": 1, "checkinAt": "` + checkinAt + `"}]`,
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				variantRepo.EXPECT().GetVariantById(gomock.Any(), int64(1)).Return(domain.Variant{Id: 1, PricingTiers: []domain.PricingTier{{UpToMinutes: 60, Price: 15000}}}, nil)
+				ticketRepo.EXPECT().GetTicketByCode(gomock.Any(), "R001").Return(domain.Ticket{}, &domain.Error{Type: domain.NotFound})
 				rentalRepo.EXPECT().CheckinRentals(gomock.Any(), gomock.Any()).Return(nil, &domain.Error{Type: domain.InternalServerError, Message: "db error"})
 			},
 			expectedStatus: http.StatusInternalServerError,
@@ -172,13 +175,13 @@ func TestRentalHandler_CheckoutRentals(t *testing.T) {
 	tests := []struct {
 		name           string
 		body           string
-		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository)
+		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository)
 		expectedStatus int
 	}{
 		{
 			name: "success",
 			body: `[1]`,
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				rentalRepo.EXPECT().GetRentalById(gomock.Any(), int64(1)).Return(domain.Rental{
@@ -196,14 +199,14 @@ func TestRentalHandler_CheckoutRentals(t *testing.T) {
 		{
 			name: "invalid JSON body",
 			body: `{invalid`,
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name: "rental not found",
 			body: `[99]`,
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				rentalRepo.EXPECT().GetRentalById(gomock.Any(), int64(99)).Return(domain.Rental{}, &domain.Error{Type: domain.NotFound, Message: "not found"})
@@ -229,13 +232,13 @@ func TestRentalHandler_DeleteRentalById(t *testing.T) {
 	tests := []struct {
 		name           string
 		rentalId       string
-		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository)
+		setupMocks     func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository)
 		expectedStatus int
 	}{
 		{
 			name:     "success",
 			rentalId: "1",
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				rentalRepo.EXPECT().GetRentalById(gomock.Any(), int64(1)).Return(domain.Rental{Id: 1, Name: "John"}, nil)
@@ -246,14 +249,14 @@ func TestRentalHandler_DeleteRentalById(t *testing.T) {
 		{
 			name:     "invalid id",
 			rentalId: "abc",
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 			},
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			name:     "not found",
 			rentalId: "99",
-			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository) {
+			setupMocks: func(rentalRepo *mock.MockRentalRepository, variantRepo *mock.MockVariantRepository, txRepo *mock.MockTransactionRepository, ticketRepo *mock.MockTicketRepository) {
 				rentalRepo.EXPECT().BeginTransaction(gomock.Any(), gomock.Any()).DoAndReturn(
 					func(ctx context.Context, cb func(context.Context) *domain.Error) *domain.Error { return cb(ctx) })
 				rentalRepo.EXPECT().GetRentalById(gomock.Any(), int64(99)).Return(domain.Rental{}, &domain.Error{Type: domain.NotFound, Message: "not found"})

--- a/apps/api/presentation/restapi/rental_transformer.go
+++ b/apps/api/presentation/restapi/rental_transformer.go
@@ -75,6 +75,8 @@ func ToApiRental(rental domain.Rental) apiContract.Rental {
 		CreatedAt:    rental.CreatedAt,
 		PricingTiers: apiPricingTiers,
 		Total:        total,
+		TicketId:     rental.TicketId,
+		TicketName:   rental.TicketName,
 	}
 }
 

--- a/libs/api-contract/src/api.yaml
+++ b/libs/api-contract/src/api.yaml
@@ -3454,6 +3454,11 @@ components:
         total:
           type: number
           readOnly: true
+        ticketId:
+          type: integer
+          format: int64
+        ticketName:
+          type: string
     RentalRequest:
       type: object
       required:

--- a/libs/ui/.storybook/mocks/mockData.ts
+++ b/libs/ui/.storybook/mocks/mockData.ts
@@ -464,6 +464,8 @@ export const mockRental: Rental = {
   checkoutAt: null,
   pricingTiers: mockRentalVariant.pricingTiers,
   total: 20000,
+  ticketId: 1,
+  ticketName: 'Ticket 01',
 };
 
 export const mockRentalCheckedOut: Rental = {
@@ -473,6 +475,8 @@ export const mockRentalCheckedOut: Rental = {
   name: 'Jane Smith',
   checkoutAt: '2024-01-21T17:00:00.000Z',
   total: 30000,
+  ticketId: null,
+  ticketName: null,
 };
 
 export const mockRentals: Rental[] = [mockRental, mockRentalCheckedOut];

--- a/libs/ui/src/data/api/rental.transformer.ts
+++ b/libs/ui/src/data/api/rental.transformer.ts
@@ -17,6 +17,8 @@ export function toRental(rental: ApiRental): Rental {
       price,
     })),
     total: rental.total,
+    ticketId: rental.ticketId ?? null,
+    ticketName: rental.ticketName ?? null,
   };
 }
 

--- a/libs/ui/src/data/mock/rental.ts
+++ b/libs/ui/src/data/mock/rental.ts
@@ -35,6 +35,8 @@ const initialRentals: Rental[] = [
     checkinAt: '2024-03-20T08:00:00.000Z',
     checkoutAt: null,
     pricingTiers: [],
+    ticketId: 1,
+    ticketName: 'Ticket 01',
   },
   {
     id: 2,
@@ -45,6 +47,8 @@ const initialRentals: Rental[] = [
     checkinAt: '2024-03-21T08:00:00.000Z',
     checkoutAt: null,
     pricingTiers: [],
+    ticketId: null,
+    ticketName: null,
   },
 ];
 

--- a/libs/ui/src/domain/entities/Rental.ts
+++ b/libs/ui/src/domain/entities/Rental.ts
@@ -10,6 +10,8 @@ export type Rental = {
   checkoutAt: string | null;
   pricingTiers: PricingTier[];
   total?: number;
+  ticketId: number | null;
+  ticketName: string | null;
 };
 
 export type RentalCheckinForm = {

--- a/libs/ui/src/presentation/components/rentals/RentalList.tsx
+++ b/libs/ui/src/presentation/components/rentals/RentalList.tsx
@@ -172,6 +172,7 @@ export const RentalList = ({
                   checkoutAt={item.checkoutAt ?? undefined}
                   variantName={item.variant.name}
                   code={item.code}
+                  ticketName={item.ticketName}
                   name={item.name}
                   total={item.total}
                   onDeleteMenuPress={

--- a/libs/ui/src/presentation/components/rentals/RentalListItem.stories.tsx
+++ b/libs/ui/src/presentation/components/rentals/RentalListItem.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof RentalListItem> = {
   component: RentalListItem,
   args: {
     code: 'RNT-001',
+    ticketName: 'Ticket 01',
     name: 'John Doe',
     variantName: 'Coffee Equipment Set - Standard Package',
     checkinAt: '2024-01-20T08:00:00.000Z',
@@ -25,7 +26,16 @@ export const CheckedOut: Story = {
   args: {
     name: 'Jane Smith',
     code: 'RNT-002',
+    ticketName: 'Ticket 02',
     checkoutAt: '2024-01-21T17:00:00.000Z',
+  },
+};
+
+export const UnmappedCard: Story = {
+  args: {
+    name: 'Jane Smith',
+    code: 'RNT-002',
+    ticketName: null,
   },
 };
 

--- a/libs/ui/src/presentation/components/rentals/RentalListItem.tsx
+++ b/libs/ui/src/presentation/components/rentals/RentalListItem.tsx
@@ -11,6 +11,7 @@ import { XStackProps } from 'tamagui';
 
 export type RentalListItemProps = {
   code: string;
+  ticketName?: string | null;
   name: string;
   variantName: string;
   checkinAt: string;
@@ -22,6 +23,7 @@ export type RentalListItemProps = {
 
 export const RentalListItem = ({
   code,
+  ticketName,
   name,
   variantName,
   checkinAt,
@@ -59,8 +61,8 @@ export const RentalListItem = ({
       footerItems={[
         {
           icon: QrCode,
-          label: 'CODE',
-          value: code,
+          label: 'TICKET',
+          value: ticketName ?? code,
         },
         {
           icon: Calendar,


### PR DESCRIPTION
## Summary
This PR implements ticket mapping functionality for rentals during the check-in process. When a rental is checked in, the system now attempts to resolve the rental code against registered tickets and snapshots the ticket information (ID and name) on the rental record.

## Key Changes

- **Domain Model Updates**: Added `TicketId` and `TicketName` fields to the `Rental` entity to store ticket snapshot data
- **Database Migration**: Created migration to add `ticket_id` and `ticket_name` columns to the `rentals` table with a foreign key constraint to the `tickets` table
- **Check-in Logic**: Modified `RentalUsecase.CheckinRentals()` to query the ticket repository by rental code and populate ticket fields when a matching ticket is found
- **Repository Integration**: Updated `RentalUsecase` constructor to accept `TicketRepository` dependency
- **Data Transformations**: Updated all data transformers (MySQL entity, API contract, REST API, frontend) to handle the new ticket fields
- **UI Updates**: 
  - Modified `RentalListItem` component to display ticket name instead of rental code in the footer
  - Added support for unmapped rentals (null ticket name) that fall back to displaying the rental code
  - Updated Storybook stories and mock data to include ticket information
- **Test Coverage**: Updated all test files to mock the `TicketRepository` and verify ticket resolution behavior, including a new test case for successful ticket mapping

## Implementation Details

- Ticket resolution is non-blocking: if a ticket lookup fails, the rental check-in continues without ticket data
- Ticket information is snapshotted at check-in time, preserving historical accuracy even if ticket details change later
- The UI gracefully handles both mapped (with ticket) and unmapped (without ticket) rentals

https://claude.ai/code/session_01UZJwQ9cqhymuSBbg4pc7CW