### PR TITLE
Support markdown rendering in checklist descriptions

### DIFF
--- a/libs/ui/src/presentation/components/base/ListItem.tsx
+++ b/libs/ui/src/presentation/components/base/ListItem.tsx
@@ -1,5 +1,5 @@
 import { MoreVertical } from '@tamagui/lucide-icons';
-import React, { NamedExoticComponent } from 'react';
+import React, { NamedExoticComponent, ReactNode } from 'react';
 import {
   Image,
   Popover,
@@ -57,7 +57,7 @@ export type ListItemFooterItem = {
 
 export type ListItemProps = {
   title: string;
-  subtitle?: string;
+  subtitle?: ReactNode;
   thumbnailSrc?: string;
   menus?: ListItemMenu[];
   footerItems?: ListItemFooterItem[];
@@ -100,11 +100,14 @@ export const ListItem = ({
         <YStack padding="$3" flex={1} gap="$3">
           <YStack flex={1} justifyContent="center">
             <H4 ellipse>{title}</H4>
-            {subtitle && (
-              <Paragraph textTransform="none" ellipse size="$6">
-                {subtitle}
-              </Paragraph>
-            )}
+            {subtitle &&
+              (typeof subtitle === 'string' ? (
+                <Paragraph textTransform="none" ellipse size="$6">
+                  {subtitle}
+                </Paragraph>
+              ) : (
+                subtitle
+              ))}
           </YStack>
 
           {shownFooterItems.length > 0 ? (

--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.test.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChecklistSessionItemRow } from './ChecklistSessionItemRow';
+import { ChecklistSessionItem } from '../../../domain';
+
+const baseItem: ChecklistSessionItem = {
+  id: 1,
+  checklistSessionId: 1,
+  checklistTemplateItemId: 1,
+  name: 'Turn on lamp',
+  description: null,
+  displayOrder: 1,
+  completedAt: null,
+  subItems: [],
+  createdAt: '2024-03-20T00:00:00.000Z',
+  updatedAt: '2024-03-20T00:00:00.000Z',
+};
+
+const noop = () => undefined;
+
+const renderRow = (item: ChecklistSessionItem) =>
+  render(
+    <ChecklistSessionItemRow
+      item={item}
+      onCheckItem={noop}
+      onUncheckItem={noop}
+      onCheckSubItem={noop}
+      onUncheckSubItem={noop}
+      togglingItemId={null}
+      togglingSubItemId={null}
+    />
+  );
+
+describe('ChecklistSessionItemRow', () => {
+  it('renders the description through the Markdown component', () => {
+    renderRow({
+      ...baseItem,
+      description: '- Bar lamp\n- Door lamp\n\n**Switches are behind the cashier**',
+    });
+
+    const markdown = screen.getByTestId('markdown');
+    expect(markdown).toBeTruthy();
+    expect(markdown.textContent).toContain('Bar lamp');
+    expect(markdown.textContent).toContain('Switches are behind the cashier');
+  });
+
+  it('does not render the Markdown component when there is no description', () => {
+    renderRow(baseItem);
+    expect(screen.queryByTestId('markdown')).toBeNull();
+  });
+});

--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.tsx
@@ -15,6 +15,7 @@ import {
 } from 'tamagui';
 import { useState } from 'react';
 import { ChecklistSessionItem, ChecklistSessionSubItem } from '../../../domain';
+import { Markdown } from '../base';
 import { ChecklistSessionSubItemRow } from './ChecklistSessionSubItemRow';
 
 export type ChecklistSessionItemRowProps = {
@@ -118,9 +119,9 @@ export function ChecklistSessionItemRow({
             )}
           </XStack>
           {item.description && (
-            <Paragraph fontSize="$3" color="$gray10">
-              {item.description}
-            </Paragraph>
+            <YStack theme="alt2">
+              <Markdown content={item.description} />
+            </YStack>
           )}
         </YStack>
 

--- a/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateListItem.tsx
+++ b/libs/ui/src/presentation/components/checklistTemplates/ChecklistTemplateListItem.tsx
@@ -1,6 +1,6 @@
 import { ClipboardList, Pencil, Trash } from '@tamagui/lucide-icons';
-import { ListItem } from '../base';
-import { XStackProps } from 'tamagui';
+import { ListItem, Markdown } from '../base';
+import { XStackProps, YStack } from 'tamagui';
 
 export type ChecklistTemplateListItemProps = {
   name: string;
@@ -21,7 +21,13 @@ export function ChecklistTemplateListItem({
   return (
     <ListItem
       title={name}
-      subtitle={description}
+      subtitle={
+        description ? (
+          <YStack theme="alt2" maxHeight={80} overflow="hidden">
+            <Markdown content={description} />
+          </YStack>
+        ) : undefined
+      }
       menus={[
         {
           title: 'Edit',


### PR DESCRIPTION
## Summary
This PR adds markdown rendering support for checklist item and template descriptions, replacing plain text display with formatted markdown content.

## Key Changes
- **ListItem component enhancement**: Updated the `subtitle` prop type from `string` to `ReactNode` to support rendering custom components, with conditional logic to handle both string and component subtitles
- **ChecklistSessionItemRow**: Replaced plain text `Paragraph` rendering of item descriptions with `Markdown` component wrapped in a `YStack` with alt2 theme
- **ChecklistTemplateListItem**: Updated to render template descriptions as markdown content within a constrained `YStack` (max-height: 80px with overflow hidden)
- **Test coverage**: Added comprehensive test suite for `ChecklistSessionItemRow` covering markdown rendering with and without descriptions

## Implementation Details
- The `Markdown` component is imported from the base components and used consistently across both checklist sessions and templates
- Descriptions are wrapped in `YStack` with `theme="alt2"` for visual consistency
- Template descriptions have a max-height constraint to prevent excessive space usage in list views
- The ListItem component now intelligently handles both string and ReactNode subtitles, maintaining backward compatibility while enabling rich content rendering

https://claude.ai/code/session_01AnaiD7NgFNrxVVn9vUQBdh