### PR TITLE
Add Markdown editor support to checklist template forms

### DIFF
--- a/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.stories.tsx
+++ b/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.stories.tsx
@@ -1,0 +1,84 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+import { useForm } from 'react-hook-form';
+import { ChecklistTemplateFormView } from './ChecklistTemplateFormView';
+import type { ChecklistTemplateForm } from '../../../domain';
+
+const emptyValues: ChecklistTemplateForm = {
+  name: '',
+  description: '',
+  items: [
+    {
+      name: '',
+      description: '',
+      displayOrder: 1,
+      subItems: [],
+    },
+  ],
+};
+
+const populatedValues: ChecklistTemplateForm = {
+  name: 'Opening Checklist',
+  description:
+    '## Opening Routine\n\nRun through this checklist **before** opening the store to customers.',
+  items: [
+    {
+      name: 'Turn on lamp',
+      description:
+        '- Bar lamp\n- Door lamp\n- Storage lamp\n\nSwitches are behind the cashier.',
+      displayOrder: 1,
+      subItems: [],
+    },
+    {
+      name: 'Count cash drawer',
+      description: '',
+      displayOrder: 2,
+      subItems: [
+        { name: 'Count Rp100,000 notes', displayOrder: 1 },
+        { name: 'Count Rp50,000 notes', displayOrder: 2 },
+      ],
+    },
+  ],
+};
+
+const EmptyStory = () => {
+  const form = useForm<ChecklistTemplateForm>({ defaultValues: emptyValues });
+  return (
+    <ChecklistTemplateFormView
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      isSubmitting={false}
+    />
+  );
+};
+
+const PopulatedStory = () => {
+  const form = useForm<ChecklistTemplateForm>({
+    defaultValues: populatedValues,
+  });
+  return (
+    <ChecklistTemplateFormView
+      form={form}
+      onSubmit={fn()}
+      isSubmitDisabled={false}
+      isSubmitting={false}
+    />
+  );
+};
+
+const meta: Meta<typeof ChecklistTemplateFormView> = {
+  title: 'Features/ChecklistTemplates/ChecklistTemplateFormView',
+  component: ChecklistTemplateFormView,
+};
+
+export default meta;
+type Story = StoryObj<typeof ChecklistTemplateFormView>;
+
+export const Empty: Story = {
+  render: () => <EmptyStory />,
+};
+
+export const Populated: Story = {
+  render: () => <PopulatedStory />,
+};

--- a/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
+++ b/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateFormView.tsx
@@ -1,7 +1,22 @@
 import { ArrowDown, ArrowUp, Plus, Trash, X } from '@tamagui/lucide-icons';
-import { Button, Card, Form, H4, Spinner, XStack, YStack } from 'tamagui';
+import {
+  Button,
+  Card,
+  Form,
+  H4,
+  SizableText,
+  Spinner,
+  XStack,
+  YStack,
+} from 'tamagui';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
-import { Field, FieldArray, FormErrorBanner, InputText } from '../base';
+import {
+  Field,
+  FieldArray,
+  FormErrorBanner,
+  InputText,
+  MarkdownEditor,
+} from '../base';
 import { ChecklistTemplateForm } from '../../../domain';
 
 export type ChecklistTemplateFormViewProps = {
@@ -24,18 +39,20 @@ export const ChecklistTemplateFormView = ({
       <Form onSubmit={form.handleSubmit(onSubmit)} gap="$3">
         <FormErrorBanner message={serverError} />
         <Card padding="$3" gap="$3">
-          <YStack gap="$3" $gtMd={{ flexDirection: 'row' }}>
-            <YStack flex={1}>
-              <Field name="name" label="Template Name">
-                <InputText placeholder="e.g. Opening Checklist" />
-              </Field>
-            </YStack>
-            <YStack flex={1}>
-              <Field name="description" label="Description (optional)">
-                <InputText placeholder="When/how to use this checklist" />
-              </Field>
-            </YStack>
-          </YStack>
+          <Field name="name" label="Template Name">
+            <InputText placeholder="e.g. Opening Checklist" />
+          </Field>
+          <Field name="description" label="Description (optional)">
+            <SizableText size="$2" color="$gray10">
+              Explain when/how to use this checklist. Markdown is supported
+              (lists, bold, headings), so you can add detail without creating
+              more checklist items.
+            </SizableText>
+            <MarkdownEditor
+              name="description"
+              defaultMode={form.getValues('description') ? 'preview' : 'edit'}
+            />
+          </Field>
         </Card>
 
         <FieldArray control={form.control} name="items" keyName="key">
@@ -94,21 +111,29 @@ export const ChecklistTemplateFormView = ({
                     </XStack>
                   </XStack>
 
-                  <YStack gap="$3" $gtMd={{ flexDirection: 'row' }}>
-                    <YStack flex={1}>
-                      <Field name={`items.${index}.name`} label="Item Name">
-                        <InputText placeholder="e.g. Turn on lights" />
-                      </Field>
-                    </YStack>
-                    <YStack flex={1}>
-                      <Field
-                        name={`items.${index}.description`}
-                        label="Description (optional)"
-                      >
-                        <InputText placeholder="Additional instructions" />
-                      </Field>
-                    </YStack>
-                  </YStack>
+                  <Field name={`items.${index}.name`} label="Item Name">
+                    <InputText placeholder="e.g. Turn on lights" />
+                  </Field>
+
+                  <Field
+                    name={`items.${index}.description`}
+                    label="Description (optional)"
+                  >
+                    <SizableText size="$2" color="$gray10">
+                      Use Markdown to clarify this item (e.g. list which
+                      lamps to turn on, or the steps to follow). Only add
+                      sub-items below when each step must be checked off
+                      individually.
+                    </SizableText>
+                    <MarkdownEditor
+                      name={`items.${index}.description`}
+                      defaultMode={
+                        form.getValues(`items.${index}.description`)
+                          ? 'preview'
+                          : 'edit'
+                      }
+                    />
+                  </Field>
 
                   <FieldArray
                     control={form.control}


### PR DESCRIPTION
## Summary
Enhanced the ChecklistTemplateFormView component to support rich text editing with Markdown for template and item descriptions, replacing simple text inputs with a dedicated MarkdownEditor component. Added comprehensive Storybook stories for testing both empty and populated form states.

## Key Changes
- **Replaced text inputs with MarkdownEditor**: Description fields for both templates and individual items now use the MarkdownEditor component instead of InputText, enabling Markdown formatting support (lists, bold, headings)
- **Improved UX with helper text**: Added descriptive helper text for description fields explaining Markdown support and when to use descriptions vs. sub-items
- **Simplified layout**: Removed responsive row layout for template name/description fields, making the form more straightforward
- **Added Storybook stories**: Created comprehensive stories (Empty and Populated) to showcase the form in different states with realistic example data
- **Smart editor mode defaults**: MarkdownEditor defaults to 'preview' mode when content exists, 'edit' mode when empty

## Implementation Details
- The MarkdownEditor component is conditionally initialized based on whether the field has existing content
- Helper text uses SizableText with gray color to provide visual hierarchy
- Example data in stories includes realistic checklist scenarios (Opening Checklist with sub-items for cash counting)
- All changes maintain backward compatibility with the existing ChecklistTemplateForm type

https://claude.ai/code/session_01BWQdA4vQNXp3rh7u5QHoMs