### PR TITLE
Add date range filtering to transaction statistics API

### DIFF
--- a/apps/api/data/mock/transaction_repository.go
+++ b/apps/api/data/mock/transaction_repository.go
@@ -131,18 +131,18 @@ func (mr *MockTransactionRepositoryMockRecorder) GetTransactionListTotal(ctx, qu
 }
 
 // GetTransactionStatistics mocks base method.
-func (m *MockTransactionRepository) GetTransactionStatistics(ctx context.Context, groupBy string) ([]domain.TransactionStatistic, *domain.Error) {
+func (m *MockTransactionRepository) GetTransactionStatistics(ctx context.Context, groupBy string, startDate, endDate *time.Time) ([]domain.TransactionStatistic, *domain.Error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTransactionStatistics", ctx, groupBy)
+	ret := m.ctrl.Call(m, "GetTransactionStatistics", ctx, groupBy, startDate, endDate)
 	ret0, _ := ret[0].([]domain.TransactionStatistic)
 	ret1, _ := ret[1].(*domain.Error)
 	return ret0, ret1
 }
 
 // GetTransactionStatistics indicates an expected call of GetTransactionStatistics.
-func (mr *MockTransactionRepositoryMockRecorder) GetTransactionStatistics(ctx, groupBy any) *gomock.Call {
+func (mr *MockTransactionRepositoryMockRecorder) GetTransactionStatistics(ctx, groupBy, startDate, endDate any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactionStatistics", reflect.TypeOf((*MockTransactionRepository)(nil).GetTransactionStatistics), ctx, groupBy)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactionStatistics", reflect.TypeOf((*MockTransactionRepository)(nil).GetTransactionStatistics), ctx, groupBy, startDate, endDate)
 }
 
 // PayTransaction mocks base method.

--- a/apps/api/data/mysql/transaction_repo.go
+++ b/apps/api/data/mysql/transaction_repo.go
@@ -190,7 +190,7 @@ func (repo Repository) UnpayTransaction(ctx context.Context, id int64) *domain.E
 	return ToErrorCtx(ctx, result.Error, "UnpayTransaction")
 }
 
