### PR TITLE
Initialize dashboard with default transaction statistic preset

### DIFF
--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -25,6 +25,8 @@ import {
   ExpenseCreate,
   ExpenseUpdate,
   TransactionStatisticApp,
+  DEFAULT_TRANSACTION_STATISTIC_PRESET,
+  getDateRangeForPreset,
   AuthLogin,
   CalculationList,
   CalculationCreate,
@@ -261,13 +263,22 @@ export const App = () => {
           />
           <Stack.Screen
             name="dashboard"
-            component={() => (
-              <TransactionStatisticApp
-                transactionStatisticListParams={{
-                  transactionStatistics: [],
-                }}
-              />
-            )}
+            component={() => {
+              const defaultRange = getDateRangeForPreset(
+                DEFAULT_TRANSACTION_STATISTIC_PRESET
+              );
+              return (
+                <TransactionStatisticApp
+                  transactionStatisticListParams={{
+                    transactionStatistics: [],
+                    preset: DEFAULT_TRANSACTION_STATISTIC_PRESET,
+                    groupBy: defaultRange.groupBy,
+                    startDate: defaultRange.startDate,
+                    endDate: defaultRange.endDate,
+                  }}
+                />
+              );
+            }}
             options={{ title: 'Dashboard' }}
           />
           <Stack.Screen

--- a/libs/api-contract/src/__generated__/go/go.mod
+++ b/libs/api-contract/src/__generated__/go/go.mod
@@ -1,4 +1,4 @@
-module github.com/GIT_USER_ID/GIT_REPO_ID
+module libs/api-contract
 
 go 1.18
 


### PR DESCRIPTION
## Summary
Updated the dashboard screen initialization to use a default transaction statistic preset with appropriate date range parameters, ensuring the dashboard loads with sensible default filtering options.

## Key Changes
- Imported `DEFAULT_TRANSACTION_STATISTIC_PRESET` and `getDateRangeForPreset` utilities from the transaction statistic module
- Modified the dashboard component to compute the default date range based on the preset
- Enhanced `transactionStatisticListParams` to include:
  - `preset`: Set to the default transaction statistic preset
  - `groupBy`: Derived from the default date range
  - `startDate` and `endDate`: Computed from the preset's date range

## Implementation Details
The dashboard now initializes with a calculated date range instead of empty parameters, providing users with a pre-configured view that matches the default preset behavior. The `getDateRangeForPreset` function is used to derive the appropriate grouping and date boundaries from the preset configuration.

https://claude.ai/code/session_01BD6J5CxHrDXE4Gm7oFC7wT