### PR TITLE
Add product status filtering to transaction item selection

### DIFF
--- a/libs/ui/.storybook/mocks/mockData.ts
+++ b/libs/ui/.storybook/mocks/mockData.ts
@@ -117,6 +117,7 @@ export const mockProduct: Product = {
     },
   ],
   saleType: 'purchase',
+  status: 'published',
 };
 
 export const mockProducts: Product[] = [
@@ -130,6 +131,7 @@ export const mockProducts: Product[] = [
     createdAt: '2024-01-16T08:00:00.000Z',
     options: [],
     saleType: 'purchase',
+    status: 'published',
   },
   {
     id: 3,
@@ -140,6 +142,7 @@ export const mockProducts: Product[] = [
     createdAt: '2024-01-17T08:00:00.000Z',
     options: [],
     saleType: 'rental',
+    status: 'published',
   },
 ];
 

--- a/libs/ui/src/data/api/product.transformer.ts
+++ b/libs/ui/src/data/api/product.transformer.ts
@@ -13,6 +13,7 @@ export function toProduct(product: ApiProduct): Product {
     description: product.description ?? '',
     options: product.options,
     saleType: product.saleType,
+    status: product.status,
   };
 }
 

--- a/libs/ui/src/data/api/product.ts
+++ b/libs/ui/src/data/api/product.ts
@@ -55,6 +55,7 @@ export class ApiProductRepository implements ProductRepository {
     query,
     sortBy,
     saleType,
+    status,
   }) => {
     const params = {
       query,
@@ -63,6 +64,7 @@ export class ApiProductRepository implements ProductRepository {
       order: orderBy,
       sortBy,
       saleType,
+      status,
     };
 
     const res = this.client.getQueryState<ProductList200>(
@@ -92,6 +94,7 @@ export class ApiProductRepository implements ProductRepository {
       orderBy: 'asc' | 'desc';
       sortBy: 'created_at';
       saleType: 'purchase' | 'rental' | 'all';
+      status: 'draft' | 'published' | 'all';
     },
     options?: Partial<RequestConfig>
   ) => {
@@ -102,6 +105,7 @@ export class ApiProductRepository implements ProductRepository {
       order: params.orderBy,
       sortBy: params.sortBy,
       saleType: params.saleType,
+      status: params.status,
     };
 
     return this.client

--- a/libs/ui/src/data/api/transaction.transformer.ts
+++ b/libs/ui/src/data/api/transaction.transformer.ts
@@ -74,6 +74,7 @@ export function toTransaction(transaction: ApiTransaction): Transaction {
           options: item.variant.product.options,
           imageUrl: item.variant.product.imageUrl,
           saleType: item.variant.product.saleType,
+          status: item.variant.product.status,
         },
         values: item.variant.values.map((value) => ({
           id: value.id,

--- a/libs/ui/src/data/api/variant.transformer.ts
+++ b/libs/ui/src/data/api/variant.transformer.ts
@@ -30,6 +30,7 @@ export function toVariant(variant: ApiVariant): Variant {
       options: variant.product.options,
       imageUrl: variant.product.imageUrl,
       saleType: variant.product.saleType,
+      status: variant.product.status,
     },
     values: variant.values.map((value) => ({
       id: value.id,

--- a/libs/ui/src/data/mock/product.ts
+++ b/libs/ui/src/data/mock/product.ts
@@ -8,6 +8,7 @@ const initialProducts: Product[] = [
     category: { id: 1, name: 'Category 1', station: 'NONE' as const, createdAt: '2024-03-20T00:00:00.000Z' },
     imageUrl: 'https://example.com/1.jpg',
     saleType: 'purchase',
+    status: 'published',
     options: [
       {
         id: 1,
@@ -26,6 +27,7 @@ const initialProducts: Product[] = [
     category: { id: 1, name: 'Category 1', station: 'NONE' as const, createdAt: '2024-03-20T00:00:00.000Z' },
     imageUrl: 'https://example.com/2.jpg',
     saleType: 'purchase',
+    status: 'published',
     options: [
       {
         id: 2,
@@ -57,6 +59,7 @@ export class MockProductRepository implements ProductRepository {
     sortBy: 'created_at';
     orderBy: 'asc' | 'desc';
     saleType: 'purchase' | 'rental' | 'all';
+    status: 'draft' | 'published' | 'all';
   }): { products: Product[]; totalItem: number } {
     return { products: [...this.products], totalItem: this.products.length };
   }
@@ -68,6 +71,7 @@ export class MockProductRepository implements ProductRepository {
     sortBy: 'created_at';
     orderBy: 'asc' | 'desc';
     saleType: 'purchase' | 'rental' | 'all';
+    status: 'draft' | 'published' | 'all';
   }): Promise<{ products: Product[]; totalItem: number }> {
     if (this.shouldFail) throw new Error('Failed to fetch products');
     return Promise.resolve({
@@ -97,6 +101,7 @@ export class MockProductRepository implements ProductRepository {
       category: { id: formValues.categoryId, name: '', station: 'NONE' as const, createdAt: new Date().toISOString() },
       imageUrl: formValues.imageUrl,
       saleType: formValues.saleType,
+      status: 'published',
       options: [],
       createdAt: new Date().toISOString(),
     });

--- a/libs/ui/src/data/mock/rental.ts
+++ b/libs/ui/src/data/mock/rental.ts
@@ -19,6 +19,7 @@ const mockVariant = {
     createdAt: '2024-03-20T00:00:00.000Z',
     options: [],
     saleType: 'rental' as const,
+    status: 'published' as const,
   },
   createdAt: '2024-03-20T00:00:00.000Z',
   values: [],

--- a/libs/ui/src/data/mock/transaction.ts
+++ b/libs/ui/src/data/mock/transaction.ts
@@ -17,6 +17,7 @@ const mockVariant = {
     category: { id: 1, name: 'Category 1', station: 'NONE' as const, createdAt: '2024-03-20T00:00:00.000Z' },
     imageUrl: '',
     saleType: 'purchase' as const,
+    status: 'published' as const,
     options: [],
     createdAt: '2024-03-20T00:00:00.000Z',
   },

--- a/libs/ui/src/data/mock/variant.ts
+++ b/libs/ui/src/data/mock/variant.ts
@@ -7,6 +7,7 @@ const mockProduct = {
   category: { id: 1, name: 'Category 1', station: 'NONE' as const, createdAt: '2024-03-20T00:00:00.000Z' },
   imageUrl: 'https://example.com/1.jpg',
   saleType: 'purchase' as const,
+  status: 'published' as const,
   options: [],
   createdAt: '2024-03-20T00:00:00.000Z',
 };

--- a/libs/ui/src/domain/entities/Product.ts
+++ b/libs/ui/src/domain/entities/Product.ts
@@ -2,6 +2,8 @@ import { Category } from './Category';
 
 export type ProductSaleType = 'purchase' | 'rental';
 
+export type ProductStatus = 'draft' | 'published';
+
 export type Product = {
   id: number;
   name: string;
@@ -11,6 +13,7 @@ export type Product = {
   createdAt: string;
   options: Option[];
   saleType: ProductSaleType;
+  status: ProductStatus;
 };
 
 export type Option = {

--- a/libs/ui/src/domain/repositories/product.ts
+++ b/libs/ui/src/domain/repositories/product.ts
@@ -8,6 +8,7 @@ export interface ProductRepository {
     sortBy: 'created_at';
     orderBy: 'asc' | 'desc';
     saleType: 'purchase' | 'rental' | 'all';
+    status: 'draft' | 'published' | 'all';
   }) => {
     products: Product[];
     totalItem: number;
@@ -20,6 +21,7 @@ export interface ProductRepository {
     sortBy: 'created_at';
     orderBy: 'asc' | 'desc';
     saleType: 'purchase' | 'rental' | 'all';
+    status: 'draft' | 'published' | 'all';
   }) => Promise<{ products: Product[]; totalItem: number }>;
 
   fetchProductById: (productId: number) => Promise<Product>;

--- a/libs/ui/src/domain/usecases/productList.ts
+++ b/libs/ui/src/domain/usecases/productList.ts
@@ -199,6 +199,7 @@ export class ProductListUsecase extends Usecase<
               query,
               sortBy,
               saleType,
+              status: 'all',
             })
             .then(({ products, totalItem }) =>
               dispatch({ type: 'FETCH_SUCCESS', products, totalItem })
@@ -237,6 +238,7 @@ export class ProductListUsecase extends Usecase<
                 query,
                 sortBy,
                 saleType,
+                status: 'all',
               });
 
             if (products.length > 0) {
@@ -267,6 +269,7 @@ export class ProductListUsecase extends Usecase<
               query,
               sortBy,
               saleType,
+              status: 'all',
             })
             .then(({ products, totalItem }) =>
               dispatch({ type: 'REVALIDATE_FINISH', products, totalItem })

--- a/libs/ui/src/domain/usecases/transactionItemSelect.test.ts
+++ b/libs/ui/src/domain/usecases/transactionItemSelect.test.ts
@@ -110,6 +110,43 @@ describe('TransactionItemSelectUsecase', () => {
     });
   });
 
+  describe('status filter', () => {
+    it('requests only published products by default', async () => {
+      const productRepository = new MockProductRepository();
+      const fetchProductListSpy = jest.spyOn(productRepository, 'fetchProductList');
+      const variantRepository = new MockVariantRepository();
+      const usecase = new TransactionItemSelectUsecase(productRepository, variantRepository, {
+        products: [],
+        totalItem: 0,
+      });
+      new UsecaseTester<TransactionItemSelectUsecase, TransactionItemSelectState, TransactionItemSelectAction, TransactionItemSelectParams>(usecase);
+
+      await flushPromises();
+
+      expect(fetchProductListSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'published' })
+      );
+    });
+
+    it('allows overriding the status filter via params', async () => {
+      const productRepository = new MockProductRepository();
+      const fetchProductListSpy = jest.spyOn(productRepository, 'fetchProductList');
+      const variantRepository = new MockVariantRepository();
+      const usecase = new TransactionItemSelectUsecase(productRepository, variantRepository, {
+        products: [],
+        totalItem: 0,
+        status: 'all',
+      });
+      new UsecaseTester<TransactionItemSelectUsecase, TransactionItemSelectState, TransactionItemSelectAction, TransactionItemSelectParams>(usecase);
+
+      await flushPromises();
+
+      expect(fetchProductListSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'all' })
+      );
+    });
+  });
+
   it('starts in loaded state when products are preloaded', () => {
     const productRepository = new MockProductRepository();
     const variantRepository = new MockVariantRepository();

--- a/libs/ui/src/domain/usecases/transactionItemSelect.ts
+++ b/libs/ui/src/domain/usecases/transactionItemSelect.ts
@@ -9,6 +9,8 @@ type SortBy = 'created_at';
 
 type OrderBy = 'asc' | 'desc';
 
+type Status = 'draft' | 'published' | 'all';
+
 type Context = {
   products: Product[];
   selectedProduct?: Product;
@@ -18,6 +20,7 @@ type Context = {
   page: number;
   query: string;
   saleType: SaleType;
+  status: Status;
   errorMessage: string | null;
   sortBy: SortBy;
   orderBy: OrderBy;
@@ -69,6 +72,7 @@ export type TransactionItemSelectParams = {
   orderBy?: OrderBy;
   itemPerPage?: number;
   saleType?: SaleType;
+  status?: Status;
 };
 
 const changeParamsDebounce = createDebounce();
@@ -100,6 +104,7 @@ export class TransactionItemSelectUsecase extends Usecase<
     const sortBy = this.params.sortBy ?? 'created_at';
     const orderBy = this.params.orderBy ?? 'desc';
     const saleType = this.params.saleType ?? 'all';
+    const status = this.params.status ?? 'published';
 
     return {
       type: this.params.products.length >= 1 ? 'loaded' : 'idle',
@@ -116,6 +121,7 @@ export class TransactionItemSelectUsecase extends Usecase<
       orderBy,
       itemPerPage,
       saleType,
+      status,
       fetchDebounceDelay: 0,
     };
   }
@@ -276,7 +282,7 @@ export class TransactionItemSelectUsecase extends Usecase<
       .with({ type: 'idle' }, () => dispatch({ type: 'FETCH' }))
       .with(
         { type: 'loading' },
-        ({ page, itemPerPage, orderBy, query, sortBy, saleType }) =>
+        ({ page, itemPerPage, orderBy, query, sortBy, saleType, status }) =>
           this.productRepository
             .fetchProductList({
               page,
@@ -285,6 +291,7 @@ export class TransactionItemSelectUsecase extends Usecase<
               query,
               sortBy,
               saleType,
+              status,
             })
             .then(({ products, totalItem }) =>
               dispatch({ type: 'FETCH_SUCCESS', products, totalItem })
@@ -305,6 +312,7 @@ export class TransactionItemSelectUsecase extends Usecase<
           query,
           sortBy,
           saleType,
+          status,
           fetchDebounceDelay,
         }) => {
           changeParamsDebounce(() => {
@@ -316,6 +324,7 @@ export class TransactionItemSelectUsecase extends Usecase<
                 query,
                 sortBy,
                 saleType,
+                status,
               });
 
             if (products.length > 0) {
@@ -337,6 +346,7 @@ export class TransactionItemSelectUsecase extends Usecase<
           products,
           totalItem,
           saleType,
+          status,
         }) => {
           this.productRepository
             .fetchProductList({
@@ -346,6 +356,7 @@ export class TransactionItemSelectUsecase extends Usecase<
               query,
               sortBy,
               saleType,
+              status,
             })
             .then(({ products, totalItem }) =>
               dispatch({ type: 'REVALIDATE_FINISH', products, totalItem })

--- a/libs/ui/src/presentation/screens/TransactionCreateHandler.printFlow.test.tsx
+++ b/libs/ui/src/presentation/screens/TransactionCreateHandler.printFlow.test.tsx
@@ -47,6 +47,7 @@ const buildVariant = (
     createdAt: '2024-01-01T00:00:00.000Z',
     options: [],
     saleType: 'purchase',
+    status: 'published',
   },
   createdAt: '2024-01-01T00:00:00.000Z',
   values: [

--- a/libs/ui/src/presentation/screens/TransactionListHandler.test.tsx
+++ b/libs/ui/src/presentation/screens/TransactionListHandler.test.tsx
@@ -84,6 +84,7 @@ const buildTransaction = (
         createdAt: '2024-01-01T00:00:00.000Z',
         options: [],
         saleType: 'purchase',
+        status: 'published',
       },
       createdAt: '2024-01-01T00:00:00.000Z',
       values: [],

--- a/libs/ui/src/utils/print.test.ts
+++ b/libs/ui/src/utils/print.test.ts
@@ -25,6 +25,7 @@ const buildVariant = (
     createdAt: '2024-01-01T00:00:00.000Z',
     options: [],
     saleType: 'purchase',
+    status: 'published',
   },
   createdAt: '2024-01-01T00:00:00.000Z',
   values: [


### PR DESCRIPTION
## Summary
This PR adds product status filtering capability to the transaction item selection usecase, allowing filtering by draft, published, or all products. By default, only published products are requested.

## Key Changes
- **Product Entity**: Added `ProductStatus` type ('draft' | 'published') and `status` field to the `Product` entity
- **Repository Interface**: Updated `ProductRepository` interface to accept `status` parameter in both sync and async `fetchProductList` methods
- **TransactionItemSelectUsecase**: 
  - Added `status` to the context and params with 'published' as the default value
  - Allows overriding the status filter via initialization params
  - Passes status parameter through all product fetch operations (initial load, search, pagination, revalidation)
- **API Integration**: Updated `ApiProductRepository` to include status in API request parameters
- **ProductListUsecase**: Updated to explicitly pass `status: 'all'` to show all products regardless of status
- **Mock Data & Transformers**: Updated all mock repositories, transformers, and test fixtures to include the new `status` field with 'published' as the default value
- **Tests**: Added comprehensive test coverage for the status filter behavior (default and override scenarios)

## Implementation Details
- The status filter defaults to 'published' in `TransactionItemSelectUsecase` to ensure only published products are shown by default
- The `ProductListUsecase` explicitly requests all statuses to maintain its current behavior of showing all products
- All data transformers (API, transaction, variant) now properly map the status field from API responses
- Mock implementations and test fixtures have been updated to include the status field for consistency

https://claude.ai/code/session_013KoSFd6BytSqgpCrgX2kv4