### PR TITLE
Add scan resolution hints for rental check-in codes

### DIFF
--- a/libs/ui/src/app/RentalCheckin.tsx
+++ b/libs/ui/src/app/RentalCheckin.tsx
@@ -3,12 +3,14 @@ import {
   ApiVariantRepository,
   ApiRentalRepository,
   ApiProductRepository,
+  ApiTicketRepository,
 } from '../data';
 import {
   AuthLogoutUsecase,
   RentalCheckinUsecase,
   TransactionItemSelectUsecase,
   TransactionItemSelectParams,
+  TicketListUsecase,
 } from '../domain';
 import { RentalCheckinHandler } from '../presentation';
 import { QueryClient } from '@tanstack/react-query';
@@ -24,10 +26,14 @@ export function RentalCheckin({
   const rentalRepository = new ApiRentalRepository(client);
   const variantRepository = new ApiVariantRepository(client);
   const productRepository = new ApiProductRepository(client);
+  const ticketRepository = new ApiTicketRepository(client);
   const authRepository = new ApiAuthRepository();
 
   const authLogoutUsecase = new AuthLogoutUsecase(authRepository);
   const rentalCheckinUsecase = new RentalCheckinUsecase(rentalRepository);
+  const ticketListUsecase = new TicketListUsecase(ticketRepository, {
+    tickets: [],
+  });
 
   const transactionItemSelectUsecase = new TransactionItemSelectUsecase(
     productRepository,
@@ -40,6 +46,7 @@ export function RentalCheckin({
       rentalCheckinUsecase={rentalCheckinUsecase}
       transactionItemSelectUsecase={transactionItemSelectUsecase}
       authLogoutUsecase={authLogoutUsecase}
+      ticketListUsecase={ticketListUsecase}
     />
   );
 }

--- a/libs/ui/src/presentation/components/rentals/RentalCheckinFormView.stories.tsx
+++ b/libs/ui/src/presentation/components/rentals/RentalCheckinFormView.stories.tsx
@@ -5,6 +5,7 @@ import { useForm, useFieldArray } from 'react-hook-form';
 import { Text } from 'tamagui';
 import { RentalCheckinFormView } from './RentalCheckinFormView';
 import type { RentalCheckinForm } from '../../../domain';
+import { mockTickets, mockVariant } from '../../../../.storybook/mocks/mockData';
 
 const defaultValues: RentalCheckinForm = {
   name: '',
@@ -27,6 +28,7 @@ const DefaultStory = () => {
       isSubmitDisabled={false}
       RentalItemSelect={() => <Text color="$color">+ Add Rental Item</Text>}
       rentalsFieldArray={rentalsFieldArray}
+      tickets={mockTickets}
     />
   );
 };
@@ -52,6 +54,37 @@ const PopulatedStory = () => {
       isSubmitDisabled={false}
       RentalItemSelect={() => <Text color="$color">+ Add Rental Item</Text>}
       rentalsFieldArray={rentalsFieldArray}
+      tickets={mockTickets}
+    />
+  );
+};
+
+const ScanResolutionStory = () => {
+  const form = useForm<RentalCheckinForm>({
+    defaultValues: {
+      name: 'John Doe',
+      rentals: [
+        { code: mockTickets[0].code, variant: mockVariant },
+        { code: '0xDEADBEEF', variant: mockVariant },
+        { code: '', variant: mockVariant },
+      ],
+      checkinAt: null,
+    },
+  });
+  const rentalsFieldArray = useFieldArray({
+    control: form.control,
+    name: 'rentals',
+    keyName: 'key',
+  });
+  return (
+    <RentalCheckinFormView
+      form={form}
+      onToggleCustomizeCheckinDateTime={fn()}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      RentalItemSelect={() => <Text color="$color">+ Add Rental Item</Text>}
+      rentalsFieldArray={rentalsFieldArray}
+      tickets={mockTickets}
     />
   );
 };
@@ -70,4 +103,8 @@ export const Default: Story = {
 
 export const Populated: Story = {
   render: () => <PopulatedStory />,
+};
+
+export const ScanResolution: Story = {
+  render: () => <ScanResolutionStory />,
 };

--- a/libs/ui/src/presentation/components/rentals/RentalCheckinFormView.tsx
+++ b/libs/ui/src/presentation/components/rentals/RentalCheckinFormView.tsx
@@ -12,8 +12,8 @@ import {
   YStack,
 } from 'tamagui';
 import { H4 } from 'tamagui';
-import { Check, Trash } from '@tamagui/lucide-icons';
-import { RentalCheckinForm } from '../../../domain';
+import { AlertCircle, Check, CheckCircle, Trash } from '@tamagui/lucide-icons';
+import { RentalCheckinForm, Ticket } from '../../../domain';
 import {
   FormProvider,
   UseFieldArrayReturn,
@@ -30,6 +30,7 @@ export type RentalCheckinFormViewProps = {
   isSubmitting: boolean;
   RentalItemSelect: () => ReactNode;
   rentalsFieldArray: UseFieldArrayReturn<RentalCheckinForm, 'rentals', 'key'>;
+  tickets: Ticket[];
   serverError?: string;
 };
 
@@ -41,6 +42,7 @@ export const RentalCheckinFormView = ({
   isSubmitting,
   RentalItemSelect,
   rentalsFieldArray,
+  tickets,
   serverError,
 }: RentalCheckinFormViewProps) => {
   const inputCodeRefs = useRef<(Input | null)[]>([]);
@@ -230,6 +232,32 @@ export const RentalCheckinFormView = ({
                               }
                             }}
                           />
+                          <FieldWatch
+                            control={form.control}
+                            name={[`rentals.${index}.code`]}
+                          >
+                            {([code]) => {
+                              if (!code) return null;
+                              const ticket = tickets.find(
+                                (ticket) => ticket.code === code
+                              );
+                              return ticket ? (
+                                <XStack alignItems="center" gap="$2">
+                                  <CheckCircle size="$1" color="$green10" />
+                                  <Paragraph color="$green10">
+                                    → {ticket.name}
+                                  </Paragraph>
+                                </XStack>
+                              ) : (
+                                <XStack alignItems="center" gap="$2">
+                                  <AlertCircle size="$1" color="$yellow10" />
+                                  <Paragraph color="$yellow10">
+                                    Unregistered card
+                                  </Paragraph>
+                                </XStack>
+                              );
+                            }}
+                          </FieldWatch>
                           <Separator />
                         </YStack>
                       );

--- a/libs/ui/src/presentation/screens/RentalCheckinHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinHandler.test.tsx
@@ -6,11 +6,13 @@ import {
   MockAuthRepository,
   MockProductRepository,
   MockRentalRepository,
+  MockTicketRepository,
   MockVariantRepository,
 } from '../../data/mock';
 import {
   AuthLogoutUsecase,
   RentalCheckinUsecase,
+  TicketListUsecase,
   TransactionItemSelectUsecase,
 } from '../../domain';
 import { flushPromises } from '../../utils/testUtils';
@@ -46,6 +48,9 @@ const createProps = (
       variantRepo,
       { products: [], totalItem: 0 }
     ),
+    ticketListUsecase: new TicketListUsecase(new MockTicketRepository(), {
+      tickets: [],
+    }),
   };
 };
 
@@ -110,6 +115,78 @@ describe('RentalCheckinHandler', () => {
       await act(async () => {
         await flushPromises();
       });
+    });
+  });
+
+  describe('scan resolution hint', () => {
+    const addRentalItem = async (user: ReturnType<typeof userEvent.setup>) => {
+      await act(async () => {
+        fireEvent.click(screen.getByRole('heading', { name: 'Product 1' }));
+      });
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await user.click(screen.getAllByRole('button', { name: 'Submit' })[0]);
+
+      await act(async () => {
+        await flushPromises();
+      });
+    };
+
+    it('should show the resolved ticket name for a registered code', async () => {
+      const user = userEvent.setup();
+      render(<RentalCheckinHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await addRentalItem(user);
+
+      const codeInput = screen.getByPlaceholderText('Code');
+      await user.type(codeInput, '0xA3F19C82');
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('→ Ticket 01')).toBeTruthy();
+    });
+
+    it('should show an unregistered card hint for an unknown code', async () => {
+      const user = userEvent.setup();
+      render(<RentalCheckinHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await addRentalItem(user);
+
+      const codeInput = screen.getByPlaceholderText('Code');
+      await user.type(codeInput, 'UNKNOWNCODE');
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getByText('Unregistered card')).toBeTruthy();
+    });
+
+    it('should not show a hint when the code is empty', async () => {
+      render(<RentalCheckinHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const user = userEvent.setup();
+      await addRentalItem(user);
+
+      expect(screen.queryByText('Unregistered card')).toBeNull();
+      expect(screen.queryByText(/→ Ticket/)).toBeNull();
     });
   });
 
@@ -342,6 +419,9 @@ describe('RentalCheckinHandler', () => {
             new MockVariantRepository(),
             { products: [], totalItem: 0 }
           )}
+          ticketListUsecase={new TicketListUsecase(new MockTicketRepository(), {
+            tickets: [],
+          })}
         />
       );
 

