### PR TITLE
docs: add plan for splitting order slip into kitchen & bar

### DIFF
--- a/docs/plans/split-order-slip-kitchen-bar.md
+++ b/docs/plans/split-order-slip-kitchen-bar.md
@@ -65,6 +65,253 @@ products inherit a sensible station automatically from their category.
 
 ---
 
+## System Design
+
+### 1. Where the marking is stored
+
+A single new column on the existing `categories` table. No new tables, no new
+relationships — products already reference a category via `products.category_id`,
+so a product's station is `product → category → station`.
+
+**`categories` table — before:**
+
+```sql
+CREATE TABLE IF NOT EXISTS `categories` (
+    `id`         BIGINT       NOT NULL AUTO_INCREMENT,
+    `name`       VARCHAR(255) NOT NULL,
+    `created_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `deleted_at` DATETIME     NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+**`categories` table — after (new column shown):**
+
+```sql
+CREATE TABLE IF NOT EXISTS `categories` (
+    `id`         BIGINT       NOT NULL AUTO_INCREMENT,
+    `name`       VARCHAR(255) NOT NULL,
+    `station`    VARCHAR(20)  NOT NULL DEFAULT 'NONE',  -- KITCHEN | BAR | NONE
+    `created_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `deleted_at` DATETIME     NULL,
+    PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+```
+
+> **Why `VARCHAR(20)` and not a native `ENUM`?** It matches the existing
+> convention in this codebase — `products.sale_type` and other status-like fields
+> are stored as `VARCHAR` and validated at the application/contract layer (Zod +
+> Go), keeping the enum's source of truth in the OpenAPI spec rather than split
+> across the DB. `NOT NULL DEFAULT 'NONE'` means every existing row is valid
+> immediately and no backfill is required.
+
+**Migration** (`apps/api/migrations/0000NN_add_category_station.up.sql`):
+
+```sql
+ALTER TABLE categories ADD COLUMN station VARCHAR(20) NOT NULL DEFAULT 'NONE';
+```
+
+**Down** (`...down.sql`):
+
+```sql
+ALTER TABLE categories DROP COLUMN station;
+```
+
+This mirrors the existing `000011_add_wallet_is_payment_target` migration pattern.
+
+### 2. Entity-relationship view
+
+```
+┌──────────────┐        ┌──────────────┐        ┌──────────────────────┐
+│  categories  │ 1    * │   products   │ 1    * │      variants        │
+│──────────────│◄───────│──────────────│◄───────│──────────────────────│
+│ id           │        │ id           │        │ id                   │
+│ name         │        │ category_id  │        │ product_id           │
+│ station ◄NEW │        │ name         │        │ ...                  │
+│ created_at   │        │ sale_type    │        └──────────┬───────────┘
+│ deleted_at   │        └──────────────┘                   │ 1
+└──────────────┘                                           │
+                                                           │ *
+                                              ┌────────────▼───────────┐
+                                              │   transaction_items    │
+                                              │────────────────────────│
+                                              │ id                     │
+                                              │ transaction_id         │
+                                              │ variant_id             │
+                                              │ product_name           │
+                                              └────────────────────────┘
+```
+
+A transaction item resolves its station by walking
+`transaction_item → variant → product → category → station`. No schema change is
+needed on `transactions` / `transaction_items`; the station is derived, not
+copied. (See §5 for the one nuance this creates.)
+
+### 3. Type changes per layer (the contract is the source of truth)
+
+All of these flow from one edit to `libs/api-contract/src/api.yaml`, then `@kubb`
+regenerates the Go and TS types.
+
+**OpenAPI — `Category` schema** (`api.yaml`, add to `properties` + `required`):
+
+```yaml
+Category:
+  required:
+    - id
+    - name
+    - station        # NEW
+    - createdAt
+  properties:
+    id: { type: integer, format: int64 }
+    name: { type: string }
+    station:         # NEW
+      type: string
+      enum: [KITCHEN, BAR, NONE]
+    createdAt: { type: string, format: date-time }
+    deletedAt: { type: string, format: date-time }
+
+CategoryRequest:
+  required:
+    - name
+    - station        # NEW
+  properties:
+    name: { type: string }
+    station:         # NEW
+      type: string
+      enum: [KITCHEN, BAR, NONE]
+```
+
+**Backend Go — three structs + four transformers must carry the field:**
+
+| Layer | File | Change |
+| --- | --- | --- |
+| Domain entity | `apps/api/domain/category_entity.go` | add `Station string` |
+| DB model | `apps/api/data/mysql/category_entity.go` | add `Station string` |
+| DB ↔ domain | `apps/api/data/mysql/category_transformer.go` | map `Station` in `ToCategoryDB` + `ToCategoryDomain` |
+| domain ↔ API | `apps/api/presentation/restapi/category_transformer.go` | map `Station` in `ToApiCategory` + `ToCategory` (request→domain) |
+
+GORM here uses `db.Table("categories")` with field-name→column mapping, so adding
+`Station` to the struct is enough for it to be selected/inserted/updated — no
+extra tags required.
+
+**Frontend TS — `libs/ui/src/domain/entities/Category.ts`:**
+
+```ts
+export type CategoryStation = 'KITCHEN' | 'BAR' | 'NONE';
+
+export type Category = {
+  id: number;
+  name: string;
+  station: CategoryStation;   // NEW
+  createdAt: string;
+};
+
+export type CategoryForm = {
+  name: string;
+  station: CategoryStation;   // NEW
+};
+```
+
+### 4. Print payload design
+
+The order slip is not rendered by the app — it is serialized to JSON and sent
+over a WebSocket to an external printer service (`ws://localhost:8080`). So
+"two slips" = **two messages, each carrying only that station's items**, plus a
+field telling the service which header to print.
+
+**`libs/ui/src/utils/print.ts` — `PrintPayload` change:**
+
+```ts
+// before
+{ type: 'INVOICE' | 'ORDER_SLIP'; transaction: TransactionPrintPayload }
+
+// after
+| { type: 'INVOICE'; transaction: TransactionPrintPayload }
+| { type: 'ORDER_SLIP';
+    station: 'KITCHEN' | 'BAR';        // NEW — tells the service which slip
+    transaction: TransactionPrintPayload }  // items already filtered to station
+```
+
+> Keeping `type: 'ORDER_SLIP'` + a `station` discriminator (rather than two new
+> types `ORDER_SLIP_KITCHEN` / `ORDER_SLIP_BAR`) is backward compatible and means
+> the printer service only needs to read one new field. Final choice is a
+> coordination point with the printer-service owner.
+
+**Shared helper** (filtering lives in one place, used by both the create flow and
+the list menu):
+
+```ts
+function buildOrderSlipPayload(
+  transaction: Transaction,
+  station: 'KITCHEN' | 'BAR'
+): PrintPayload | null {
+  const items = transaction.transactionItems.filter(
+    (item) => item.variant.product.category.station === station
+  );
+  if (items.length === 0) return null;          // skip empty slip
+  return { type: 'ORDER_SLIP', station, transaction: { ...mapped, items } };
+}
+```
+
+Items whose category station is `NONE` (e.g. Board Game Ticket) match neither
+filter, so they never appear on an order slip — but they still appear on the
+INVOICE, which is unfiltered.
+
+### 5. Data-availability check (important)
+
+For filtering to work at print time, every code path that prints must be able to
+read `item.variant.product.category.station`:
+
+- **Create flow** (`TransactionCreateHandler`): builds the payload from the
+  **form** values (`variant.product...`). The products loaded into the create
+  screen already include their `category`, so the field is present once the TS
+  type carries it. ✅ Low risk.
+- **List menu** (`TransactionListHandler`): builds from the **fetched
+  transaction**. We must confirm the `GET /transactions` (and
+  `/transactions/{id}`) response serializes the nested
+  `transactionItems[].variant.product.category` **including the new `station`
+  field**. Adding `station` to the `Category` schema makes it available wherever
+  Category is already nested; the task is to **verify** it is not stripped by an
+  intermediate transformer. This verification is an explicit step in Phase 1/3.
+
+> Design note: because station is *derived* from the live category, re-printing an
+> old transaction reflects the category's **current** station, not the station at
+> the time of sale. That is the desired behavior here (a slip is an operational
+> routing document, not a historical record), and it avoids denormalizing station
+> onto `transaction_items` the way `product_name` was snapshotted. If historical
+> accuracy were ever required, the alternative would be to copy `station` onto
+> `transaction_items` at creation time — explicitly **not** chosen.
+
+### 6. End-to-end sequence (create flow)
+
+```
+Cashier submits transaction
+        │
+        ▼
+  Payment success
+        │
+        ▼
+  "Print Invoice?" ──Yes──► print({type:'INVOICE', ...all items})
+        │                                │
+        └──No──────────────┐             ▼
+                           ▼     "Print Kitchen Slip?"  (only if kitchen items exist)
+                                          │
+                                   Yes──► print({type:'ORDER_SLIP', station:'KITCHEN', kitchen items})
+                                          │
+                                          ▼
+                                 "Print Bar Slip?"      (only if bar items exist)
+                                          │
+                                   Yes──► print({type:'ORDER_SLIP', station:'BAR', bar items})
+                                          │
+                                          ▼
+                                  navigate to /transactions
+```
+
+The list-menu flow (Phase 5) reuses the same `buildOrderSlipPayload` helper but
+is triggered per-station directly from the menu, with no chained dialogs.
+
+---
+
 ## Phase 1 — Add `station` to Category (backend + contract only)
 
 **Goal:** the data model supports the marking. No UI, no behavior change yet —

