### PR TITLE
Add date range filtering for transaction statistics

### DIFF
--- a/apps/web/src/pages/index.tsx
+++ b/apps/web/src/pages/index.tsx
@@ -25,14 +25,24 @@ export const getServerSideProps: GetServerSideProps<
     new UrlTransactionStatisticListQueryRepository();
 
   const groupBy = transactionStatisticListQueryRepository.getGroupBy(url);
+  const preset = transactionStatisticListQueryRepository.getPreset(url);
+  const startDate = transactionStatisticListQueryRepository.getStartDate(url);
+  const endDate = transactionStatisticListQueryRepository.getEndDate(url);
   const transactionStatistics =
-    await transactionRepository.fetchTransactionStatisticList(groupBy, {
-      headers: { Cookie: ctx.req.headers.cookie },
-    });
+    await transactionRepository.fetchTransactionStatisticList(
+      { groupBy, startDate, endDate },
+      { headers: { Cookie: ctx.req.headers.cookie } }
+    );
 
   return {
     props: {
-      transactionStatisticListParams: { transactionStatistics, groupBy },
+      transactionStatisticListParams: {
+        transactionStatistics,
+        groupBy,
+        preset,
+        startDate,
+        endDate,
+      },
     },
   };
 };

--- a/libs/ui/src/data/api/transaction.ts
+++ b/libs/ui/src/data/api/transaction.ts
@@ -32,26 +32,40 @@ export class ApiTransactionRepository implements TransactionRepository {
   }
 
   getTransactionStatisticList: TransactionRepository['getTransactionStatisticList'] =
-    (groupBy: 'date' | 'month') => {
+    ({ groupBy, startDate, endDate }) => {
+      const params = {
+        groupBy,
+        startDate: startDate ?? undefined,
+        endDate: endDate ?? undefined,
+      };
       const res = this.client.getQueryState<TransactionStatistics200>(
-        transactionStatisticsQueryKey({ groupBy })
+        transactionStatisticsQueryKey(params)
       )?.data;
 
       this.client.removeQueries({
-        queryKey: transactionStatisticsQueryKey({ groupBy }),
+        queryKey: transactionStatisticsQueryKey(params),
       });
 
       return res?.data.map(toTransactionStatistic) ?? [];
     };
 
   fetchTransactionStatisticList = (
-    groupBy: 'date' | 'month',
+    {
+      groupBy,
+      startDate,
+      endDate,
+    }: { groupBy: 'date' | 'month'; startDate: string | null; endDate: string | null },
     options?: Partial<RequestConfig>
   ) => {
+    const params = {
+      groupBy,
+      startDate: startDate ?? undefined,
+      endDate: endDate ?? undefined,
+    };
     return this.client
       .fetchQuery({
-        queryKey: transactionStatisticsQueryKey({ groupBy }),
-        queryFn: () => transactionStatistics({ groupBy }, options),
+        queryKey: transactionStatisticsQueryKey(params),
+        queryFn: () => transactionStatistics(params, options),
       })
       .then((data) => data.data.map(toTransactionStatistic));
   };

--- a/libs/ui/src/data/mock/transaction.ts
+++ b/libs/ui/src/data/mock/transaction.ts
@@ -185,15 +185,19 @@ export class MockTransactionRepository implements TransactionRepository {
     };
   }
 
