### PR TITLE
Add order slip splitting by station functionality

### DIFF
--- a/libs/ui/src/utils/print.test.ts
+++ b/libs/ui/src/utils/print.test.ts
@@ -1,0 +1,106 @@
+import { Variant } from '../domain/entities/Variant';
+import { Category, CategoryStation } from '../domain/entities/Category';
+import { buildOrderSlipPayload, OrderSlipSource } from './print';
+
+const buildCategory = (station: CategoryStation): Category => ({
+  id: 1,
+  name: 'Category',
+  station,
+  createdAt: '2024-01-01T00:00:00.000Z',
+});
+
+const buildVariant = (
+  productName: string,
+  station: CategoryStation
+): Variant => ({
+  id: 1,
+  name: 'Variant',
+  price: 10000,
+  materials: [],
+  product: {
+    id: 1,
+    name: productName,
+    category: buildCategory(station),
+    imageUrl: '',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    options: [],
+    saleType: 'purchase',
+  },
+  createdAt: '2024-01-01T00:00:00.000Z',
+  values: [
+    {
+      id: 1,
+      variantId: 1,
+      optionValueId: 1,
+      optionValue: { id: 1, name: 'Large' },
+    },
+  ],
+  pricingTiers: [],
+});
+
+const buildSource = (
+  items: { productName: string; station: CategoryStation }[]
+): OrderSlipSource => ({
+  createdAt: '17/06/2026 10:00',
+  name: 'Table 1',
+  orderNumber: 1,
+  coupons: [],
+  isCashless: false,
+  paidAmount: 0,
+  items: items.map(({ productName, station }) => ({
+    variant: buildVariant(productName, station),
+    price: 10000,
+    amount: 1,
+    discountAmount: 0,
+    note: '',
+  })),
+});
+
+describe('buildOrderSlipPayload', () => {
+  it('splits items into a KITCHEN slip containing only kitchen items', () => {
+    const transaction = buildSource([
+      { productName: 'Fried Rice', station: 'KITCHEN' },
+      { productName: 'Beer', station: 'BAR' },
+      { productName: 'Board Game Ticket', station: 'NONE' },
+    ]);
+
+    const payload = buildOrderSlipPayload(transaction, 'KITCHEN');
+
+    expect(payload?.type).toBe('ORDER_SLIP');
+    expect(payload && 'station' in payload && payload.station).toBe(
+      'KITCHEN'
+    );
+    expect(payload?.transaction.items).toHaveLength(1);
+    expect(payload?.transaction.items[0].name).toBe('Fried Rice - Large');
+  });
+
+  it('splits items into a BAR slip containing only bar items', () => {
+    const transaction = buildSource([
+      { productName: 'Fried Rice', station: 'KITCHEN' },
+      { productName: 'Beer', station: 'BAR' },
+      { productName: 'Board Game Ticket', station: 'NONE' },
+    ]);
+
+    const payload = buildOrderSlipPayload(transaction, 'BAR');
+
+    expect(payload?.transaction.items).toHaveLength(1);
+    expect(payload?.transaction.items[0].name).toBe('Beer - Large');
+  });
+
+  it('excludes NONE-station items from both slips', () => {
+    const transaction = buildSource([
+      { productName: 'Board Game Ticket', station: 'NONE' },
+    ]);
+
+    expect(buildOrderSlipPayload(transaction, 'KITCHEN')).toBeNull();
+    expect(buildOrderSlipPayload(transaction, 'BAR')).toBeNull();
+  });
+
+  it('returns null when the station has no items', () => {
+    const transaction = buildSource([
+      { productName: 'Beer', station: 'BAR' },
+    ]);
+
+    expect(buildOrderSlipPayload(transaction, 'KITCHEN')).toBeNull();
+  });
+});

--- a/libs/ui/src/utils/print.ts
+++ b/libs/ui/src/utils/print.ts
@@ -1,5 +1,8 @@
 import { useCallback } from 'react';
 import { useToastController } from '@tamagui/toast';
+import { Variant } from '../domain/entities/Variant';
+
+export type OrderSlipStation = 'KITCHEN' | 'BAR';
 
 export type TransactionPrintPayload = {
   createdAt: string;
@@ -47,6 +50,9 @@ export type CheckinPrintPayload = {
 export type PrintPayload =
   | {
       type: 'INVOICE' | 'ORDER_SLIP';
+      // Present once a slip has been split by station (see buildOrderSlipPayload).
+      // Optional for now so existing unsplit ORDER_SLIP call sites still type-check.
+      station?: OrderSlipStation;
       transaction: TransactionPrintPayload;
     }
   | {
@@ -57,6 +63,48 @@ export type PrintPayload =
       type: 'CHECKIN_SLIP';
       checkin: CheckinPrintPayload;
     };
+
+export type OrderSlipSourceItem = {
+  variant: Variant;
+  price: number;
+  amount: number;
+  discountAmount: number;
+  note: string;
+};
+
+export type OrderSlipSource = Omit<TransactionPrintPayload, 'items'> & {
+  items: OrderSlipSourceItem[];
+};
+
+export const buildOrderSlipPayload = (
+  transaction: OrderSlipSource,
+  station: OrderSlipStation
+): PrintPayload | null => {
+  const items = transaction.items.filter(
+    ({ variant }) => variant.product.category.station === station
+  );
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  return {
+    type: 'ORDER_SLIP',
+    station,
+    transaction: {
+      ...transaction,
+      items: items.map(({ variant, price, amount, discountAmount, note }) => ({
+        name: `${variant.product.name} - ${variant.values
+          .map(({ optionValue: { name } }) => name)
+          .join(' - ')}`,
+        price,
+        amount,
+        discountAmount,
+        note,
+      })),
+    },
+  };
+};
 
 export const usePrinter = () => {
   const toast = useToastController();


### PR DESCRIPTION
## Summary
This PR adds functionality to split order slips by station (KITCHEN or BAR), filtering items based on their category's assigned station and generating station-specific print payloads.

## Key Changes
- Added `OrderSlipStation` type to represent valid station types ('KITCHEN' | 'BAR')
- Added `station` field to `PrintPayload` to track which station an order slip is for
- Created `OrderSlipSourceItem` and `OrderSlipSource` types to represent order data before transformation
- Implemented `buildOrderSlipPayload()` function that:
  - Filters items by the requested station
  - Returns `null` if no items match the station
  - Transforms variant data into formatted item names (product name + variant options)
  - Returns a station-specific `PrintPayload` with filtered items
- Added comprehensive test suite covering:
  - Filtering items for specific stations (KITCHEN and BAR)
  - Excluding items with 'NONE' station
  - Returning null when a station has no matching items

## Implementation Details
- The `station` field in `PrintPayload` is optional to maintain backward compatibility with existing unsplit ORDER_SLIP call sites
- Item names are formatted by combining the product name with variant option values (e.g., "Fried Rice - Large")
- The function preserves all transaction metadata while only filtering and transforming the items array

https://claude.ai/code/session_01HGecxjPdrgYNFNvJWfeaJK