### PR TITLE
Add station field to category management

### DIFF
--- a/libs/ui/.storybook/mocks/mockData.ts
+++ b/libs/ui/.storybook/mocks/mockData.ts
@@ -22,13 +22,29 @@ import type {
 export const mockCategory: Category = {
   id: 1,
   name: 'Beverages',
+  station: 'BAR',
   createdAt: '2024-01-15T08:00:00.000Z',
 };
 
 export const mockCategories: Category[] = [
-  { id: 1, name: 'Beverages', createdAt: '2024-01-15T08:00:00.000Z' },
-  { id: 2, name: 'Snacks', createdAt: '2024-01-16T08:00:00.000Z' },
-  { id: 3, name: 'Merchandise', createdAt: '2024-01-17T08:00:00.000Z' },
+  {
+    id: 1,
+    name: 'Beverages',
+    station: 'BAR',
+    createdAt: '2024-01-15T08:00:00.000Z',
+  },
+  {
+    id: 2,
+    name: 'Snacks',
+    station: 'KITCHEN',
+    createdAt: '2024-01-16T08:00:00.000Z',
+  },
+  {
+    id: 3,
+    name: 'Merchandise',
+    station: 'NONE',
+    createdAt: '2024-01-17T08:00:00.000Z',
+  },
 ];
 
 // ─── Material ────────────────────────────────────────────────────────────────

--- a/libs/ui/src/data/api/category.transformer.ts
+++ b/libs/ui/src/data/api/category.transformer.ts
@@ -1,8 +1,5 @@
 // eslint-disable-next-line @nx/enforce-module-boundaries
-import {
-  Category as ApiCategory,
-  categoryRequestStation,
-} from '../../../../api-contract/src';
+import { Category as ApiCategory } from '../../../../api-contract/src';
 import { Category, CategoryForm } from '../../domain';
 
 export function toCategory(category: ApiCategory): Category {
@@ -10,12 +7,13 @@ export function toCategory(category: ApiCategory): Category {
     id: category.id,
     createdAt: category.createdAt,
     name: category.name,
+    station: category.station,
   };
 }
 
 export function toApiCategory(form: CategoryForm) {
   return {
     name: form.name,
-    station: categoryRequestStation.NONE,
+    station: form.station,
   };
 }

--- a/libs/ui/src/data/mock/category.ts
+++ b/libs/ui/src/data/mock/category.ts
@@ -1,11 +1,23 @@
 import { Category, CategoryForm } from '../../domain/entities/Category';
 import { CategoryRepository } from '../../domain/repositories/category';
 
+const initialCategories: Category[] = [
+  {
+    id: 1,
+    name: 'Mock Category 1',
+    station: 'NONE',
+    createdAt: '2024-03-20T00:00:00.000Z',
+  },
+  {
+    id: 2,
+    name: 'Mock Category 2',
+    station: 'NONE',
+    createdAt: '2024-03-21T00:00:00.000Z',
+  },
+];
+
 export class MockCategoryRepository implements CategoryRepository {
-  categories: Category[] = [
-    { id: 1, name: 'Mock Category 1', createdAt: '2024-03-20T00:00:00.000Z' },
-    { id: 2, name: 'Mock Category 2', createdAt: '2024-03-21T00:00:00.000Z' },
-  ];
+  categories: Category[] = [...initialCategories];
 
   private nextId = 3;
   private shouldFail = false;
@@ -44,6 +56,7 @@ export class MockCategoryRepository implements CategoryRepository {
     this.categories.push({
       id: this.nextId++,
       name: formValues.name,
+      station: formValues.station,
       createdAt: new Date().toISOString(),
     });
   }
@@ -60,14 +73,12 @@ export class MockCategoryRepository implements CategoryRepository {
     this.categories[idx] = {
       ...this.categories[idx],
       name: formValues.name,
+      station: formValues.station,
     };
   }
 
   reset() {
-    this.categories = [
-      { id: 1, name: 'Mock Category 1', createdAt: '2024-03-20T00:00:00.000Z' },
-      { id: 2, name: 'Mock Category 2', createdAt: '2024-03-21T00:00:00.000Z' },
-    ];
+    this.categories = [...initialCategories];
     this.nextId = 3;
     this.shouldFail = false;
   }

--- a/libs/ui/src/domain/entities/Category.ts
+++ b/libs/ui/src/domain/entities/Category.ts
@@ -1,9 +1,13 @@
+export type CategoryStation = 'KITCHEN' | 'BAR' | 'NONE';
+
 export type Category = {
   id: number;
   name: string;
+  station: CategoryStation;
   createdAt: string;
 };
 
 export type CategoryForm = {
   name: string;
+  station: CategoryStation;
 };

--- a/libs/ui/src/domain/usecases/categoryCreate.test.ts
+++ b/libs/ui/src/domain/usecases/categoryCreate.test.ts
@@ -15,7 +15,7 @@ describe('CategoryCreateUsecase', () => {
 
       expect(tester.state.type).toBe('loaded');
 
-      tester.dispatch({ type: 'SUBMIT', values: { name: 'New Category' } });
+      tester.dispatch({ type: 'SUBMIT', values: { name: 'New Category', station: 'NONE' } });
       expect(tester.state.type).toBe('submitting');
 
       await flushPromises();
@@ -32,7 +32,7 @@ describe('CategoryCreateUsecase', () => {
 
       expect(tester.state.type).toBe('loaded');
 
-      tester.dispatch({ type: 'SUBMIT', values: { name: 'New Category' } });
+      tester.dispatch({ type: 'SUBMIT', values: { name: 'New Category', station: 'NONE' } });
       expect(tester.state.type).toBe('submitting');
 
       await flushPromises();

--- a/libs/ui/src/domain/usecases/categoryCreate.ts
+++ b/libs/ui/src/domain/usecases/categoryCreate.ts
@@ -40,6 +40,7 @@ export class CategoryCreateUsecase extends Usecase<
       errorMessage: null,
       values: {
         name: '',
+        station: 'NONE',
       },
     };
   }

--- a/libs/ui/src/domain/usecases/categoryUpdate.test.ts
+++ b/libs/ui/src/domain/usecases/categoryUpdate.test.ts
@@ -20,7 +20,7 @@ describe('CategoryUpdateUsecase', () => {
       await flushPromises();
       expect(tester.state.type).toBe('loaded');
 
-      tester.dispatch({ type: 'SUBMIT', values: { name: 'Updated Category' } });
+      tester.dispatch({ type: 'SUBMIT', values: { name: 'Updated Category', station: 'NONE' } });
       expect(tester.state.type).toBe('submitting');
 
       await flushPromises();
@@ -61,7 +61,7 @@ describe('CategoryUpdateUsecase', () => {
 
       expect(tester.state.type).toBe('loaded');
 
-      tester.dispatch({ type: 'SUBMIT', values: { name: 'Updated Category' } });
+      tester.dispatch({ type: 'SUBMIT', values: { name: 'Updated Category', station: 'NONE' } });
       expect(tester.state.type).toBe('submitting');
 
       await flushPromises();

--- a/libs/ui/src/domain/usecases/categoryUpdate.ts
+++ b/libs/ui/src/domain/usecases/categoryUpdate.ts
@@ -53,6 +53,7 @@ export class CategoryUpdateUsecase extends Usecase<
       errorMessage: null,
       values: {
         name: this.params.category?.name ?? '',
+        station: this.params.category?.station ?? 'NONE',
       },
     };
   }
@@ -144,6 +145,7 @@ export class CategoryUpdateUsecase extends Usecase<
               type: 'FETCH_SUCCESS',
               values: {
                 name: category.name,
+                station: category.station,
               },
             })
           )

--- a/libs/ui/src/presentation/components/categories/CategoryFormView.stories.tsx
+++ b/libs/ui/src/presentation/components/categories/CategoryFormView.stories.tsx
@@ -6,7 +6,7 @@ import { CategoryFormView } from './CategoryFormView';
 import type { CategoryForm } from '../../../domain';
 
 const LoadedStory = () => {
-  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  const form = useForm<CategoryForm>({ defaultValues: { name: '', station: 'NONE' } });
   return (
     <CategoryFormView
       variant={{ type: 'loaded' }}
@@ -19,7 +19,7 @@ const LoadedStory = () => {
 
 const PopulatedStory = () => {
   const form = useForm<CategoryForm>({
-    defaultValues: { name: 'Beverages' },
+    defaultValues: { name: 'Beverages', station: 'BAR' },
   });
   return (
     <CategoryFormView
@@ -48,7 +48,7 @@ export const Populated: Story = {
 };
 
 const LoadingStory = () => {
-  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  const form = useForm<CategoryForm>({ defaultValues: { name: '', station: 'NONE' } });
   return (
     <CategoryFormView
       variant={{ type: 'loading' }}
@@ -60,7 +60,7 @@ const LoadingStory = () => {
 };
 
 const ErrorStory = () => {
-  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  const form = useForm<CategoryForm>({ defaultValues: { name: '', station: 'NONE' } });
   return (
     <CategoryFormView
       variant={{ type: 'error', onRetryButtonPress: fn() }}
@@ -72,7 +72,7 @@ const ErrorStory = () => {
 };
 
 const SubmitDisabledStory = () => {
-  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  const form = useForm<CategoryForm>({ defaultValues: { name: '', station: 'NONE' } });
   return (
     <CategoryFormView
       variant={{ type: 'loaded' }}

--- a/libs/ui/src/presentation/components/categories/CategoryFormView.tsx
+++ b/libs/ui/src/presentation/components/categories/CategoryFormView.tsx
@@ -1,4 +1,11 @@
-import { Field, FormErrorBanner, InputText, LoadingView, ErrorView } from '../base';
+import {
+  Field,
+  FormErrorBanner,
+  InputText,
+  Select,
+  LoadingView,
+  ErrorView,
+} from '../base';
 import { CategoryForm } from '../../../domain';
 import { FormProvider, UseFormReturn } from 'react-hook-form';
 import { Button, Form, Spinner } from 'tamagui';
@@ -29,6 +36,15 @@ export const CategoryFormView = ({
         <FormErrorBanner message={serverError} />
         <Field name="name" label="Name">
           <InputText />
+        </Field>
+        <Field name="station" label="Station">
+          <Select
+            items={[
+              { label: 'Kitchen', value: 'KITCHEN' },
+              { label: 'Bar', value: 'BAR' },
+              { label: 'None', value: 'NONE' },
+            ]}
+          />
         </Field>
         <Button
           disabled={isSubmitDisabled}

--- a/libs/ui/src/presentation/components/categories/CategoryList.tsx
+++ b/libs/ui/src/presentation/components/categories/CategoryList.tsx
@@ -48,6 +48,7 @@ export const CategoryList = ({
             renderItem={({ item }) => (
               <CategoryListItem
                 name={item.name}
+                station={item.station}
                 onDeleteMenuPress={() => onDeleteMenuPress(item)}
                 onEditMenuPress={() => onEditMenuPress(item)}
                 onPress={() => onItemPress(item)}

--- a/libs/ui/src/presentation/components/categories/CategoryListItem.stories.tsx
+++ b/libs/ui/src/presentation/components/categories/CategoryListItem.stories.tsx
@@ -7,6 +7,7 @@ const meta: Meta<typeof CategoryListItem> = {
   component: CategoryListItem,
   args: {
     name: 'Beverages',
+    station: 'BAR',
     onEditMenuPress: fn(),
     onDeleteMenuPress: fn(),
   },

--- a/libs/ui/src/presentation/components/categories/CategoryListItem.tsx
+++ b/libs/ui/src/presentation/components/categories/CategoryListItem.tsx
@@ -1,15 +1,24 @@
 import { Pencil, Trash } from '@tamagui/lucide-icons';
 import { ListItem } from '../base';
 import { XStackProps } from 'tamagui';
+import { CategoryStation } from '../../../domain';
+
+const stationLabels: Record<CategoryStation, string> = {
+  KITCHEN: 'Kitchen',
+  BAR: 'Bar',
+  NONE: 'None',
+};
 
 export type CategoryListItemProps = {
   name: string;
+  station: CategoryStation;
   onEditMenuPress: () => void;
   onDeleteMenuPress: () => void;
 } & XStackProps;
 
 export const CategoryListItem = ({
   name,
+  station,
   onDeleteMenuPress,
   onEditMenuPress,
   ...xStackProps
@@ -17,6 +26,7 @@ export const CategoryListItem = ({
   return (
     <ListItem
       title={name}
+      subtitle={`Station: ${stationLabels[station]}`}
       thumbnailSrc="https://placehold.jp/120x120.png"
       menus={[
         { title: 'Edit', icon: Pencil, onPress: onEditMenuPress },

--- a/libs/ui/src/presentation/controllers/CategoryCreateController.tsx
+++ b/libs/ui/src/presentation/controllers/CategoryCreateController.tsx
@@ -18,7 +18,12 @@ export const useCategoryCreateController = (usecase: CategoryCreateUsecase) => {
 
   const form = useForm({
     defaultValues: state.values,
-    resolver: zodResolver(z.object({ name: z.string().min(1) })),
+    resolver: zodResolver(
+      z.object({
+        name: z.string().min(1),
+        station: z.enum(['KITCHEN', 'BAR', 'NONE']),
+      })
+    ),
   });
 
   return {

--- a/libs/ui/src/presentation/controllers/CategoryUpdateController.tsx
+++ b/libs/ui/src/presentation/controllers/CategoryUpdateController.tsx
@@ -18,7 +18,12 @@ export const useCategoryUpdateController = (usecase: CategoryUpdateUsecase) => {
 
   const form = useForm({
     defaultValues: state.values,
-    resolver: zodResolver(z.object({ name: z.string().min(1) })),
+    resolver: zodResolver(
+      z.object({
+        name: z.string().min(1),
+        station: z.enum(['KITCHEN', 'BAR', 'NONE']),
+      })
+    ),
   });
 
   return {

--- a/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryCreateHandler.test.tsx
@@ -40,6 +40,13 @@ describe('CategoryCreateHandler', () => {
       render(<CategoryCreateHandler {...createProps()} />);
       expect(screen.getByRole('textbox', { name: 'Name' })).toBeTruthy();
     });
+
+    it('should render the station select field', () => {
+      render(<CategoryCreateHandler {...createProps()} />);
+      expect(screen.getByRole('option', { name: 'Kitchen' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'Bar' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'None' })).toBeTruthy();
+    });
   });
 
   describe('navigation', () => {
@@ -55,6 +62,28 @@ describe('CategoryCreateHandler', () => {
       });
 
       expect(mockRouterPush).toHaveBeenCalledWith('/categories');
+    });
+
+    it('should create category with the selected station', async () => {
+      const user = userEvent.setup();
+      const categoryRepo = new MockCategoryRepository();
+
+      render(
+        <CategoryCreateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          categoryCreateUsecase={new CategoryCreateUsecase(categoryRepo)}
+        />
+      );
+
+      await user.type(screen.getByRole('textbox', { name: 'Name' }), 'New Category');
+      await user.click(screen.getByRole('option', { name: 'Kitchen' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(categoryRepo.categories.at(-1)?.station).toBe('KITCHEN');
     });
 
     it('should not navigate when creation fails', async () => {

--- a/libs/ui/src/presentation/screens/CategoryCreateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CategoryCreateScreen.stories.tsx
@@ -6,7 +6,7 @@ import { CategoryCreateScreen } from './CategoryCreateScreen';
 import type { CategoryForm } from '../../domain';
 
 const CreateStory = () => {
-  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  const form = useForm<CategoryForm>({ defaultValues: { name: '', station: 'NONE' } });
   return (
     <CategoryCreateScreen
       form={form}
@@ -19,7 +19,7 @@ const CreateStory = () => {
 };
 
 const LoadingStory = () => {
-  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  const form = useForm<CategoryForm>({ defaultValues: { name: '', station: 'NONE' } });
   return (
     <CategoryCreateScreen
       form={form}

--- a/libs/ui/src/presentation/screens/CategoryListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryListHandler.test.tsx
@@ -59,6 +59,16 @@ describe('CategoryListHandler', () => {
       expect(screen.getByRole('heading', { name: 'Mock Category 2' })).toBeTruthy();
     });
 
+    it('should show the station for each category', async () => {
+      render(<CategoryListHandler {...createProps()} />);
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(screen.getAllByText('Station: None').length).toBe(2);
+    });
+
     it('should show error state when fetch fails', async () => {
       const categoryRepo = new MockCategoryRepository();
       categoryRepo.setShouldFail(true);

--- a/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/CategoryUpdateHandler.test.tsx
@@ -78,6 +78,16 @@ describe('CategoryUpdateHandler', () => {
       });
     });
 
+    it('should render the station select field with the current value', async () => {
+      render(<CategoryUpdateHandler {...createProps({ preloaded: true })} />);
+      expect(screen.getByRole('option', { name: 'Kitchen' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'Bar' })).toBeTruthy();
+      expect(screen.getByRole('option', { name: 'None' })).toBeTruthy();
+      await act(async () => {
+        await flushPromises();
+      });
+    });
+
     it('should show error state when category fetch fails', async () => {
       render(<CategoryUpdateHandler {...createProps({ shouldFail: true })} />);
 
@@ -104,6 +114,34 @@ describe('CategoryUpdateHandler', () => {
       });
 
       expect(mockRouterPush).toHaveBeenCalledWith('/categories');
+    });
+
+    it('should update category with the selected station', async () => {
+      const user = userEvent.setup();
+      const categoryRepo = new MockCategoryRepository();
+      const preloadedCategory = categoryRepo.categories[0];
+
+      render(
+        <CategoryUpdateHandler
+          authLogoutUsecase={new AuthLogoutUsecase(new MockAuthRepository())}
+          categoryUpdateUsecase={new CategoryUpdateUsecase(categoryRepo, {
+            categoryId: preloadedCategory.id,
+            category: preloadedCategory,
+          })}
+        />
+      );
+
+      await user.click(screen.getByRole('option', { name: 'Bar' }));
+      await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+      await act(async () => {
+        await flushPromises();
+      });
+
+      expect(
+        categoryRepo.categories.find((c) => c.id === preloadedCategory.id)
+          ?.station
+      ).toBe('BAR');
     });
 
     it('should not navigate when update fails', async () => {

--- a/libs/ui/src/presentation/screens/CategoryUpdateScreen.stories.tsx
+++ b/libs/ui/src/presentation/screens/CategoryUpdateScreen.stories.tsx
@@ -6,7 +6,9 @@ import { CategoryUpdateScreen } from './CategoryUpdateScreen';
 import type { CategoryForm } from '../../domain';
 
 const UpdateStory = () => {
-  const form = useForm<CategoryForm>({ defaultValues: { name: 'Beverages' } });
+  const form = useForm<CategoryForm>({
+    defaultValues: { name: 'Beverages', station: 'BAR' },
+  });
   return (
     <CategoryUpdateScreen
       form={form}
@@ -19,7 +21,9 @@ const UpdateStory = () => {
 };
 
 const LoadingStory = () => {
-  const form = useForm<CategoryForm>({ defaultValues: { name: '' } });
+  const form = useForm<CategoryForm>({
+    defaultValues: { name: '', station: 'NONE' },
+  });
   return (
     <CategoryUpdateScreen
       form={form}


### PR DESCRIPTION
## Summary
This PR adds support for managing a `station` field on categories, allowing categories to be assigned to specific stations (Kitchen, Bar, or None). The station field is now part of the category entity, form validation, and UI components throughout the category management flow.

## Key Changes

- **Domain Model**: Added `CategoryStation` type ('KITCHEN' | 'BAR' | 'NONE') and updated `Category` and `CategoryForm` entities to include the `station` field
- **Form Validation**: Updated `CategoryCreateController` and `CategoryUpdateController` to validate the station field using Zod schema
- **UI Components**: 
  - Added a `Select` dropdown in `CategoryFormView` for station selection with three options (Kitchen, Bar, None)
  - Updated `CategoryListItem` to display the station as a subtitle with human-readable labels
  - Updated `CategoryList` to pass the station prop to list items
- **Use Cases**: Modified `CategoryCreateUsecase` and `CategoryUpdateUsecase` to initialize and handle the station field with a default value of 'NONE'
- **API Integration**: Updated `category.transformer.ts` to map the station field from form data to API requests instead of hardcoding 'NONE'
- **Mock Data**: Updated `MockCategoryRepository` and Storybook mock data to include station values for all test categories
- **Tests**: Added comprehensive test coverage for:
  - Rendering station select field in create and update handlers
  - Creating/updating categories with selected station values
  - Displaying station information in category lists
- **Stories**: Updated all Storybook stories to include station field in default form values

## Implementation Details

- Station field defaults to 'NONE' for new categories
- The station value is persisted through the entire create/update flow
- Mock repository properly maintains station values across create, update, and reset operations
- All existing tests updated to include the station field in form submissions

https://claude.ai/code/session_01NKfZnWpnUccSSw2RDGbVjN