-  getTransactionStatisticList(
-    _groupBy: 'date' | 'month'
-  ): TransactionStatistic[] {
+  getTransactionStatisticList(_params: {
+    groupBy: 'date' | 'month';
+    startDate: string | null;
+    endDate: string | null;
+  }): TransactionStatistic[] {
     return [...this.statistics];
   }
 
-  async fetchTransactionStatisticList(
-    _groupBy: 'date' | 'month'
-  ): Promise<TransactionStatistic[]> {
+  async fetchTransactionStatisticList(_params: {
+    groupBy: 'date' | 'month';
+    startDate: string | null;
+    endDate: string | null;
+  }): Promise<TransactionStatistic[]> {
     if (this.shouldFail)
       throw new Error('Failed to fetch transaction statistics');
     return Promise.resolve([...this.statistics]);

--- a/libs/ui/src/data/mock/transactionStatisticListQuery.ts
+++ b/libs/ui/src/data/mock/transactionStatisticListQuery.ts
@@ -1,4 +1,5 @@
 import { TransactionStatisticListQueryRepository } from '../../domain/repositories/transactionStatisticListQuery';
+import { getDateRangeForPreset } from '../../domain/entities';
 
 export class MockTransactionStatisticListQueryRepository
   implements TransactionStatisticListQueryRepository
@@ -7,5 +8,21 @@ export class MockTransactionStatisticListQueryRepository
 
   setGroupBy = (groupBy: 'date' | 'month') => {
     console.log(`Setting group by to ${groupBy}`);
+  };
+
+  getPreset = () => 'last30Days' as const;
+
+  getStartDate = () => getDateRangeForPreset('last30Days').startDate;
+
+  getEndDate = () => getDateRangeForPreset('last30Days').endDate;
+
+  setDateRange: TransactionStatisticListQueryRepository['setDateRange'] = ({
+    preset,
+    startDate,
+    endDate,
+  }) => {
+    console.log(
+      `Setting date range to preset=${preset} startDate=${startDate} endDate=${endDate}`
+    );
   };
 }

--- a/libs/ui/src/data/url/transactionStatisticListQuery.ts
+++ b/libs/ui/src/data/url/transactionStatisticListQuery.ts
@@ -1,5 +1,10 @@
 import { TransactionStatisticListQueryRepository } from '../../domain';
 import {
+  DEFAULT_TRANSACTION_STATISTIC_PRESET,
+  getDateRangeForPreset,
+  TransactionStatisticPreset,
+} from '../../domain/entities';
+import {
   getQueryParam,
   setQueryParam,
   createStringUnionParser,
@@ -18,9 +23,48 @@ export class UrlTransactionStatisticListQueryRepository
   ) => {
     setQueryParam('groupBy', groupBy);
   };
+
+  getPreset = (url?: string) => {
+    const presetQuery = getQueryParam('preset', url);
+    return presetQuery
+      ? toPreset(presetQuery) ?? DEFAULT_TRANSACTION_STATISTIC_PRESET
+      : DEFAULT_TRANSACTION_STATISTIC_PRESET;
+  };
+
+  getStartDate = (url?: string) => {
+    const startDateQuery = getQueryParam('startDate', url);
+    if (startDateQuery) return startDateQuery;
+    return getDateRangeForPreset(this.getPreset(url)).startDate;
+  };
+
+  getEndDate = (url?: string) => {
+    const endDateQuery = getQueryParam('endDate', url);
+    if (endDateQuery) return endDateQuery;
+    return getDateRangeForPreset(this.getPreset(url)).endDate;
+  };
+
+  setDateRange: TransactionStatisticListQueryRepository['setDateRange'] = ({
+    preset,
+    startDate,
+    endDate,
+  }) => {
+    setQueryParam('preset', preset);
+    if (startDate) setQueryParam('startDate', startDate);
+    if (endDate) setQueryParam('endDate', endDate);
+  };
 }
 
 const toGroupBy = createStringUnionParser<('date' | 'month')[]>([
   'date',
   'month',
+]);
+
+const toPreset = createStringUnionParser<TransactionStatisticPreset[]>([
+  'last7Days',
+  'last30Days',
+  'last3Months',
+  'last12Months',
+  'thisMonth',
+  'thisYear',
+  'custom',
 ]);

--- a/libs/ui/src/domain/entities/TransactionStatisticDateRange.test.ts
+++ b/libs/ui/src/domain/entities/TransactionStatisticDateRange.test.ts
@@ -1,0 +1,70 @@
+import { getDateRangeForPreset } from './TransactionStatisticDateRange';
+
+describe('getDateRangeForPreset', () => {
+  const today = new Date('2025-03-15T12:00:00Z');
+
+  it('computes last7Days', () => {
+    expect(getDateRangeForPreset('last7Days', today)).toEqual({
+      startDate: '2025-03-09',
+      endDate: '2025-03-15',
+      groupBy: 'date',
+    });
+  });
+
+  it('computes last30Days', () => {
+    expect(getDateRangeForPreset('last30Days', today)).toEqual({
+      startDate: '2025-02-14',
+      endDate: '2025-03-15',
+      groupBy: 'date',
+    });
+  });
+
+  it('computes last3Months', () => {
+    expect(getDateRangeForPreset('last3Months', today)).toEqual({
+      startDate: '2024-12-15',
+      endDate: '2025-03-15',
+      groupBy: 'date',
+    });
+  });
+
+  it('computes last12Months with month granularity', () => {
+    expect(getDateRangeForPreset('last12Months', today)).toEqual({
+      startDate: '2024-03-15',
+      endDate: '2025-03-15',
+      groupBy: 'month',
+    });
+  });
+
+  it('computes thisMonth starting on the 1st', () => {
+    expect(getDateRangeForPreset('thisMonth', today)).toEqual({
+      startDate: '2025-03-01',
+      endDate: '2025-03-15',
+      groupBy: 'date',
+    });
+  });
+
+  it('computes thisYear starting on Jan 1 with month granularity', () => {
+    expect(getDateRangeForPreset('thisYear', today)).toEqual({
+      startDate: '2025-01-01',
+      endDate: '2025-03-15',
+      groupBy: 'month',
+    });
+  });
+
+  it('computes thisMonth correctly across a year boundary', () => {
+    const newYearToday = new Date('2025-01-05T12:00:00Z');
+    expect(getDateRangeForPreset('thisMonth', newYearToday)).toEqual({
+      startDate: '2025-01-01',
+      endDate: '2025-01-05',
+      groupBy: 'date',
+    });
+  });
+
+  it('returns null bounds for custom', () => {
+    expect(getDateRangeForPreset('custom', today)).toEqual({
+      startDate: null,
+      endDate: null,
+      groupBy: 'date',
+    });
+  });
+});

--- a/libs/ui/src/domain/entities/TransactionStatisticDateRange.ts
+++ b/libs/ui/src/domain/entities/TransactionStatisticDateRange.ts
@@ -1,0 +1,68 @@
+import dayjs from 'dayjs';
+
+export type TransactionStatisticDateRange = {
+  startDate: string | null;
+  endDate: string | null;
+};
+
+export type TransactionStatisticPreset =
+  | 'last7Days'
+  | 'last30Days'
+  | 'last3Months'
+  | 'last12Months'
+  | 'thisMonth'
+  | 'thisYear'
+  | 'custom';
+
+const DATE_FORMAT = 'YYYY-MM-DD';
+
+export function getDateRangeForPreset(
+  preset: TransactionStatisticPreset,
+  today: Date = new Date()
+): TransactionStatisticDateRange & { groupBy: 'date' | 'month' } {
+  const endDate = dayjs(today).format(DATE_FORMAT);
+
+  switch (preset) {
+    case 'last7Days':
+      return {
+        startDate: dayjs(today).subtract(6, 'day').format(DATE_FORMAT),
+        endDate,
+        groupBy: 'date',
+      };
+    case 'last30Days':
+      return {
+        startDate: dayjs(today).subtract(29, 'day').format(DATE_FORMAT),
+        endDate,
+        groupBy: 'date',
+      };
+    case 'last3Months':
+      return {
+        startDate: dayjs(today).subtract(3, 'month').format(DATE_FORMAT),
+        endDate,
+        groupBy: 'date',
+      };
+    case 'last12Months':
+      return {
+        startDate: dayjs(today).subtract(12, 'month').format(DATE_FORMAT),
+        endDate,
+        groupBy: 'month',
+      };
+    case 'thisMonth':
+      return {
+        startDate: dayjs(today).startOf('month').format(DATE_FORMAT),
+        endDate,
+        groupBy: 'date',
+      };
+    case 'thisYear':
+      return {
+        startDate: dayjs(today).startOf('year').format(DATE_FORMAT),
+        endDate,
+        groupBy: 'month',
+      };
+    case 'custom':
+      return { startDate: null, endDate: null, groupBy: 'date' };
+  }
+}
+
+export const DEFAULT_TRANSACTION_STATISTIC_PRESET: TransactionStatisticPreset =
+  'last30Days';

--- a/libs/ui/src/domain/entities/index.ts
+++ b/libs/ui/src/domain/entities/index.ts
@@ -12,6 +12,7 @@ export * from './WalletTransfer';
 export * from './Expense';
 export * from './Transaction';
 export * from './TransactionStatistic';
+export * from './TransactionStatisticDateRange';
 export * from './Rental';
 export * from './Supplier';
 export * from './ChecklistTemplate';

--- a/libs/ui/src/domain/repositories/transaction.ts
+++ b/libs/ui/src/domain/repositories/transaction.ts
@@ -53,11 +53,15 @@ export interface TransactionRepository {
 
   unpayTransaction: (transactionId: number) => Promise<void>;
 
-  getTransactionStatisticList: (
-    groupBy: 'date' | 'month'
-  ) => TransactionStatistic[];
+  getTransactionStatisticList: (params: {
+    groupBy: 'date' | 'month';
+    startDate: string | null;
+    endDate: string | null;
+  }) => TransactionStatistic[];
 
-  fetchTransactionStatisticList: (
-    groupBy: 'date' | 'month'
-  ) => Promise<TransactionStatistic[]>;
+  fetchTransactionStatisticList: (params: {
+    groupBy: 'date' | 'month';
+    startDate: string | null;
+    endDate: string | null;
+  }) => Promise<TransactionStatistic[]>;
 }

--- a/libs/ui/src/domain/repositories/transactionStatisticListQuery.ts
+++ b/libs/ui/src/domain/repositories/transactionStatisticListQuery.ts
@@ -1,4 +1,14 @@
+import { TransactionStatisticPreset } from '../entities';
+
 export interface TransactionStatisticListQueryRepository {
   getGroupBy: () => 'date' | 'month';
   setGroupBy: (groupBy: 'date' | 'month') => void;
+  getPreset: () => TransactionStatisticPreset;
+  getStartDate: () => string | null;
+  getEndDate: () => string | null;
+  setDateRange: (params: {
+    preset: TransactionStatisticPreset;
+    startDate: string | null;
+    endDate: string | null;
+  }) => void;
 }

--- a/libs/ui/src/domain/usecases/transactionStatisticList.test.ts
+++ b/libs/ui/src/domain/usecases/transactionStatisticList.test.ts
@@ -8,6 +8,7 @@ import {
   MockTransactionRepository,
   MockTransactionStatisticListQueryRepository,
 } from '../../data/mock';
+import { getDateRangeForPreset } from '../entities';
 import { UsecaseTester, flushPromises } from '../../utils/usecase';
 
 describe('TransactionStatisticListUsecase', () => {
@@ -29,11 +30,16 @@ describe('TransactionStatisticListUsecase', () => {
         TransactionStatisticListParams
       >(usecase);
 
+      const { startDate, endDate } = getDateRangeForPreset('last30Days');
+
       expect(transactionStatisticList.state).toEqual({
         type: 'loading',
         transactionStatistics: [],
         errorMessage: null,
         groupBy: 'date',
+        preset: 'last30Days',
+        startDate: null,
+        endDate: null,
       });
 
       await flushPromises();
@@ -42,6 +48,9 @@ describe('TransactionStatisticListUsecase', () => {
         transactionStatistics: repository.statistics,
         errorMessage: null,
         groupBy: 'date',
+        preset: 'last30Days',
+        startDate: null,
+        endDate: null,
       });
 
       transactionStatisticList.dispatch({
@@ -53,6 +62,9 @@ describe('TransactionStatisticListUsecase', () => {
         transactionStatistics: repository.statistics,
         errorMessage: null,
         groupBy: 'month',
+        preset: 'last30Days',
+        startDate: null,
+        endDate: null,
       });
 
       await flushPromises();
@@ -61,6 +73,37 @@ describe('TransactionStatisticListUsecase', () => {
         transactionStatistics: repository.statistics,
         errorMessage: null,
         groupBy: 'month',
+        preset: 'last30Days',
+        startDate: null,
+        endDate: null,
+      });
+
+      transactionStatisticList.dispatch({
+        type: 'SET_DATE_RANGE',
+        preset: 'last7Days',
+        startDate,
+        endDate,
+        groupBy: 'date',
+      });
+      expect(transactionStatisticList.state).toEqual({
+        type: 'loading',
+        transactionStatistics: repository.statistics,
+        errorMessage: null,
+        groupBy: 'date',
+        preset: 'last7Days',
+        startDate,
+        endDate,
+      });
+
+      await flushPromises();
+      expect(transactionStatisticList.state).toEqual({
+        type: 'loaded',
+        transactionStatistics: repository.statistics,
+        errorMessage: null,
+        groupBy: 'date',
+        preset: 'last7Days',
+        startDate,
+        endDate,
       });
     });
   });
@@ -89,6 +132,9 @@ describe('TransactionStatisticListUsecase', () => {
         transactionStatistics: [],
         errorMessage: null,
         groupBy: 'date',
+        preset: 'last30Days',
+        startDate: null,
+        endDate: null,
       });
 
       await flushPromises();
@@ -97,6 +143,9 @@ describe('TransactionStatisticListUsecase', () => {
         transactionStatistics: [],
         errorMessage: 'Failed to fetch transaction',
         groupBy: 'date',
+        preset: 'last30Days',
+        startDate: null,
+        endDate: null,
       });
 
       repository.setShouldFail(false);
@@ -106,6 +155,9 @@ describe('TransactionStatisticListUsecase', () => {
         transactionStatistics: [],
         errorMessage: null,
         groupBy: 'date',
+        preset: 'last30Days',
+        startDate: null,
+        endDate: null,
       });
 
       await flushPromises();
@@ -114,6 +166,9 @@ describe('TransactionStatisticListUsecase', () => {
         transactionStatistics: repository.statistics,
         errorMessage: null,
         groupBy: 'date',
+        preset: 'last30Days',
+        startDate: null,
+        endDate: null,
       });
     });
   });