-func (repo Repository) GetTransactionStatistics(ctx context.Context, groupBy string) ([]domain.TransactionStatistic, *domain.Error) {
+func (repo Repository) GetTransactionStatistics(ctx context.Context, groupBy string, startDate *time.Time, endDate *time.Time) ([]domain.TransactionStatistic, *domain.Error) {
 	db := GetDbFromCtx(ctx, repo.db)
 
 	dateFormat := ""
@@ -201,8 +201,22 @@ func (repo Repository) GetTransactionStatistics(ctx context.Context, groupBy str
 		dateFormat = "%m-%Y"
 	}
 
+	groupExpr := fmt.Sprintf("DATE_FORMAT(created_at, '%s')", dateFormat)
+
+	query := db.Table("transactions").
+		Select(fmt.Sprintf("%s as date, SUM(total) as total, SUM(total_income) as total_income", groupExpr)).
+		Where("deleted_at is NULL")
+
+	if startDate != nil {
+		query = query.Where("created_at >= ?", *startDate)
+	}
+
+	if endDate != nil {
+		query = query.Where("created_at < ?", endDate.AddDate(0, 0, 1))
+	}
+
 	var transactionStatistics []TransactionStatistic
-	result := db.Table("transactions").Select(fmt.Sprintf("DATE_FORMAT(created_at, '%s') as date, SUM(total) as total, SUM(total_income) as total_income", dateFormat)).Where("deleted_at is NULL").Group(fmt.Sprintf("DATE_FORMAT(created_at, '%s')", dateFormat)).Find(&transactionStatistics)
+	result := query.Group(groupExpr).Order("MIN(created_at) ASC").Find(&transactionStatistics)
 
 	return ToTransactionStatisticsListDomain(transactionStatistics), ToErrorCtx(ctx, result.Error, "GetTransactionStatistics")
 }

--- a/apps/api/data/mysql/transaction_repo_test.go
+++ b/apps/api/data/mysql/transaction_repo_test.go
@@ -201,3 +201,84 @@ func TestTransactionRepository_WholeBillCouponRoundTrip(t *testing.T) {
 	require.Len(t, reloaded.TransactionCoupons, 1)
 	assert.Nil(t, reloaded.TransactionCoupons[0].TransactionItemId)
 }
+
+// createTransactionAt creates a transaction via the repository and then
+// backdates its created_at with a raw UPDATE, since CreateTransaction always
+// stamps "now" and the statistics tests need deterministic, spread-out dates.
+func createTransactionAt(t *testing.T, db *gorm.DB, transactionRepo domain.TransactionRepository, name string, total float32, createdAt time.Time) int64 {
+	t.Helper()
+
+	created, err := transactionRepo.CreateTransaction(context.Background(), domain.Transaction{Name: name, Total: total})
+	require.Nil(t, err)
+	t.Cleanup(func() { db.Exec("DELETE FROM transactions WHERE id = ?", created.Id) })
+
+	require.NoError(t, db.Exec("UPDATE transactions SET created_at = ? WHERE id = ?", createdAt, created.Id).Error)
+
+	return created.Id
+}
+
+// TestTransactionRepository_GetTransactionStatistics_RangeAndOrdering covers
+// Phase 1 of the dashboard date-range filter (PRD FR-1/FR-2): bounded results,
+// inclusive endDate, and chronological (not string) ordering across the
+// year boundary that exposes the "01-2025" < "12-2024" string-sort bug.
+func TestTransactionRepository_GetTransactionStatistics_RangeAndOrdering(t *testing.T) {
+	db := setupTestDB(t)
+	ctx := context.Background()
+	transactionRepo := mysql.NewTransactionRepository(db)
+
+	dec := createTransactionAt(t, db, transactionRepo, "Stats Dec 2024", 100, time.Date(2024, 12, 15, 10, 0, 0, 0, time.Local))
+	jan10 := createTransactionAt(t, db, transactionRepo, "Stats Jan 10 2025", 200, time.Date(2025, 1, 10, 10, 0, 0, 0, time.Local))
+	jan20 := createTransactionAt(t, db, transactionRepo, "Stats Jan 20 2025", 300, time.Date(2025, 1, 20, 23, 59, 0, 0, time.Local))
+	feb := createTransactionAt(t, db, transactionRepo, "Stats Feb 2025", 400, time.Date(2025, 2, 5, 10, 0, 0, 0, time.Local))
+	_ = dec
+	_ = jan10
+	_ = jan20
+	_ = feb
+
+	t.Run("month grouping orders chronologically across year boundary", func(t *testing.T) {
+		stats, err := transactionRepo.GetTransactionStatistics(ctx, "month", nil, nil)
+		require.Nil(t, err)
+		require.True(t, len(stats) >= 2)
+
+		decIndex, janIndex := -1, -1
+		for i, s := range stats {
+			if s.Date == "12-2024" {
+				decIndex = i
+			}
+			if s.Date == "01-2025" {
+				janIndex = i
+			}
+		}
+		require.NotEqual(t, -1, decIndex, "expected 12-2024 in results")
+		require.NotEqual(t, -1, janIndex, "expected 01-2025 in results")
+		assert.Less(t, decIndex, janIndex, "12-2024 must come before 01-2025 in real chronological order")
+	})
+
+	t.Run("bounded range excludes rows outside the window", func(t *testing.T) {
+		startDate := time.Date(2025, 1, 1, 0, 0, 0, 0, time.Local)
+		endDate := time.Date(2025, 1, 31, 0, 0, 0, 0, time.Local)
+
+		stats, err := transactionRepo.GetTransactionStatistics(ctx, "date", &startDate, &endDate)
+		require.Nil(t, err)
+
+		var total int32
+		for _, s := range stats {
+			total += s.Total
+		}
+		assert.Equal(t, int32(500), total, "expected only the two January transactions (200 + 300)")
+	})
+
+	t.Run("inclusive endDate includes the whole day", func(t *testing.T) {
+		startDate := time.Date(2025, 1, 20, 0, 0, 0, 0, time.Local)
+		endDate := time.Date(2025, 1, 20, 0, 0, 0, 0, time.Local)
+
+		stats, err := transactionRepo.GetTransactionStatistics(ctx, "date", &startDate, &endDate)
+		require.Nil(t, err)
+
+		var total int32
+		for _, s := range stats {
+			total += s.Total
+		}
+		assert.Equal(t, int32(300), total, "endDate=2025-01-20 must include the 23:59 transaction on that day")
+	})
+}

--- a/apps/api/domain/transaction_repository.go
+++ b/apps/api/domain/transaction_repository.go
@@ -17,5 +17,5 @@ type TransactionRepository interface {
 	DeleteTransactionById(ctx context.Context, id int64) *Error
 	PayTransaction(ctx context.Context, walletId int64, paidAt time.Time, paidAmount float32, id int64) *Error
 	UnpayTransaction(ctx context.Context, id int64) *Error
-	GetTransactionStatistics(ctx context.Context, groupBy string) ([]TransactionStatistic, *Error)
+	GetTransactionStatistics(ctx context.Context, groupBy string, startDate *time.Time, endDate *time.Time) ([]TransactionStatistic, *Error)
 }

--- a/apps/api/domain/transaction_usecase.go
+++ b/apps/api/domain/transaction_usecase.go
@@ -342,8 +342,12 @@ func (usecase TransactionUsecase) UnpayTransaction(ctx context.Context, id int64
 	})
 }
 
