### PR TITLE
Collapse sub-items by default in checklist session rows

### DIFF
--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.test.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.test.tsx
@@ -21,6 +21,33 @@ const itemWithDescription: ChecklistSessionItem = {
   description: '- Bar lamp\n- Door lamp\n\n**Switches are behind the cashier**',
 };
 
+const itemWithSubItems: ChecklistSessionItem = {
+  ...baseItem,
+  name: 'Clean tables',
+  subItems: [
+    {
+      id: 1,
+      checklistSessionItemId: 1,
+      checklistTemplateSubItemId: 1,
+      name: 'Table 1',
+      displayOrder: 1,
+      completedAt: '2024-03-20T00:00:00.000Z',
+      createdAt: '2024-03-20T00:00:00.000Z',
+      updatedAt: '2024-03-20T00:00:00.000Z',
+    },
+    {
+      id: 2,
+      checklistSessionItemId: 1,
+      checklistTemplateSubItemId: 2,
+      name: 'Table 2',
+      displayOrder: 2,
+      completedAt: null,
+      createdAt: '2024-03-20T00:00:00.000Z',
+      updatedAt: '2024-03-20T00:00:00.000Z',
+    },
+  ],
+};
+
 const noop = () => undefined;
 
 const renderRow = (
@@ -92,5 +119,27 @@ describe('ChecklistSessionItemRow', () => {
     fireEvent.click(screen.getByText('Turn on lamp'));
 
     expect(onCheckItem).toHaveBeenCalledWith(itemWithDescription.id);
+  });
+
+  it('collapses sub-items by default, showing only the completed/total badge', () => {
+    renderRow(itemWithSubItems);
+
+    expect(screen.getByText('1/2')).toBeTruthy();
+    expect(screen.queryByText('Table 1')).toBeNull();
+    expect(screen.queryByText('Table 2')).toBeNull();
+  });
+
+  it('expands sub-items when the row is pressed, and collapses again on a second press', () => {
+    renderRow(itemWithSubItems);
+
+    fireEvent.click(screen.getByText('Clean tables'));
+
+    expect(screen.getByText('Table 1')).toBeTruthy();
+    expect(screen.getByText('Table 2')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Clean tables'));
+
+    expect(screen.queryByText('Table 1')).toBeNull();
+    expect(screen.queryByText('Table 2')).toBeNull();
   });
 });

--- a/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.tsx
+++ b/libs/ui/src/presentation/components/checklistSessions/ChecklistSessionItemRow.tsx
@@ -38,7 +38,7 @@ export function ChecklistSessionItemRow({
   togglingItemId,
   togglingSubItemId,
 }: ChecklistSessionItemRowProps) {
-  const [isExpanded, setIsExpanded] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [isDescriptionExpanded, setIsDescriptionExpanded] = useState(false);
   const hasSubItems = item.subItems.length > 0;
   const isCompleted = item.completedAt != null;
@@ -103,10 +103,8 @@ export function ChecklistSessionItemRow({
               flex={1}
               fontSize="$5"
               fontWeight="bold"
-              textDecorationLine={
-                isCompleted && !hasSubItems ? 'line-through' : 'none'
-              }
-              color={isCompleted && !hasSubItems ? '$gray9' : '$color'}
+              textDecorationLine={isCompleted ? 'line-through' : 'none'}
+              color={isCompleted ? '$gray9' : '$color'}
             >
               {item.name}
             </Text>


### PR DESCRIPTION
## Summary
Updated the ChecklistSessionItemRow component to collapse sub-items by default instead of expanding them, improving the initial UI presentation for checklist items with sub-tasks.

## Key Changes
- Changed default `isExpanded` state from `true` to `false`, so sub-items are hidden on initial render
- Updated text styling logic to apply strikethrough and gray color to completed items regardless of whether they have sub-items (previously only applied when items had no sub-items)
- Added comprehensive test coverage for the new collapse/expand behavior:
  - Test verifying sub-items are collapsed by default with a completion badge (e.g., "1/2")
  - Test verifying sub-items expand when the row is clicked and collapse again on a second click

## Implementation Details
The styling change ensures visual consistency for completed items - they now display with strikethrough and gray text whether or not they contain sub-items. This provides a clearer visual hierarchy where users can expand rows to see details only when needed.

https://claude.ai/code/session_01JKHG5zMr2u3w1PSgpQ4RyY