@@ -143,6 +198,9 @@ describe('TransactionStatisticListUsecase', () => {
       transactionStatistics,
       errorMessage: null,
       groupBy: 'date',
+      preset: 'last30Days',
+      startDate: null,
+      endDate: null,
     });
   });
 });

--- a/libs/ui/src/domain/usecases/transactionStatisticList.ts
+++ b/libs/ui/src/domain/usecases/transactionStatisticList.ts
@@ -1,5 +1,5 @@
 import { match } from 'ts-pattern';
-import { TransactionStatistic } from '../entities';
+import { TransactionStatistic, TransactionStatisticPreset } from '../entities';
 import {
   TransactionRepository,
   TransactionStatisticListQueryRepository,
@@ -10,6 +10,9 @@ type Context = {
   errorMessage: string | null;
   transactionStatistics: TransactionStatistic[];
   groupBy: 'date' | 'month';
+  preset: TransactionStatisticPreset;
+  startDate: string | null;
+  endDate: string | null;
 };
 
 export type TransactionStatisticListState = (
@@ -24,11 +27,21 @@ export type TransactionStatisticListAction =
   | { type: 'FETCH' }
   | { type: 'FETCH_SUCCESS'; transactionStatistics: TransactionStatistic[] }
   | { type: 'FETCH_ERROR'; errorMessage: string }
-  | { type: 'SET_GROUP_BY'; groupBy: 'date' | 'month' };
+  | { type: 'SET_GROUP_BY'; groupBy: 'date' | 'month' }
+  | {
+      type: 'SET_DATE_RANGE';
+      preset: TransactionStatisticPreset;
+      startDate: string | null;
+      endDate: string | null;
+      groupBy: 'date' | 'month';
+    };
 
 export type TransactionStatisticListParams = {
   transactionStatistics: TransactionStatistic[];
   groupBy?: 'date' | 'month';
+  preset?: TransactionStatisticPreset;
+  startDate?: string | null;
+  endDate?: string | null;
 };
 
 export class TransactionStatisticListUsecase extends Usecase<
@@ -58,6 +71,9 @@ export class TransactionStatisticListUsecase extends Usecase<
       errorMessage: null,
       transactionStatistics: this.params.transactionStatistics,
       groupBy: this.params.groupBy ?? 'date',
+      preset: this.params.preset ?? 'last30Days',
+      startDate: this.params.startDate ?? null,
+      endDate: this.params.endDate ?? null,
     };
   }
 
