### PR TITLE
Split order slip printing into separate kitchen and bar prompts

### DIFF
--- a/libs/ui/src/data/mock/product.ts
+++ b/libs/ui/src/data/mock/product.ts
@@ -5,7 +5,7 @@ const initialProducts: Product[] = [
   {
     id: 1,
     name: 'Product 1',
-    category: { id: 1, name: 'Category 1', createdAt: '2024-03-20T00:00:00.000Z' },
+    category: { id: 1, name: 'Category 1', station: 'NONE' as const, createdAt: '2024-03-20T00:00:00.000Z' },
     imageUrl: 'https://example.com/1.jpg',
     saleType: 'purchase',
     options: [
@@ -23,7 +23,7 @@ const initialProducts: Product[] = [
   {
     id: 2,
     name: 'Product 2',
-    category: { id: 1, name: 'Category 1', createdAt: '2024-03-20T00:00:00.000Z' },
+    category: { id: 1, name: 'Category 1', station: 'NONE' as const, createdAt: '2024-03-20T00:00:00.000Z' },
     imageUrl: 'https://example.com/2.jpg',
     saleType: 'purchase',
     options: [
@@ -94,7 +94,7 @@ export class MockProductRepository implements ProductRepository {
       id: this.nextId++,
       name: formValues.name,
       description: formValues.description,
-      category: { id: formValues.categoryId, name: '', createdAt: new Date().toISOString() },
+      category: { id: formValues.categoryId, name: '', station: 'NONE' as const, createdAt: new Date().toISOString() },
       imageUrl: formValues.imageUrl,
       saleType: formValues.saleType,
       options: [],

--- a/libs/ui/src/data/mock/rental.ts
+++ b/libs/ui/src/data/mock/rental.ts
@@ -14,7 +14,7 @@ const mockVariant = {
   product: {
     id: 1,
     name: 'Product 1',
-    category: { id: 1, name: 'Cat 1', createdAt: '2024-03-20T00:00:00.000Z' },
+    category: { id: 1, name: 'Cat 1', station: 'NONE' as const, createdAt: '2024-03-20T00:00:00.000Z' },
     imageUrl: '',
     createdAt: '2024-03-20T00:00:00.000Z',
     options: [],

--- a/libs/ui/src/data/mock/transaction.ts
+++ b/libs/ui/src/data/mock/transaction.ts
@@ -14,7 +14,7 @@ const mockVariant = {
   product: {
     id: 1,
     name: 'Product 1',
-    category: { id: 1, name: 'Category 1', createdAt: '2024-03-20T00:00:00.000Z' },
+    category: { id: 1, name: 'Category 1', station: 'NONE' as const, createdAt: '2024-03-20T00:00:00.000Z' },
     imageUrl: '',
     saleType: 'purchase' as const,
     options: [],

--- a/libs/ui/src/data/mock/variant.ts
+++ b/libs/ui/src/data/mock/variant.ts
@@ -4,7 +4,7 @@ import { VariantRepository } from '../../domain/repositories/variant';
 const mockProduct = {
   id: 1,
   name: 'Product 1',
-  category: { id: 1, name: 'Category 1', createdAt: '2024-03-20T00:00:00.000Z' },
+  category: { id: 1, name: 'Category 1', station: 'NONE' as const, createdAt: '2024-03-20T00:00:00.000Z' },
   imageUrl: 'https://example.com/1.jpg',
   saleType: 'purchase' as const,
   options: [],

--- a/libs/ui/src/presentation/screens/TransactionCreateHandler.printFlow.test.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateHandler.printFlow.test.tsx
@@ -1,0 +1,264 @@
+import React from 'react';
+import { render, act } from '@testing-library/react';
+import { TransactionCreateHandler } from './TransactionCreateHandler';
+import { Variant } from '../../domain/entities/Variant';
+import { flushPromises } from '../../utils/testUtils';
+
+const mockRouterPush = jest.fn();
+jest.mock('solito/router', () => ({
+  useRouter: () => ({ push: mockRouterPush, replace: jest.fn(), back: jest.fn() }),
+}));
+
+jest.mock('@tamagui/toast', () => ({
+  useToastController: () => ({ show: jest.fn() }),
+}));
+
+const mockPrint = jest.fn().mockResolvedValue(undefined);
+jest.mock('../../utils', () => ({
+  ...jest.requireActual('../../utils'),
+  usePrinter: () => ({ print: mockPrint }),
+}));
+
+const mockConfirmationShow = jest.fn();
+jest.mock('../components', () => ({
+  ...jest.requireActual('../components'),
+  useConfirmationAlert: () => ({ show: mockConfirmationShow }),
+}));
+
+// Avoid rendering the real screen tree — these tests only exercise the
+// payingSuccess print-chain orchestration in the handler.
+jest.mock('./TransactionCreateScreen', () => ({
+  TransactionCreateScreen: () => null,
+}));
+
+const buildVariant = (
+  productName: string,
+  station: 'KITCHEN' | 'BAR' | 'NONE'
+): Variant => ({
+  id: 1,
+  name: 'Variant',
+  price: 10000,
+  materials: [],
+  product: {
+    id: 1,
+    name: productName,
+    category: { id: 1, name: 'Category', station, createdAt: '2024-01-01T00:00:00.000Z' },
+    imageUrl: '',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    options: [],
+    saleType: 'purchase',
+  },
+  createdAt: '2024-01-01T00:00:00.000Z',
+  values: [
+    { id: 1, variantId: 1, optionValueId: 1, optionValue: { id: 1, name: 'Large' } },
+  ],
+  pricingTiers: [],
+});
+
+let transactionItemsValue: {
+  variant: Variant;
+  price: number;
+  amount: number;
+  discountAmount: number;
+  note: string;
+}[] = [];
+
+const transactionCreateCtrl = {
+  state: {
+    type: 'idle' as string,
+    transactionId: null as number | null,
+    values: { transactionItems: [] as never[], transactionCoupons: [] as never[] },
+  },
+  dispatch: jest.fn(),
+  form: {
+    getValues: (key: string) => {
+      if (key === 'name') return 'Table 1';
+      if (key === 'orderNumber') return 1;
+      if (key === 'transactionItems') return transactionItemsValue;
+      if (key === 'transactionCoupons') return [];
+      return undefined;
+    },
+  } as never,
+  isCouponSheetOpen: false,
+  onCouponSheetOpenChange: jest.fn(),
+  onItemCouponSheetOpen: jest.fn(),
+  onAddItem: jest.fn(),
+  onAddCoupon: jest.fn(),
+  onRemoveItemCoupon: jest.fn(),
+  itemsFieldArray: {} as never,
+  couponsFieldArray: {} as never,
+};
+
+const transactionPayCtrl = {
+  state: {
+    type: 'hidden' as string,
+    wallets: [] as { id: number; name: string; isCashless: boolean; isPaymentTarget: boolean }[],
+    transactionTotal: 0,
+    transactionId: null as number | null,
+    paidAmount: 0,
+    walletId: null as number | null,
+  },
+  dispatch: jest.fn(),
+  form: {} as never,
+};
+
+const transactionItemSelectCtrl = {
+  state: {
+    type: 'loaded' as string,
+    products: [] as never[],
+    totalItem: 0,
+    page: 1,
+    itemPerPage: 10,
+    query: '',
+    selectedOptionValues: [] as never[],
+    selectedProduct: null as never,
+    amount: 1,
+  },
+  dispatch: jest.fn(),
+};
+
+const couponListCtrl = {
+  state: { type: 'loaded' as string, coupons: [] as never[] },
+  dispatch: jest.fn(),
+};
+
+const authLogoutCtrl = {
+  state: { type: 'idle' as string },
+  dispatch: jest.fn(),
+};
+
+jest.mock('../controllers', () => ({
+  useTransactionCreateController: () => transactionCreateCtrl,
+  useTransactionItemSelectController: () => transactionItemSelectCtrl,
+  useTransactionPayController: () => transactionPayCtrl,
+  useCouponListController: () => couponListCtrl,
+  useAuthLogoutController: () => authLogoutCtrl,
+}));
+
+const usecaseProps = {
+  transactionCreateUsecase: {} as never,
+  transactionItemSelectUsecase: {} as never,
+  transactionPayUsecase: {} as never,
+  couponListUsecase: {} as never,
+  authLogoutUsecase: {} as never,
+};
+
+const confirmLatestPrompt = async (title: string) => {
+  const call = mockConfirmationShow.mock.calls.find(([params]) => params.title === title);
+  expect(call).toBeDefined();
+  await act(async () => {
+    call?.[0].onConfirm?.();
+    await flushPromises();
+  });
+};
+
+// onCancel chains to the next prompt via a 200ms setTimeout (see
+// TransactionCreateHandler) — wait past it with real timers.
+const cancelLatestPrompt = async (title: string) => {
+  const call = mockConfirmationShow.mock.calls.find(([params]) => params.title === title);
+  expect(call).toBeDefined();
+  await act(async () => {
+    call?.[0].onCancel?.();
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  });
+};
+
+describe('TransactionCreateHandler print flow', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    transactionPayCtrl.state = {
+      type: 'payingSuccess',
+      wallets: [{ id: 1, name: 'Cash', isCashless: false, isPaymentTarget: true }],
+      transactionTotal: 30000,
+      transactionId: 1,
+      paidAmount: 30000,
+      walletId: 1,
+    };
+  });
+
+  it('prompts invoice, kitchen slip, and bar slip in sequence when both stations have items', async () => {
+    transactionItemsValue = [
+      { variant: buildVariant('Fried Rice', 'KITCHEN'), price: 10000, amount: 1, discountAmount: 0, note: '' },
+      { variant: buildVariant('Beer', 'BAR'), price: 20000, amount: 1, discountAmount: 0, note: '' },
+    ];
+
+    await act(async () => {
+      render(<TransactionCreateHandler {...usecaseProps} />);
+      await flushPromises();
+    });
+
+    await confirmLatestPrompt('Print Invoice');
+    expect(mockPrint).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'INVOICE' })
+    );
+
+    await confirmLatestPrompt('Print Kitchen Slip');
+    expect(mockPrint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ORDER_SLIP',
+        station: 'KITCHEN',
+        transaction: expect.objectContaining({
+          items: [expect.objectContaining({ name: 'Fried Rice - Large' })],
+        }),
+      })
+    );
+
+    await confirmLatestPrompt('Print Bar Slip');
+    expect(mockPrint).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'ORDER_SLIP',
+        station: 'BAR',
+        transaction: expect.objectContaining({
+          items: [expect.objectContaining({ name: 'Beer - Large' })],
+        }),
+      })
+    );
+
+    expect(mockPrint).toHaveBeenCalledTimes(3);
+    expect(mockRouterPush).toHaveBeenCalledWith('/transactions');
+  });
+
+  it('skips the kitchen slip prompt when there are no kitchen items', async () => {
+    transactionItemsValue = [
+      { variant: buildVariant('Beer', 'BAR'), price: 20000, amount: 1, discountAmount: 0, note: '' },
+      { variant: buildVariant('Board Game Ticket', 'NONE'), price: 10000, amount: 1, discountAmount: 0, note: '' },
+    ];
+
+    await act(async () => {
+      render(<TransactionCreateHandler {...usecaseProps} />);
+      await flushPromises();
+    });
+
+    await confirmLatestPrompt('Print Invoice');
+
+    expect(mockConfirmationShow).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Print Kitchen Slip' })
+    );
+
+    await confirmLatestPrompt('Print Bar Slip');
+
+    expect(mockPrint).toHaveBeenCalledTimes(2);
+    expect(mockRouterPush).toHaveBeenCalledWith('/transactions');
+  });
+
+  it('navigates to /transactions when every slip prompt is cancelled', async () => {
+    transactionItemsValue = [
+      { variant: buildVariant('Fried Rice', 'KITCHEN'), price: 10000, amount: 1, discountAmount: 0, note: '' },
+    ];
+
+    await act(async () => {
+      render(<TransactionCreateHandler {...usecaseProps} />);
+      await flushPromises();
+    });
+
+    await cancelLatestPrompt('Print Invoice');
+    await cancelLatestPrompt('Print Kitchen Slip');
+
+    // No bar items, so the bar prompt is skipped entirely and we navigate away.
+    expect(mockConfirmationShow).not.toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Print Bar Slip' })
+    );
+    expect(mockPrint).not.toHaveBeenCalled();
+    expect(mockRouterPush).toHaveBeenCalledWith('/transactions');
+  });
+});