-func (usecase TransactionUsecase) GetTransactionStatistics(ctx context.Context, groupBy string) ([]TransactionStatistic, *Error) {
-	return usecase.transactionRepository.GetTransactionStatistics(ctx, groupBy)
+func (usecase TransactionUsecase) GetTransactionStatistics(ctx context.Context, groupBy string, startDate *time.Time, endDate *time.Time) ([]TransactionStatistic, *Error) {
+	if startDate != nil && endDate != nil && startDate.After(*endDate) {
+		return []TransactionStatistic{}, &Error{Type: BadRequest, Message: "startDate must be on or before endDate"}
+	}
+
+	return usecase.transactionRepository.GetTransactionStatistics(ctx, groupBy, startDate, endDate)
 }
 
 // applyTransactionCoupons resolves each TransactionCoupon against the coupon

--- a/apps/api/domain/transaction_usecase_test.go
+++ b/apps/api/domain/transaction_usecase_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/mock/gomock"
 )
 
@@ -829,10 +830,19 @@ func TestTransactionUsecase_CreateTransaction_ItemCoupon(t *testing.T) {
 	})
 }
 
+func mustParseDate(t *testing.T, s string) *time.Time {
+	t.Helper()
+	parsed, err := time.Parse("2006-01-02", s)
+	require.NoError(t, err)
+	return &parsed
+}
+
 func TestTransactionUsecase_GetTransactionStatistics(t *testing.T) {
 	tests := []struct {
 		name          string
 		groupBy       string
+		startDate     func(t *testing.T) *time.Time
+		endDate       func(t *testing.T) *time.Time
 		setupMock     func(txRepo *mock.MockTransactionRepository)
 		expectedLen   int
 		expectedError *domain.Error
@@ -841,7 +851,7 @@ func TestTransactionUsecase_GetTransactionStatistics(t *testing.T) {
 			name:    "success",
 			groupBy: "day",
 			setupMock: func(txRepo *mock.MockTransactionRepository) {
-				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), "day").Return([]domain.TransactionStatistic{{Total: 100000}}, nil)
+				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), "day", (*time.Time)(nil), (*time.Time)(nil)).Return([]domain.TransactionStatistic{{Total: 100000}}, nil)
 			},
 			expectedLen: 1,
 		},