@@ -100,6 +116,17 @@ export class TransactionStatisticListUsecase extends Usecase<
           groupBy,
         })
       )
+      .with(
+        [{ type: 'loaded' }, { type: 'SET_DATE_RANGE' }],
+        ([state, { preset, startDate, endDate, groupBy }]) => ({
+          ...state,
+          type: 'loading',
+          preset,
+          startDate,
+          endDate,
+          groupBy,
+        })
+      )
       .otherwise(() => state);
   }
 
@@ -111,10 +138,15 @@ export class TransactionStatisticListUsecase extends Usecase<
       .with({ type: 'idle' }, () => {
         dispatch({ type: 'FETCH' });
       })
-      .with({ type: 'loading' }, ({ groupBy }) => {
+      .with({ type: 'loading' }, ({ groupBy, preset, startDate, endDate }) => {
         this.transactionStatisticListQueryRepository.setGroupBy(groupBy);
+        this.transactionStatisticListQueryRepository.setDateRange({
+          preset,
+          startDate,
+          endDate,
+        });
         this.transactionRepository
-          .fetchTransactionStatisticList(groupBy)
+          .fetchTransactionStatisticList({ groupBy, startDate, endDate })
           .then((transactionStatistics) =>
             dispatch({
               type: 'FETCH_SUCCESS',


### PR DESCRIPTION
## Summary
This PR adds support for date range filtering in transaction statistics, allowing users to select from preset date ranges (last 7 days, last 30 days, last 3 months, last 12 months, this month, this year) or specify custom date ranges.

## Key Changes

- **New Entity**: `TransactionStatisticDateRange` with `getDateRangeForPreset()` function that computes start/end dates and appropriate grouping granularity (date vs month) for each preset
- **Updated State Management**: Extended `TransactionStatisticListUsecase` to track `preset`, `startDate`, and `endDate` in addition to `groupBy`
- **New Action**: Added `SET_DATE_RANGE` action to allow changing the date range and preset
- **Query Repository Enhancement**: Extended `TransactionStatisticListQueryRepository` with methods to get/set preset and date range parameters, with URL query parameter persistence
- **API Integration**: Updated `fetchTransactionStatisticList()` and `getTransactionStatisticList()` to accept date range parameters and pass them to the API
- **Server-side Props**: Updated `getServerSideProps` to read and pass preset/date range parameters from URL query strings

## Implementation Details

- Date calculations use `dayjs` library for consistent date handling
- Preset-based ranges are computed relative to "today" (injectable for testing)
- `last12Months` and `thisYear` presets use month-level grouping; others use daily grouping
- Custom preset returns null for both dates, allowing manual specification
- URL query parameters (`preset`, `startDate`, `endDate`) are persisted and restored on page load
- All existing tests updated to include new state properties

https://claude.ai/code/session_013YhaK4ptgCYZ3H4WLvfCri