--- a/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateHandler.tsx
@@ -19,6 +19,8 @@ import {
   TransactionCreateScreenProps,
 } from './TransactionCreateScreen';
 import {
+  buildOrderSlipPayload,
+  OrderSlipSource,
   roundToNearest500,
   TransactionPrintPayload,
   usePrinter,
@@ -107,17 +109,19 @@ export const TransactionCreateHandler = ({
       transactionPayController.state.type === 'payingSuccess' &&
       selectedWallet
     ) {
+      const transactionItems = transactionCreateController.form
+        .getValues('transactionItems')
+        .sort((a, b) =>
+          a.variant.product.name.localeCompare(b.variant.product.name)
+        );
+
       const transaction: TransactionPrintPayload = {
         createdAt: dayjs(new Date().toISOString()).format('DD/MM/YYYY HH:mm'),
         paidAt: dayjs(new Date().toISOString()).format('DD/MM/YYYY HH:mm'),
         name: transactionCreateController.form.getValues('name'),
         orderNumber: transactionCreateController.form.getValues('orderNumber'),
-        items: transactionCreateController.form
-          .getValues('transactionItems')
-          .sort((a, b) =>
-            a.variant.product.name.localeCompare(b.variant.product.name)
-          )
-          .map(({ variant, price, amount, discountAmount, note }) => ({
+        items: transactionItems.map(
+          ({ variant, price, amount, discountAmount, note }) => ({
             name: `${variant.product.name} - ${variant.values
               .map(({ optionValue: { name } }) => name)
               .join(' - ')}`,
@@ -125,7 +129,8 @@ export const TransactionCreateHandler = ({
             amount,
             discountAmount,
             note,
-          })),
+          })
+        ),
         coupons: transactionCreateController.form
           .getValues('transactionCoupons')
           .map(({ coupon }) => ({
@@ -137,41 +142,57 @@ export const TransactionCreateHandler = ({
         paidAmount: transactionPayController.state.paidAmount,
       };
 
+      const orderSlipSource: OrderSlipSource = {
+        ...transaction,
+        items: transactionItems,
+      };
+
+      const kitchenSlip = buildOrderSlipPayload(orderSlipSource, 'KITCHEN');
+      const barSlip = buildOrderSlipPayload(orderSlipSource, 'BAR');
+
+      const promptBarSlip = () => {
+        if (!barSlip) {
+          router.push('/transactions');
+          return;
+        }
+
+        show({
+          title: 'Print Bar Slip',
+          description: 'Do you want to print bar slip ?',
+          onConfirm: () => {
+            print(barSlip).then(() => router.push('/transactions'));
+          },
+          onCancel: () => router.push('/transactions'),
+        });
+      };
+
+      const promptKitchenSlip = () => {
+        if (!kitchenSlip) {
+          promptBarSlip();
+          return;
+        }
+
+        show({
+          title: 'Print Kitchen Slip',
+          description: 'Do you want to print kitchen slip ?',
+          onConfirm: () => {
+            print(kitchenSlip).then(promptBarSlip);
+          },
+          onCancel: () => setTimeout(promptBarSlip, 200),
+        });
+      };
+
       show({
         title: 'Print Invoice',
         description: 'Do you want to print invoice ?',
         onConfirm: () => {
           print({ type: 'INVOICE', transaction })
-            .then(() => {
-              show({
-                title: 'Print Order Slip',
-                description: 'Do you want to print order slip ?',
-                onConfirm: () => {
-                  print({ type: 'ORDER_SLIP', transaction }).then(() => {
-                    router.push('/transactions');
-                  });
-                },
-                onCancel: () => router.push('/transactions'),
-              });
-            })
+            .then(promptKitchenSlip)
             .catch(() => {
               router.push('/transactions');
             });
         },
-        onCancel: () => {
-          setTimeout(() => {
-            show({
-              title: 'Print Order Slip',
-              description: 'Do you want to print order slip ?',
-              onConfirm: () => {
-                print({ type: 'ORDER_SLIP', transaction }).then(() => {
-                  router.push('/transactions');
-                });
-              },
-              onCancel: () => router.push('/transactions'),
-            });
-          }, 200);
-        },
+        onCancel: () => setTimeout(promptKitchenSlip, 200),
       });
     }
   }, [


### PR DESCRIPTION
## Summary
Refactored the transaction payment success flow to prompt users separately for kitchen and bar slip printing, rather than a single generic order slip prompt. This allows for more granular control over which slips are printed based on the items in the transaction.

## Key Changes
- **Separated order slip prompts**: Split the single "Print Order Slip" prompt into separate "Print Kitchen Slip" and "Print Bar Slip" prompts that are shown conditionally based on whether the transaction contains items for each station
- **Added `buildOrderSlipPayload` utility**: Introduced a new function to build station-specific order slip payloads, filtering items by their product's station category
- **Updated `OrderSlipSource` type**: Created a new type to represent the source data needed for building order slips, including the full transaction items with variant information
- **Enhanced print flow orchestration**: Implemented a chained prompt system where:
  - Invoice prompt is shown first
  - Kitchen slip prompt is shown only if kitchen items exist
  - Bar slip prompt is shown only if bar items exist
  - Navigation to `/transactions` occurs after all applicable prompts are completed or cancelled
- **Updated mock data**: Added `station` field to category objects in mock data files to support the new station-based filtering logic

## Notable Implementation Details
- The prompt chain uses nested callback functions (`promptBarSlip` and `promptKitchenSlip`) to handle the sequential flow
- When a prompt is cancelled, a 200ms `setTimeout` is used before showing the next prompt to ensure proper async handling
- Items are filtered by station using the `buildOrderSlipPayload` function, which only includes items whose product category matches the target station
- Comprehensive test coverage added with 3 test cases covering: both stations present, missing kitchen items, and all prompts cancelled

https://claude.ai/code/session_01C6tam7VNE1LZExDKQsmzMf