### PR TITLE
Fix rental item coupon removal to restore full price

### DIFF
--- a/apps/api/domain/transaction_usecase.go
+++ b/apps/api/domain/transaction_usecase.go
@@ -115,14 +115,23 @@ func (usecase TransactionUsecase) UpdateTransactionById(ctx context.Context, tra
 
 		for index, item := range transaction.TransactionItems {
 			if existingItem, ok := existingItemsById[item.Id]; ok && existingItem.RentalId != nil {
-				transaction.Total += existingItem.Subtotal
+				// Preserve the duration-based Price and the rental link (#131):
+				// the update payload carries neither, and recalculating from the
+				// variant's base price would corrupt them. The DiscountAmount,
+				// however, must come from the request so a per-item coupon can be
+				// removed — otherwise the discount baked in at apply time would be
+				// re-preserved here forever. Subtotal is re-derived from the
+				// preserved Price; if a coupon row still targets this item,
+				// applyTransactionCoupons overwrites both below.
+				subTotal := (existingItem.Price * existingItem.Amount) - item.DiscountAmount
+				transaction.Total += subTotal
 				transaction.TransactionItems[index] = TransactionItem{
 					Id:             existingItem.Id,
 					TransactionId:  id,
 					VariantId:      existingItem.VariantId,
 					Amount:         existingItem.Amount,
-					DiscountAmount: existingItem.DiscountAmount,
-					Subtotal:       existingItem.Subtotal,
+					DiscountAmount: item.DiscountAmount,
+					Subtotal:       subTotal,
 					Price:          existingItem.Price,
 					RentalId:       existingItem.RentalId,
 					Note:           existingItem.Note,

--- a/apps/api/domain/transaction_usecase_test.go
+++ b/apps/api/domain/transaction_usecase_test.go
@@ -598,6 +598,37 @@ func TestTransactionUsecase_UpdateTransactionById_ItemCoupons(t *testing.T) {
 		assert.Equal(t, float32(15000), secondSave.TransactionItems[0].Subtotal)
 	})
 
+	t.Run("removing a rental item coupon restores the full price", func(t *testing.T) {
+		ctrl := gomock.NewController(t)
+		defer ctrl.Finish()
+
+		// The stored item already has the coupon's discount baked in from a
+		// previous save (Subtotal 15000, DiscountAmount 15000 on a 30K rental).
+		rentalId := int64(103)
+		txRepo, variantRepo, couponRepo, walletRepo, budgetRepo := setupUpdateTransactionMocks(ctrl, 1, domain.Transaction{
+			Id: 1, PaidAt: nil,
+			TransactionItems: []domain.TransactionItem{
+				{Id: 13, VariantId: 1, Amount: 1, Price: 30000, Subtotal: 15000, DiscountAmount: 15000, RentalId: &rentalId, Note: "2 hour(s)"},
+			},
+		})
+
+		usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
+		// The frontend removes the coupon: no coupon row, DiscountAmount back to 0.
+		updated, err := usecase.UpdateTransactionById(context.Background(), domain.Transaction{
+			TransactionItems: []domain.TransactionItem{
+				{Id: 13, VariantId: 1, Amount: 1, DiscountAmount: 0, Note: "2 hour(s)"},
+			},
+			TransactionCoupons: []domain.TransactionCoupon{},
+		}, 1)
+
+		assert.Nil(t, err)
+		assert.Equal(t, float32(30000), updated.Total)
+		assert.Equal(t, float32(0), updated.TransactionItems[0].DiscountAmount)
+		assert.Equal(t, float32(30000), updated.TransactionItems[0].Subtotal)
+		assert.Equal(t, &rentalId, updated.TransactionItems[0].RentalId)
+		assert.Empty(t, updated.TransactionCoupons)
+	})
+
 	t.Run("FREE 2 HOUR on a 15K rental item clamps to the base (FR-4 #4)", func(t *testing.T) {
 		ctrl := gomock.NewController(t)
 		defer ctrl.Finish()


### PR DESCRIPTION
## Summary
Fixed a bug where removing a coupon from a rental transaction item would not restore the item's full price. The issue occurred because the discount amount was being preserved from the existing item instead of using the value from the update request.

## Key Changes
- **Updated coupon removal logic**: Modified `UpdateTransactionById` to use the `DiscountAmount` from the incoming request payload rather than the existing item's stored value. This allows per-item coupons to be properly removed.
- **Preserved rental metadata**: Ensured that duration-based `Price` and `RentalId` are preserved during updates, as these are not included in the update payload and should not be recalculated.
- **Recalculated subtotal**: The `Subtotal` is now derived from the preserved `Price` and the request's `DiscountAmount`, ensuring consistency when coupons are removed.

## Implementation Details
- When updating a rental item, the code now distinguishes between fields that should be preserved from the existing item (Price, RentalId, Note) and fields that should come from the request (DiscountAmount).
- The subtotal calculation is: `(Price × Amount) - DiscountAmount`
- If a coupon row still targets the item after the update, `applyTransactionCoupons` will overwrite both `DiscountAmount` and `Subtotal` as needed.
- Added comprehensive test case verifying that removing a coupon from a rental item correctly restores the full price and clears the discount.

https://claude.ai/code/session_01KDPd4CYszsrVwLRq25jDrY