--- a/docs/plans/split-order-slip-kitchen-bar.md
+++ b/docs/plans/split-order-slip-kitchen-bar.md
@@ -1,0 +1,162 @@
+# Plan: Split Order Slip into Kitchen & Bar Slips
+
+## Background
+
+Currently, when a transaction is created, a single "order slip" is printed
+containing **all** order items. In reality, after the cashier prints the slip,
+the order has to be communicated to **two separate stations** — the **bar** and
+the **kitchen** — each of which should only see the items it is responsible for
+making.
+
+This plan introduces a way to mark which products belong to the kitchen, which
+belong to the bar, and which belong to neither (e.g. a "Board Game Ticket",
+which is not made by either station). From that marking we produce **two order
+slips** — one for the kitchen and one for the bar — both after creating a
+transaction and from the transaction list menu.
+
+## Design Summary
+
+- **Station lives on `Category`**: add a `station` enum =
+  `KITCHEN | BAR | NONE`. Every product inherits its station from its category.
+  Products in a `NONE` category (e.g. "Board Game Ticket") appear on the invoice
+  but on **neither** order slip.
+- **Print flow after create**: sequential confirmations —
+  *Print Invoice?* → *Print Kitchen Slip?* → *Print Bar Slip?* — where a slip
+  dialog only appears if that station actually has items.
+- **Transaction menu**: replace the single *Print Order Slip* with
+  *Print Kitchen Slip* and *Print Bar Slip*.
+
+### Why station on Category (not Product)?
+
+Products already each belong to exactly one `Category` (many-to-one). Tagging at
+the category level matches how a cafe organizes its menu (Drinks → bar, Food →
+kitchen, Tickets → none) and avoids re-tagging every individual product. New
+products inherit a sensible station automatically from their category.
+
+## Key Facts Driving the Design
+
+- Order slips are rendered by an **external printer service** at
+  `ws://localhost:8080`; the app sends a JSON `PrintPayload`
+  (`libs/ui/src/utils/print.ts`). The `TransactionPrintEmployee.tsx` component is
+  effectively legacy — the service does the actual rendering. So splitting the
+  slip = **filtering `items` by station + telling the service which station** it
+  is.
+- The OpenAPI spec (`libs/api-contract/src/api.yaml`) is the **single source of
+  truth**; backend Go types and frontend TS types/hooks are codegen'd from it via
+  `@kubb`. Any model change starts there.
+- Station must be reachable from a transaction item at print time:
+  `transactionItem.variant.product.category.station`. We must confirm the
+  transaction GET response serializes the nested category (it should once the
+  field is added to the Category schema).
+
+## Relevant Files
+
+| Concern | File |
+| --- | --- |
+| API contract (source of truth) | `libs/api-contract/src/api.yaml` |
+| DB migrations | `apps/api/migrations/` |
+| Category backend entity | `apps/api/domain/category_entity.go` |
+| Category frontend entity | `libs/ui/src/domain/entities/Category.ts` |
+| Print payload + hook | `libs/ui/src/utils/print.ts` |
+| Create-transaction print flow | `libs/ui/src/presentation/screens/TransactionCreateHandler.tsx` |
+| Transaction list print flow | `libs/ui/src/presentation/screens/TransactionListHandler.tsx` |
+| Transaction list item menu | `libs/ui/src/presentation/components/transactions/TransactionListItem.tsx` |
+| Legacy slip template (reference) | `libs/ui/src/presentation/components/transactions/TransactionPrintEmployee.tsx` |
+
+---
+
+## Phase 1 — Add `station` to Category (backend + contract only)
+
+**Goal:** the data model supports the marking. No UI, no behavior change yet —
+a safe, isolated PR.
+
+1. `libs/api-contract/src/api.yaml`: add a `station` enum
+   (`KITCHEN` / `BAR` / `NONE`) to the `Category` response schema and to
+   `CategoryRequest`. Regenerate contracts (Go + TS).
+2. New migration `0000NN_add_category_station.up.sql` / `.down.sql`: add
+   `station VARCHAR(20) NOT NULL DEFAULT 'NONE'` to `categories`. (All existing
+   categories default to `NONE`; staff classify them in Phase 2.)
+3. Backend `apps/api/domain/category_entity.go`: add a `Station` field; thread it
+   through the category repository, usecase, and create/update handlers so it is
+   persisted and returned.
+4. Verify the field is included wherever `Category` is serialized nested
+   (product responses, and transaction-item → variant → product → category).
+
+**Reviewable as:** schema + contract + backend persistence.
+**Tests:** category create/update round-trips `station`.
+
+## Phase 2 — Category admin UI for setting station
+
+**Goal:** staff can tag each category. Still no print change.
+
+1. `libs/ui/src/domain/entities/Category.ts`: add `station` to `Category` and
+   `CategoryForm`.
+2. Category create/edit forms + controllers: add a station `Select`
+   (Kitchen / Bar / None).
+3. Show the station on the category list/detail (small badge) for visibility.
+
+**Reviewable as:** a focused UI PR. After this ships, categories can be
+classified in production ahead of the print change.
+
+## Phase 3 — Station-aware print payload + filtering helper
+
+**Goal:** the core logic to produce a per-station order slip. Pure utility,
+unit-testable in isolation.
+
+1. `libs/ui/src/utils/print.ts`: extend the order-slip payload with a
+   `station: 'KITCHEN' | 'BAR'` field (keep `type: 'ORDER_SLIP'` for backward
+   compatibility, or introduce `ORDER_SLIP_KITCHEN` / `ORDER_SLIP_BAR` — decide
+   with the printer-service owner). The service prints the station as a header.
+2. Add a shared helper, e.g. `buildOrderSlipPayload(transaction, station)`, that
+   **filters items to that station** via `category.station` and returns
+   `null`/empty when no items — so callers can skip empty slips.
+3. **Coordinate the printer service** (separate component/repo) to render the
+   station header. This is an external dependency to flag and scope.
+
+**Reviewable as:** pure utility + types.
+**Tests:** items across stations → correct split; `NONE` excluded from both.
+
+## Phase 4 — Wire the create-transaction flow
+
+**Goal:** sequential confirmations after payment.
+
+1. `TransactionCreateHandler.tsx` (the `payingSuccess` effect): change the chain
+   to *Invoice → Kitchen slip → Bar slip*, each dialog shown only if that station
+   has items (using the Phase 3 helper). Preserve the existing cancel/skip and
+   navigation-to-`/transactions` behavior.
+
+**Reviewable as:** one screen-handler change, behavior visible end-to-end.
+
+## Phase 5 — Wire the transaction-list menu
+
+**Goal:** per-station menu actions.
+
+1. `TransactionListItem.tsx`: replace `onPrintOrderSlipMenuPress` with
+   `onPrintKitchenSlipMenuPress` + `onPrintBarSlipMenuPress` (two "Printer" menu
+   entries, web-only as today). Optionally hide a station's entry when the
+   transaction has no items for it.
+2. `TransactionListHandler.tsx`: implement both handlers using the Phase 3
+   helper.
+
+**Reviewable as:** menu + handler change, mirrors Phase 4.
+
+---
+
+## Sequencing & Risk Notes
+
+- Phases **1 → 2** can ship and let staff classify categories **before** any
+  print behavior changes — a zero-risk rollout.
+- Phases **4 & 5** depend on **3** (and on the printer service being updated). If
+  the printer-service update lags, Phases 4/5 can still send filtered items; only
+  the printed header would be missing.
+- Default `NONE` means that until categories are classified, **both order slips
+  would be empty** — so Phase 2 classification must happen before Phases 4/5
+  reach production. Good candidate for a feature flag, or simply order the merges
+  accordingly.
+
+## Open Coordination Item
+
+The **printer service** at `ws://localhost:8080` is external to this repo's
+frontend. Confirming how it should distinguish/label kitchen vs bar is the one
+cross-team dependency. We should check whether that service lives in an
+accessible repo so its change can be scoped alongside Phase 3.


### PR DESCRIPTION
## Summary

This PR adds a comprehensive planning document for implementing station-aware order slip printing, allowing separate kitchen and bar order slips to be generated from a single transaction.

## Changes

- **New file:** `docs/plans/split-order-slip-kitchen-bar.md`
  - Detailed 5-phase implementation plan for splitting order slips by station (kitchen/bar/none)
  - Design rationale for placing `station` enum on the `Category` model
  - Phase-by-phase breakdown with specific files, responsibilities, and reviewability criteria
  - Risk analysis and sequencing guidance for safe rollout
  - Coordination notes for external printer service dependency

## Key Details

The plan outlines:
1. **Data model change:** Add `station` enum field to `Category` (backend + API contract)
2. **Admin UI:** Category management forms to classify stations
3. **Print utility:** Station-aware filtering and payload building
4. **Integration:** Wire both create-transaction and transaction-list print flows
5. **Rollout strategy:** Phases 1–2 can ship before print behavior changes, reducing risk

The document identifies the printer service at `ws://localhost:8080` as an external dependency requiring coordination and specifies all affected files across the codebase.

https://claude.ai/code/session_0188GLeZgc52WdMJ1hcW6WXn