@@ -849,9 +859,37 @@ func TestTransactionUsecase_GetTransactionStatistics(t *testing.T) {
 			name:    "repo error",
 			groupBy: "day",
 			setupMock: func(txRepo *mock.MockTransactionRepository) {
-				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), "day").Return(nil, &domain.Error{Type: domain.InternalServerError})
+				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), "day", (*time.Time)(nil), (*time.Time)(nil)).Return(nil, &domain.Error{Type: domain.InternalServerError})
 			},
 			expectedError: &domain.Error{Type: domain.InternalServerError},
+		},
+		{
+			name:      "both empty delegates unchanged",
+			groupBy:   "",
+			startDate: func(t *testing.T) *time.Time { return nil },
+			endDate:   func(t *testing.T) *time.Time { return nil },
+			setupMock: func(txRepo *mock.MockTransactionRepository) {
+				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), "", (*time.Time)(nil), (*time.Time)(nil)).Return([]domain.TransactionStatistic{{Total: 100000}}, nil)
+			},
+			expectedLen: 1,
+		},
+		{
+			name:      "valid range forwarded to repo",
+			groupBy:   "date",
+			startDate: func(t *testing.T) *time.Time { return mustParseDate(t, "2024-01-01") },
+			endDate:   func(t *testing.T) *time.Time { return mustParseDate(t, "2024-01-31") },
+			setupMock: func(txRepo *mock.MockTransactionRepository) {
+				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), "date", mustParseDate(t, "2024-01-01"), mustParseDate(t, "2024-01-31")).Return([]domain.TransactionStatistic{{Total: 100000}}, nil)
+			},
+			expectedLen: 1,
+		},
+		{
+			name:          "startDate after endDate returns bad request",
+			groupBy:       "date",
+			startDate:     func(t *testing.T) *time.Time { return mustParseDate(t, "2024-02-01") },
+			endDate:       func(t *testing.T) *time.Time { return mustParseDate(t, "2024-01-01") },
+			setupMock:     func(txRepo *mock.MockTransactionRepository) {},
+			expectedError: &domain.Error{Type: domain.BadRequest},
 		},
 	}
 
