### PR TITLE
Fix print dialog re-opening after successful rental checkin

### DIFF
--- a/libs/ui/src/presentation/screens/RentalCheckinHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinHandler.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { render, screen, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { RentalCheckinHandler } from './RentalCheckinHandler';
+import { ConfirmationAlertProvider } from '../components';
 import {
   MockAuthRepository,
   MockProductRepository,
@@ -223,7 +224,11 @@ describe('RentalCheckinHandler', () => {
   describe('navigation', () => {
     it('should navigate to "/rentals" after successful checkin', async () => {
       const user = userEvent.setup();
-      render(<RentalCheckinHandler {...createProps()} />);
+      render(
+        <ConfirmationAlertProvider>
+          <RentalCheckinHandler {...createProps()} />
+        </ConfirmationAlertProvider>
+      );
 
       await act(async () => {
         await flushPromises();
@@ -259,6 +264,68 @@ describe('RentalCheckinHandler', () => {
         await flushPromises();
       });
 
+      // After a successful checkin the print confirmation dialog appears.
+      // Declining it ("No") must still redirect to the rental list screen.
+      await user.click(screen.getByRole('button', { name: 'No' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(mockRouterPush).toHaveBeenCalledWith('/rentals');
+    });
+
+    it('should redirect to "/rentals" only once even after re-renders', async () => {
+      const user = userEvent.setup();
+      render(
+        <ConfirmationAlertProvider>
+          <RentalCheckinHandler {...createProps()} />
+        </ConfirmationAlertProvider>
+      );
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByRole('heading', { name: 'Product 1' }));
+      });
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      await user.click(screen.getAllByRole('button', { name: 'Submit' })[0]);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      const codeInput = screen.getByPlaceholderText('Code');
+      await user.type(codeInput, 'RENTAL001');
+
+      const nameInput = screen.getByRole('textbox', { name: 'Customer Name' });
+      await user.type(nameInput, 'John Doe');
+
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      // The print confirmation dialog must be shown exactly once. A second
+      // dialog would mean the effect re-fired and could block the redirect.
+      expect(screen.getAllByText('Print Checkin Slip')).toHaveLength(1);
+
+      await user.click(screen.getByRole('button', { name: 'No' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      // Declining closes the dialog and redirects without re-opening it.
+      expect(screen.queryByText('Print Checkin Slip')).toBeNull();
+      expect(mockRouterPush).toHaveBeenCalledTimes(1);
       expect(mockRouterPush).toHaveBeenCalledWith('/rentals');
     });
 

--- a/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
+++ b/libs/ui/src/presentation/screens/RentalCheckinHandler.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'solito/router';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { match, P } from 'ts-pattern';
 import {
   useRentalCheckinController,
@@ -43,6 +43,7 @@ export const RentalCheckinHandler = ({
     transactionItemSelectUsecase
   );
   const ticketList = useTicketListController(ticketListUsecase);
+  const hasShownPrintDialogRef = useRef(false);
 
   useEffect(() => {
     if (
@@ -62,33 +63,43 @@ export const RentalCheckinHandler = ({
   ]);
 
   useEffect(() => {
-    if (rentalCheckin.state.type === 'submitSuccess') {
-      const checkin: CheckinPrintPayload = {
-        createdAt: dayjs(new Date().toISOString()).format('DD/MM/YYYY HH:mm'),
-        name: rentalCheckin.form.getValues('name'),
-        tickets: rentalCheckin.form
-          .getValues('rentals')
-          .map(({ code, variant }) => ({
-            name:
-              ticketList.state.tickets.find((ticket) => ticket.code === code)
-                ?.name ?? '',
-            variant: variant.values
-              .map(({ optionValue }) => optionValue.name)
-              .join(' - '),
-          })),
-      };
-
-      show({
-        title: 'Print Checkin Slip',
-        description: 'Do you want to print checkin slip ?',
-        onConfirm: () => {
-          print({ type: 'CHECKIN_SLIP', checkin })
-            .then(() => router.push('/rentals'))
-            .catch(() => router.push('/rentals'));
-        },
-        onCancel: () => router.push('/rentals'),
-      });
+    if (rentalCheckin.state.type !== 'submitSuccess') {
+      hasShownPrintDialogRef.current = false;
+      return;
     }
+
+    // The checkin state machine stays in `submitSuccess` permanently, so this
+    // effect can re-run on later re-renders (e.g. while navigation is in
+    // flight). Guard with a ref so the print confirmation dialog is shown
+    // exactly once and never re-opens to block the redirect to /rentals.
+    if (hasShownPrintDialogRef.current) return;
+    hasShownPrintDialogRef.current = true;
+
+    const checkin: CheckinPrintPayload = {
+      createdAt: dayjs(new Date().toISOString()).format('DD/MM/YYYY HH:mm'),
+      name: rentalCheckin.form.getValues('name'),
+      tickets: rentalCheckin.form
+        .getValues('rentals')
+        .map(({ code, variant }) => ({
+          name:
+            ticketList.state.tickets.find((ticket) => ticket.code === code)
+              ?.name ?? '',
+          variant: variant.values
+            .map(({ optionValue }) => optionValue.name)
+            .join(' - '),
+        })),
+    };
+
+    show({
+      title: 'Print Checkin Slip',
+      description: 'Do you want to print checkin slip ?',
+      onConfirm: () => {
+        print({ type: 'CHECKIN_SLIP', checkin })
+          .then(() => router.push('/rentals'))
+          .catch(() => router.push('/rentals'));
+      },
+      onCancel: () => router.push('/rentals'),
+    });
   }, [
     rentalCheckin.form,
     rentalCheckin.state.type,

--- a/libs/ui/src/utils/print.ts
+++ b/libs/ui/src/utils/print.ts
@@ -1,3 +1,4 @@
+import { useCallback } from 'react';
 import { useToastController } from '@tamagui/toast';
 
 export type TransactionPrintPayload = {
@@ -60,24 +61,27 @@ export type PrintPayload =
 export const usePrinter = () => {
   const toast = useToastController();
 
-  const print = (payload: PrintPayload): Promise<void> => {
-    return new Promise((resolve, reject) => {
-      const socket = new WebSocket('ws://localhost:8080');
-      socket.onopen = () => {
-        socket.send(JSON.stringify(payload));
-      };
+  const print = useCallback(
+    (payload: PrintPayload): Promise<void> => {
+      return new Promise((resolve, reject) => {
+        const socket = new WebSocket('ws://localhost:8080');
+        socket.onopen = () => {
+          socket.send(JSON.stringify(payload));
+        };
 
-      socket.onmessage = (event) => {
-        toast.show('Printing info', { message: event.data });
-        resolve();
-      };
+        socket.onmessage = (event) => {
+          toast.show('Printing info', { message: event.data });
+          resolve();
+        };
 
-      socket.onerror = () => {
-        toast.show('Printing info', { message: 'Cannot connect to printer' });
-        reject();
-      };
-    });
-  };
+        socket.onerror = () => {
+          toast.show('Printing info', { message: 'Cannot connect to printer' });
+          reject();
+        };
+      });
+    },
+    [toast]
+  );
 
   return { print };
 };


### PR DESCRIPTION
## Summary
Fixed a bug where the print confirmation dialog could re-open multiple times after a successful rental checkin, potentially blocking navigation to the rentals list. The issue occurred because the effect showing the dialog would re-run on subsequent re-renders while the checkin state remained in `submitSuccess`.

## Key Changes
- **RentalCheckinHandler.tsx**: Added a `useRef` to track whether the print dialog has been shown, preventing it from re-opening on re-renders. The effect now guards against re-firing by checking this ref before showing the dialog.
- **RentalCheckinHandler.test.tsx**: 
  - Wrapped test component with `ConfirmationAlertProvider` to properly render the confirmation dialog
  - Added test case verifying that declining the print dialog still redirects to `/rentals`
  - Added test case ensuring the print dialog appears exactly once and doesn't re-open, blocking the redirect
- **print.ts**: Wrapped the `print` function with `useCallback` to memoize it and prevent unnecessary re-renders of dependent components

## Implementation Details
The core fix uses a ref (`hasShownPrintDialogRef`) to ensure the print confirmation dialog is shown exactly once per successful checkin. When the checkin state transitions away from `submitSuccess`, the ref is reset. This prevents the dialog from re-opening during navigation or other re-renders that might occur while the state machine is in the terminal `submitSuccess` state.

https://claude.ai/code/session_018T95ZrT4GpydVxaRstD4g4