### PR TITLE
Add checkin slip printing functionality to rental checkin flow

### DIFF
--- a/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
@@ -66,12 +66,16 @@ export const RentalCheckinHandler = ({
       const checkin: CheckinPrintPayload = {
         createdAt: dayjs(new Date().toISOString()).format('DD/MM/YYYY HH:mm'),
         name: rentalCheckin.form.getValues('name'),
-        tickets: rentalCheckin.form.getValues('rentals').map(({ variant }) => ({
-          name: variant.product.name,
-          variant: variant.values
-            .map(({ optionValue }) => optionValue.name)
-            .join(' - '),
-        })),
+        tickets: rentalCheckin.form
+          .getValues('rentals')
+          .map(({ code, variant }) => ({
+            name:
+              ticketList.state.tickets.find((ticket) => ticket.code === code)
+                ?.name ?? '',
+            variant: variant.values
+              .map(({ optionValue }) => optionValue.name)
+              .join(' - '),
+          })),
       };
 
       show({
@@ -85,7 +89,14 @@ export const RentalCheckinHandler = ({
         onCancel: () => router.push('/rentals'),
       });
     }
-  }, [rentalCheckin.form, rentalCheckin.state.type, router, show, print]);
+  }, [
+    rentalCheckin.form,
+    rentalCheckin.state.type,
+    ticketList.state.tickets,
+    router,
+    show,
+    print,
+  ]);
 
   return (
     <RentalCheckinScreen

--- a/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
@@ -17,6 +17,9 @@ import {
   RentalCheckinScreen,
   RentalCheckinScreenProps,
 } from './RentalCheckinScreen';
+import { CheckinPrintPayload, usePrinter } from '../../utils';
+import { useConfirmationAlert } from '../components';
+import dayjs from 'dayjs';
 
 export type RentalCheckinHandlerProps = {
   rentalCheckinUsecase: RentalCheckinUsecase;
@@ -32,6 +35,8 @@ export const RentalCheckinHandler = ({
   ticketListUsecase,
 }: RentalCheckinHandlerProps) => {
   const router = useRouter();
+  const { print } = usePrinter();
+  const { show } = useConfirmationAlert();
   const rentalCheckin = useRentalCheckinController(rentalCheckinUsecase);
   const authLogout = useAuthLogoutController(authLogoutUsecase);
   const transactionItemSelect = useTransactionItemSelectController(
@@ -58,9 +63,29 @@ export const RentalCheckinHandler = ({
 
   useEffect(() => {
     if (rentalCheckin.state.type === 'submitSuccess') {
-      router.push(`/rentals`);
+      const checkin: CheckinPrintPayload = {
+        createdAt: dayjs(new Date().toISOString()).format('DD/MM/YYYY HH:mm'),
+        name: rentalCheckin.form.getValues('name'),
+        tickets: rentalCheckin.form.getValues('rentals').map(({ variant }) => ({
+          name: variant.product.name,
+          variant: variant.values
+            .map(({ optionValue }) => optionValue.name)
+            .join(' - '),
+        })),
+      };
+
+      show({
+        title: 'Print Checkin Slip',
+        description: 'Do you want to print checkin slip ?',
+        onConfirm: () => {
+          print({ type: 'CHECKIN_SLIP', checkin })
+            .then(() => router.push('/rentals'))
+            .catch(() => router.push('/rentals'));
+        },
+        onCancel: () => router.push('/rentals'),
+      });
     }
-  }, [rentalCheckin.state.type, router]);
+  }, [rentalCheckin.form, rentalCheckin.state.type, router, show, print]);
 
   return (
     <RentalCheckinScreen

--- a/libs/ui/src/utils/print.ts
+++ b/libs/ui/src/utils/print.ts
@@ -34,6 +34,15 @@ export type PurchaseListPrintPayload = {
   }[];
 };
 
+export type CheckinPrintPayload = {
+  createdAt: string;
+  name: string;
+  tickets: {
+    name: string;
+    variant: string;
+  }[];
+};
+
 export type PrintPayload =
   | {
       type: 'INVOICE' | 'ORDER_SLIP';
@@ -42,6 +51,10 @@ export type PrintPayload =
   | {
       type: 'PURCHASE_LIST';
       purchaseList: PurchaseListPrintPayload;
+    }
+  | {
+      type: 'CHECKIN_SLIP';
+      checkin: CheckinPrintPayload;
     };
 
 export const usePrinter = () => {


### PR DESCRIPTION
## Summary
Added print functionality to the rental checkin process, allowing users to print a checkin slip after successfully completing a rental checkin. The user is now prompted with a confirmation dialog before printing.

## Key Changes
- **RentalCheckinHandler.tsx**: 
  - Integrated `usePrinter` hook to enable printing capabilities
  - Integrated `useConfirmationAlert` hook to show a confirmation dialog
  - Modified the `submitSuccess` effect to display a confirmation prompt asking if the user wants to print the checkin slip
  - Constructs a `CheckinPrintPayload` object containing checkin details (date, customer name, and rental items with variants)
  - Routes to `/rentals` after printing completes (or if user cancels)
  - Updated effect dependencies to include `show` and `print` functions

- **print.ts**:
  - Added `CheckinPrintPayload` type definition with fields for creation timestamp, customer name, and ticket details
  - Extended `PrintPayload` union type to support `CHECKIN_SLIP` print type with the new payload structure

## Implementation Details
- The checkin slip payload is constructed from the rental checkin form values, extracting product names and variant option values
- The timestamp is formatted as `DD/MM/YYYY HH:mm` using dayjs
- The print operation is non-blocking; navigation to `/rentals` occurs regardless of print success or failure
- User can opt out of printing via the cancel button, which also navigates to `/rentals`

https://claude.ai/code/session_01VRDMoxffYQKfMkqQhRZUjy