@@ -867,8 +905,16 @@ func TestTransactionUsecase_GetTransactionStatistics(t *testing.T) {
 			budgetRepo := mock.NewMockBudgetRepository(ctrl)
 			tt.setupMock(txRepo)
 
+			var startDate, endDate *time.Time
+			if tt.startDate != nil {
+				startDate = tt.startDate(t)
+			}
+			if tt.endDate != nil {
+				endDate = tt.endDate(t)
+			}
+
 			usecase := domain.NewTransactionUsecase(txRepo, variantRepo, couponRepo, walletRepo, budgetRepo)
-			result, err := usecase.GetTransactionStatistics(context.Background(), tt.groupBy)
+			result, err := usecase.GetTransactionStatistics(context.Background(), tt.groupBy, startDate, endDate)
 
 			if tt.expectedError != nil {
 				assert.NotNil(t, err)

--- a/apps/api/presentation/restapi/base_transformers.go
+++ b/apps/api/presentation/restapi/base_transformers.go
@@ -5,11 +5,13 @@ import (
 	"apps/api/pkg/logger"
 	"context"
 	"encoding/json"
+	"fmt"
 	apiContract "libs/api-contract"
 	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 )
 
 func WriteError(ctx context.Context, w http.ResponseWriter, err apiContract.Error) {
@@ -112,6 +114,28 @@ func GetQuery(r *http.Request) string {
 
 func GetGroupBy(r *http.Request) string {
 	return r.URL.Query().Get("groupBy")
+}
+
+func GetStartDate(r *http.Request) (*time.Time, error) {
+	return parseDateQuery(r, "startDate")
+}
+
+func GetEndDate(r *http.Request) (*time.Time, error) {
+	return parseDateQuery(r, "endDate")
+}
+
+func parseDateQuery(r *http.Request, param string) (*time.Time, error) {
+	value := r.URL.Query().Get(param)
+	if value == "" {
+		return nil, nil
+	}
+
+	parsed, err := time.Parse("2006-01-02", value)
+	if err != nil {
+		return nil, fmt.Errorf("%s must be YYYY-MM-DD", param)
+	}
+
+	return &parsed, nil
 }
 
 func GetLimit(r *http.Request) (int, error) {

--- a/apps/api/presentation/restapi/transaction_handler.go
+++ b/apps/api/presentation/restapi/transaction_handler.go
@@ -172,7 +172,19 @@ func (handler TransactionHandler) GetTransactionStatistics(w http.ResponseWriter
 
 	groupBy := GetGroupBy(r)
 
-	transactionStatistics, err := handler.usecase.GetTransactionStatistics(ctx, groupBy)
+	startDate, parseErr := GetStartDate(r)
+	if parseErr != nil {
+		WriteError(ctx, w, apiContract.Error{Code: apiContract.BAD_REQUEST, Message: parseErr.Error()})
+		return
+	}
+
+	endDate, parseErr := GetEndDate(r)
+	if parseErr != nil {
+		WriteError(ctx, w, apiContract.Error{Code: apiContract.BAD_REQUEST, Message: parseErr.Error()})
+		return
+	}
+
+	transactionStatistics, err := handler.usecase.GetTransactionStatistics(ctx, groupBy, startDate, endDate)
 	if err != nil {
 		WriteError(ctx, w, apiContract.Error{Code: ToErrorCode(err.Type), Message: err.Message})
 		return

--- a/apps/api/presentation/restapi/transaction_handler_test.go
+++ b/apps/api/presentation/restapi/transaction_handler_test.go
@@ -377,22 +377,54 @@ func TestTransactionHandler_UnpayTransaction(t *testing.T) {
 func TestTransactionHandler_GetTransactionStatistics(t *testing.T) {
 	tests := []struct {
 		name           string
+		url            string
 		setupMocks     func(txRepo *mock.MockTransactionRepository, variantRepo *mock.MockVariantRepository, couponRepo *mock.MockCouponRepository, walletRepo *mock.MockWalletRepository, budgetRepo *mock.MockBudgetRepository)
 		expectedStatus int
 	}{
 		{
 			name: "success",
+			url:  "/transactions/statistics",
 			setupMocks: func(txRepo *mock.MockTransactionRepository, variantRepo *mock.MockVariantRepository, couponRepo *mock.MockCouponRepository, walletRepo *mock.MockWalletRepository, budgetRepo *mock.MockBudgetRepository) {
-				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), gomock.Any()).Return([]domain.TransactionStatistic{{Date: "2024-01", Total: 10000}}, nil)
+				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]domain.TransactionStatistic{{Date: "2024-01", Total: 10000}}, nil)
 			},
 			expectedStatus: http.StatusOK,
 		},
 		{
 			name: "repo error",
+			url:  "/transactions/statistics",
 			setupMocks: func(txRepo *mock.MockTransactionRepository, variantRepo *mock.MockVariantRepository, couponRepo *mock.MockCouponRepository, walletRepo *mock.MockWalletRepository, budgetRepo *mock.MockBudgetRepository) {
-				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), gomock.Any()).Return(nil, &domain.Error{Type: domain.InternalServerError, Message: "db error"})
+				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, &domain.Error{Type: domain.InternalServerError, Message: "db error"})
 			},
 			expectedStatus: http.StatusInternalServerError,
+		},
+		{
+			name: "valid range",
+			url:  "/transactions/statistics?startDate=2024-01-01&endDate=2024-01-31",
+			setupMocks: func(txRepo *mock.MockTransactionRepository, variantRepo *mock.MockVariantRepository, couponRepo *mock.MockCouponRepository, walletRepo *mock.MockWalletRepository, budgetRepo *mock.MockBudgetRepository) {
+				txRepo.EXPECT().GetTransactionStatistics(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return([]domain.TransactionStatistic{{Date: "2024-01", Total: 10000}}, nil)
+			},
+			expectedStatus: http.StatusOK,
+		},
+		{
+			name: "malformed startDate",
+			url:  "/transactions/statistics?startDate=not-a-date",
+			setupMocks: func(txRepo *mock.MockTransactionRepository, variantRepo *mock.MockVariantRepository, couponRepo *mock.MockCouponRepository, walletRepo *mock.MockWalletRepository, budgetRepo *mock.MockBudgetRepository) {
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "malformed endDate",
+			url:  "/transactions/statistics?endDate=not-a-date",
+			setupMocks: func(txRepo *mock.MockTransactionRepository, variantRepo *mock.MockVariantRepository, couponRepo *mock.MockCouponRepository, walletRepo *mock.MockWalletRepository, budgetRepo *mock.MockBudgetRepository) {
+			},
+			expectedStatus: http.StatusBadRequest,
+		},
+		{
+			name: "startDate after endDate",
+			url:  "/transactions/statistics?startDate=2024-02-01&endDate=2024-01-01",
+			setupMocks: func(txRepo *mock.MockTransactionRepository, variantRepo *mock.MockVariantRepository, couponRepo *mock.MockCouponRepository, walletRepo *mock.MockWalletRepository, budgetRepo *mock.MockBudgetRepository) {
+			},
+			expectedStatus: http.StatusBadRequest,
 		},
 	}
 
@@ -400,7 +432,7 @@ func TestTransactionHandler_GetTransactionStatistics(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			handler, ctrl := newTransactionHandler(t, tt.setupMocks)
 			defer ctrl.Finish()
-			req := httptest.NewRequest(http.MethodGet, "/transactions/statistics", nil)
+			req := httptest.NewRequest(http.MethodGet, tt.url, nil)
 			w := httptest.NewRecorder()
 			handler.GetTransactionStatistics(w, req)
 			assert.Equal(t, tt.expectedStatus, w.Code)


### PR DESCRIPTION
## Summary
This PR adds optional date range filtering (`startDate` and `endDate` query parameters) to the transaction statistics endpoint, enabling users to view aggregated transaction data within a specific time window. It also fixes a chronological ordering bug that occurred when grouping by month across year boundaries.

## Key Changes

- **API Handler**: Added query parameter parsing for `startDate` and `endDate` in `GetTransactionStatistics` with validation for malformed dates
- **Repository Layer**: Updated `GetTransactionStatistics` to accept optional `startDate` and `endDate` parameters and apply them as WHERE clause filters
- **Usecase Layer**: Added validation to ensure `startDate` is not after `endDate`, returning a `BadRequest` error if violated
- **Query Ordering**: Fixed chronological ordering by adding `ORDER BY MIN(created_at) ASC` to ensure correct month ordering across year boundaries (e.g., "12-2024" before "01-2025")
- **Date Range Logic**: Implemented inclusive `endDate` handling by querying up to the start of the next day (`endDate.AddDate(0, 0, 1)`)
- **Helper Functions**: Added `parseDateQuery`, `GetStartDate`, and `GetEndDate` utility functions in `base_transformers.go` for consistent date parsing (YYYY-MM-DD format)
- **Test Coverage**: 
  - Added comprehensive integration tests in `transaction_repo_test.go` covering range filtering, boundary conditions, and year-crossing ordering
  - Updated unit tests across handler, usecase, and repository layers to verify date parameter handling
  - Added helper function `createTransactionAt` to support deterministic test data with backdated timestamps

## Notable Implementation Details

- Date parameters are optional; omitting them returns all statistics (backward compatible)
- Dates are parsed in `YYYY-MM-DD` format with clear error messages for malformed input
- The `endDate` is inclusive of the entire day (queries through 23:59:59 of that date)
- Chronological ordering uses `MIN(created_at)` to ensure correct grouping behavior across time boundaries

https://claude.ai/code/session_01SNkGGCjMBKH2x1cBn9T6Y4