### PR TITLE
Add date range filtering to transaction statistics endpoint

### DIFF
--- a/libs/api-contract/src/api.yaml
+++ b/libs/api-contract/src/api.yaml
@@ -1536,6 +1536,16 @@ paths:
           in: query
           schema:
             type: string
+        - name: startDate
+          in: query
+          description: 'Inclusive lower bound on created_at, format YYYY-MM-DD'
+          schema:
+            type: string
+        - name: endDate
+          in: query
+          description: 'Inclusive upper bound on created_at, format YYYY-MM-DD'
+          schema:
+            type: string
       responses:
         '200':
           description: success response
@@ -1543,6 +1553,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TransactionStatisticResponse'
+        '400':
+          description: validation error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
         '500':
           description: server error
           content:


### PR DESCRIPTION
## Summary
Enhanced the transaction statistics API endpoint to support filtering results by date range, allowing clients to query transaction statistics for a specific period.

## Key Changes
- Added `startDate` query parameter for inclusive lower bound filtering on `created_at` (format: YYYY-MM-DD)
- Added `endDate` query parameter for inclusive upper bound filtering on `created_at` (format: YYYY-MM-DD)
- Added `400` error response documentation for validation errors when invalid date parameters are provided
- Updated API contract to reflect the new validation error response schema

## Implementation Details
- Both date parameters are optional query parameters with string type
- Date format is standardized to YYYY-MM-DD for consistency
- The bounds are inclusive on both ends, allowing clients to query a complete date range
- Added proper error handling documentation to indicate when validation errors may occur

https://claude.ai/code/session_01HipbdxzLbsWLTBR8FP33LB