### PR TITLE
Fix MarkdownEditor to support nested form fields

### DIFF
--- a/libs/ui/src/presentation/components/base/Form/MarkdownEditor.stories.tsx
+++ b/libs/ui/src/presentation/components/base/Form/MarkdownEditor.stories.tsx
@@ -26,6 +26,24 @@ const withEmptyFormProvider: Decorator = (Story) => {
   );
 };
 
+const withNestedFormProvider: Decorator = (Story) => {
+  const form = useForm({
+    defaultValues: {
+      items: [
+        {
+          description:
+            '# Nested Item\n\nThis previews `items.0.description`, not the top-level `description` field.',
+        },
+      ],
+    },
+  });
+  return (
+    <FormProvider {...form}>
+      <Story />
+    </FormProvider>
+  );
+};
+
 const meta: Meta<typeof MarkdownEditor> = {
   title: 'Base/Form/MarkdownEditor',
   component: MarkdownEditor,
@@ -55,5 +73,13 @@ export const EmptyContent: Story = {
   decorators: [withEmptyFormProvider],
   args: {
     defaultMode: 'edit',
+  },
+};
+
+export const NestedFieldPreview: Story = {
+  decorators: [withNestedFormProvider],
+  args: {
+    name: 'items.0.description',
+    defaultMode: 'preview',
   },
 };

--- a/libs/ui/src/presentation/components/base/Form/MarkdownEditor.tsx
+++ b/libs/ui/src/presentation/components/base/Form/MarkdownEditor.tsx
@@ -31,7 +31,7 @@ export const MarkdownEditor = (props: MarkdownEditorProps) => {
       {isEdit ? (
         <Textarea name={props.name} id={props.name} />
       ) : (
-        <FieldWatch control={form.control} name={['description']}>
+        <FieldWatch control={form.control} name={[props.name ?? 'description']}>
           {([description]) => <Markdown content={description} />}
         </FieldWatch>
       )}


### PR DESCRIPTION
## Summary
Fixed the MarkdownEditor component to properly support nested form field paths, enabling it to work with fields beyond the top-level `description` field.

## Key Changes
- **MarkdownEditor.tsx**: Updated the `FieldWatch` component to use the `name` prop instead of hardcoded `'description'`, allowing it to watch any field path passed to the component
- **MarkdownEditor.stories.tsx**: Added comprehensive test coverage for nested fields:
  - New `withNestedFormProvider` decorator that sets up a form with nested `items[0].description` field
  - New `NestedFieldPreview` story demonstrating the component working with nested field paths

## Implementation Details
The fix changes the field watching logic from a hardcoded field name to using the component's `name` prop with a sensible default. This allows the MarkdownEditor to be reused in complex forms with nested structures while maintaining backward compatibility for existing implementations that rely on the default `'description'` field name.

https://claude.ai/code/session_01Y72sodi47a2o9T8pp4diDt