### PR TITLE
Add collapsible description toggle to checklist items

### DIFF
--- a/libs/ui/src/__mocks__/@tamagui/lucide-icons.tsx
+++ b/libs/ui/src/__mocks__/@tamagui/lucide-icons.tsx
@@ -18,6 +18,7 @@ export const Clock = NullIcon;
 export const CreditCard = NullIcon;
 export const Eye = NullIcon;
 export const Filter = NullIcon;
+export const Info = NullIcon;
 export const Map = NullIcon;
 export const MapPin = NullIcon;
 export const Minus = NullIcon;

--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.test.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { ChecklistSessionItemRow } from './ChecklistSessionItemRow';
 import { ChecklistSessionItem } from '../../../domain';
 
@@ -16,14 +16,25 @@ const baseItem: ChecklistSessionItem = {
   updatedAt: '2024-03-20T00:00:00.000Z',
 };
 
+const itemWithDescription: ChecklistSessionItem = {
+  ...baseItem,
+  description: '- Bar lamp\n- Door lamp\n\n**Switches are behind the cashier**',
+};
+
 const noop = () => undefined;
 
-const renderRow = (item: ChecklistSessionItem) =>
+const renderRow = (
+  item: ChecklistSessionItem,
+  handlers: {
+    onCheckItem?: (itemId: number) => void;
+    onUncheckItem?: (itemId: number) => void;
+  } = {}
+) =>
   render(
     <ChecklistSessionItemRow
       item={item}
-      onCheckItem={noop}
-      onUncheckItem={noop}
+      onCheckItem={handlers.onCheckItem ?? noop}
+      onUncheckItem={handlers.onUncheckItem ?? noop}
       onCheckSubItem={noop}
       onUncheckSubItem={noop}
       togglingItemId={null}
@@ -32,20 +43,54 @@ const renderRow = (item: ChecklistSessionItem) =>
   );
 
 describe('ChecklistSessionItemRow', () => {
-  it('renders the description through the Markdown component', () => {
-    renderRow({
-      ...baseItem,
-      description: '- Bar lamp\n- Door lamp\n\n**Switches are behind the cashier**',
-    });
+  it('does not render the Markdown component or a description toggle when there is no description', () => {
+    renderRow(baseItem);
+
+    expect(screen.queryByTestId('markdown')).toBeNull();
+    expect(screen.queryByTestId('description-toggle')).toBeNull();
+  });
+
+  it('hides the description behind a toggle by default', () => {
+    renderRow(itemWithDescription);
+
+    expect(screen.getByTestId('description-toggle')).toBeTruthy();
+    expect(screen.queryByTestId('markdown')).toBeNull();
+  });
+
+  it('reveals the description through the Markdown component when the toggle is pressed', () => {
+    renderRow(itemWithDescription);
+
+    fireEvent.click(screen.getByTestId('description-toggle'));
 
     const markdown = screen.getByTestId('markdown');
-    expect(markdown).toBeTruthy();
     expect(markdown.textContent).toContain('Bar lamp');
     expect(markdown.textContent).toContain('Switches are behind the cashier');
   });
 
-  it('does not render the Markdown component when there is no description', () => {
-    renderRow(baseItem);
+  it('hides the description again when the toggle is pressed a second time', () => {
+    renderRow(itemWithDescription);
+
+    fireEvent.click(screen.getByTestId('description-toggle'));
+    fireEvent.click(screen.getByTestId('description-toggle'));
+
     expect(screen.queryByTestId('markdown')).toBeNull();
+  });
+
+  it('does not check the item when the description toggle is pressed', () => {
+    const onCheckItem = jest.fn();
+    renderRow(itemWithDescription, { onCheckItem });
+
+    fireEvent.click(screen.getByTestId('description-toggle'));
+
+    expect(onCheckItem).not.toHaveBeenCalled();
+  });
+
+  it('still checks the item when the row is pressed', () => {
+    const onCheckItem = jest.fn();
+    renderRow(itemWithDescription, { onCheckItem });
+
+    fireEvent.click(screen.getByText('Turn on lamp'));
+
+    expect(onCheckItem).toHaveBeenCalledWith(itemWithDescription.id);
   });
 });

--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.tsx
@@ -2,6 +2,7 @@ import {
   Check,
   ChevronDown,
   ChevronUp,
+  Info,
 } from '@tamagui/lucide-icons';
 import {
   Card,
@@ -38,6 +39,7 @@ export function ChecklistSessionItemRow({
   togglingSubItemId,
 }: ChecklistSessionItemRowProps) {
   const [isExpanded, setIsExpanded] = useState(true);
+  const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const hasSubItems = item.subItems.length > 0;
   const isCompleted = item.completedAt != null;
   const isToggling = togglingItemId === item.id;
@@ -108,6 +110,26 @@ export function ChecklistSessionItemRow({
             >
               {item.name}
             </Text>
+            {item.description && (
+              <XStack
+                testID="description-toggle"
+                accessibilityLabel={
+                  isDescriptionExpanded ? 'Hide description' : 'Show description'
+                }
+                onPress={(event) => {
+                  event.stopPropagation();
+                  setIsDescriptionExpanded((prev) => !prev);
+                }}
+                pressStyle={{ opacity: 0.6 }}
+                padding="$1"
+                flexShrink={0}
+              >
+                <Info
+                  size="$1"
+                  color={isDescriptionExpanded ? '$blue10' : '$gray9'}
+                />
+              </XStack>
+            )}
             {isCompleted && !hasSubItems && item.completedAt && (
               <Paragraph fontSize="$2" color="$gray9" flexShrink={0}>
                 {new Date(item.completedAt).toLocaleTimeString([], {
@@ -118,7 +140,7 @@ export function ChecklistSessionItemRow({
               </Paragraph>
             )}
           </XStack>
-          {item.description && (
+          {item.description && isDescriptionExpanded && (
             <YStack theme="alt2">
               <Markdown content={item.description} />
             </YStack>


### PR DESCRIPTION
## Summary
This PR adds a collapsible description feature to checklist session items. Descriptions are now hidden by default and can be revealed by clicking an info icon toggle, improving the UI by reducing visual clutter for items with descriptions.

## Key Changes
- Added a description toggle button (info icon) that appears only when an item has a description
- Descriptions are now hidden by default and only displayed when the toggle is clicked
- The toggle uses `event.stopPropagation()` to prevent triggering the item's check/uncheck action
- Updated test suite to comprehensively cover the new toggle behavior:
  - No toggle shown when description is absent
  - Toggle hides/shows description on click
  - Toggle doesn't trigger item check/uncheck
  - Item can still be checked by clicking elsewhere on the row
- Added `Info` icon import from lucide-icons and its mock

## Implementation Details
- New state variable `isDescriptionExpanded` tracks toggle state
- Toggle button is an `XStack` with `onPress` handler that stops event propagation
- Icon color changes based on expanded state (blue when expanded, gray when collapsed)
- Markdown component only renders when `isDescriptionExpanded` is true
- Test helper `renderRow` now accepts optional handler overrides for better test flexibility

https://claude.ai/code/session_01SK26ougwWWsyojZf6PV5Xq