--- a/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
@@ -5,11 +5,13 @@ import {
   useRentalCheckinController,
   useAuthLogoutController,
   useTransactionItemSelectController,
+  useTicketListController,
 } from '../controllers';
 import {
   AuthLogoutUsecase,
   RentalCheckinUsecase,
   TransactionItemSelectUsecase,
+  TicketListUsecase,
 } from '../../domain';
 import {
   RentalCheckinScreen,
@@ -20,12 +22,14 @@ export type RentalCheckinHandlerProps = {
   rentalCheckinUsecase: RentalCheckinUsecase;
   transactionItemSelectUsecase: TransactionItemSelectUsecase;
   authLogoutUsecase: AuthLogoutUsecase;
+  ticketListUsecase: TicketListUsecase;
 };
 
 export const RentalCheckinHandler = ({
   rentalCheckinUsecase,
   transactionItemSelectUsecase,
   authLogoutUsecase,
+  ticketListUsecase,
 }: RentalCheckinHandlerProps) => {
   const router = useRouter();
   const rentalCheckin = useRentalCheckinController(rentalCheckinUsecase);
@@ -33,6 +37,7 @@ export const RentalCheckinHandler = ({
   const transactionItemSelect = useTransactionItemSelectController(
     transactionItemSelectUsecase
   );
+  const ticketList = useTicketListController(ticketListUsecase);
 
   useEffect(() => {
     if (
@@ -75,6 +80,7 @@ export const RentalCheckinHandler = ({
       onToggleCustomizeCheckinDateTime={
         rentalCheckin.onToggleCustomizeCheckinDateTime
       }
+      tickets={ticketList.state.tickets}
       rentalItemSelect={{
         amount: transactionItemSelect.state.amount,
         currentPage: transactionItemSelect.state.page,

--- a/libs/ui/src/presentation/screens/RentalCheckinScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinScreen.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { useForm, useFieldArray } from 'react-hook-form';
 import { RentalCheckinScreen } from './RentalCheckinScreen';
 import type { RentalCheckinForm } from '../../domain';
-import { mockProducts } from '../../../.storybook/mocks/mockData';
+import { mockProducts, mockTickets } from '../../../.storybook/mocks/mockData';
 
 const defaultValues: RentalCheckinForm = {
   name: '',
@@ -24,6 +24,7 @@ const CheckinStory = () => {
       onLogoutPress={fn()}
       rentalsFieldArray={rentalsFieldArray}
       onToggleCustomizeCheckinDateTime={fn()}
+      tickets={mockTickets}
       rentalItemSelect={{
         amount: 1,
         currentPage: 1,

--- a/libs/ui/src/presentation/screens/RentalCheckinScreen.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinScreen.tsx
@@ -5,7 +5,7 @@ import {
   TransactionItemSelect,
   TransactionItemSelectProps,
 } from '../components';
-import { OptionValue, Product, RentalCheckinForm } from '../../domain';
+import { OptionValue, Product, RentalCheckinForm, Ticket } from '../../domain';
 import { UseFormReturn, UseFieldArrayReturn } from 'react-hook-form';
 
 export type RentalCheckinScreenProps = {
@@ -16,6 +16,7 @@ export type RentalCheckinScreenProps = {
   onLogoutPress: () => void;
   rentalsFieldArray: UseFieldArrayReturn<RentalCheckinForm, 'rentals', 'key'>;
   onToggleCustomizeCheckinDateTime: (checked: boolean) => void;
+  tickets: Ticket[];
   rentalItemSelect: {
     amount: number;
     currentPage: number;
@@ -55,6 +56,7 @@ export const RentalCheckinScreen = (props: RentalCheckinScreenProps) => {
           onToggleCustomizeCheckinDateTime={
             props.onToggleCustomizeCheckinDateTime
           }
+          tickets={props.tickets}
           serverError={props.serverError}
           RentalItemSelect={() => (
             <TransactionItemSelect


### PR DESCRIPTION
## Summary
This PR adds visual feedback when scanning ticket codes during rental check-in, displaying the resolved ticket name for registered codes or an "Unregistered card" warning for unknown codes.

## Key Changes
- **Ticket integration**: Integrated `TicketListUsecase` and `ApiTicketRepository` into the rental check-in flow to fetch and manage ticket data
- **Scan resolution UI**: Added real-time hint display in `RentalCheckinFormView` that shows:
  - A green checkmark with ticket name (e.g., "→ Ticket 01") for registered codes
  - A yellow alert with "Unregistered card" message for unknown codes
  - No hint when the code field is empty
- **Component updates**: Updated `RentalCheckinHandler`, `RentalCheckinScreen`, and related components to pass ticket data through the component hierarchy
- **Test coverage**: Added comprehensive test suite covering registered codes, unknown codes, and empty code scenarios
- **Storybook stories**: Added new `ScanResolution` story and updated existing stories to demonstrate the scan resolution feature

## Implementation Details
- Uses `FieldWatch` component to reactively monitor code input changes and resolve against the ticket list
- Leverages existing icon components (`CheckCircle`, `AlertCircle`) from `@tamagui/lucide-icons` for visual indicators
- Maintains backward compatibility by making the `tickets` prop required but allowing empty arrays in mock/test scenarios

https://claude.ai/code/session_017Bi5NUH7tFMfrUs6nzdmtP